### PR TITLE
Test audit and locales

### DIFF
--- a/.github/workflows/audit-locales.yml
+++ b/.github/workflows/audit-locales.yml
@@ -2,15 +2,9 @@ name: Check npm audit and locales
 
 on:
   push:
-    branches:
-      - '**'
     branches-ignore:
       - 'main'
-    tags:
-        - '**'
   pull_request:
-    branches:
-      - '**'
     branches-ignore:
       - 'main'
 

--- a/.github/workflows/audit-locales.yml
+++ b/.github/workflows/audit-locales.yml
@@ -53,9 +53,9 @@ jobs:
     - name: Check npm audit and locale on ${{ matrix.os }}
       run: |
         npm install
-        if [ "$(npm audit --audit-level=high)" ]; then echo "npm audit failed!" && exit 1; fi
+        npm audit --audit-level=high
+        if [ $? ne 0 ]; then echo "npm audit failed!" && exit 1; fi
         npm run locale:extract
-        git diff-index --quiet HEAD
         if [ "$(git diff-index --quiet HEAD)" ]; then echo "locales need to be extracted!" && exit 1; fi
         git status
         echo "No issues found."

--- a/.github/workflows/audit-locales.yml
+++ b/.github/workflows/audit-locales.yml
@@ -51,10 +51,11 @@ jobs:
         node-version: '12.x'
 
     - name: Check npm audit and locale on ${{ matrix.os }}
+      shell: bash
       run: |
         npm install
-        npm audit --audit-level=high
-        if [ $? ne 0 ]; then echo "npm audit failed!" && exit 1; fi
+        if ! output=$(npm audit --audit-level=high); then echo "$output" && exit 1; fi
+        echo "$output"
         npm run locale:extract
         if [ "$(git diff-index --quiet HEAD)" ]; then echo "locales need to be extracted!" && exit 1; fi
         git status

--- a/.github/workflows/audit-locales.yml
+++ b/.github/workflows/audit-locales.yml
@@ -1,0 +1,67 @@
+name: Check npm audit and locales
+
+on:
+  push:
+    branches:
+      - '**'
+    branches-ignore:
+      - 'main'
+    tags:
+        - '**'
+  pull_request:
+    branches:
+      - '**'
+    branches-ignore:
+      - 'main'
+
+jobs:
+  build:
+    name: Check npm audit and locales
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        python-version: [3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - name: Cancel previous runs on the same branch
+      if: ${{ github.ref != 'refs/heads/dev' }}
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Cache npm
+      uses: actions/cache@v2.1.4
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Setup Node 12.x
+      uses: actions/setup-node@v2.1.5
+      with:
+        node-version: '12.x'
+
+    - name: Check npm audit and locale on ${{ matrix.os }}
+      run: |
+        npm install
+        if [ "$(npm audit --audit-level=high)" ]; then echo "npm audit failed!" && exit 1; fi
+        npm run locale:extract
+        git diff-index --quiet HEAD
+        if [ "$(git diff-index --quiet HEAD)" ]; then echo "locales need to be extracted!" && exit 1; fi
+        git status
+        echo "No issues found."


### PR DESCRIPTION
I'm sure you have a better way but I'm very afraid of `npm run locale:extract` changing the scm version in the installers and I've seen some misbehavior there. The alternative of the GUI in an install having that not run is also a bad idea.

Let's go ahead and squash merge this for the short run and then you can tell me what you'd like to do instead.