### PR TITLE
return early from electron-starter on app.quit

### DIFF
--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -25,7 +25,9 @@ if (!setupEvents.handleSquirrelEvent()) {
     const gotTheLock = app.requestSingleInstanceLock();
 
     if (!gotTheLock) {
+      console.log("Second instance. Quitting.");
       app.quit();
+      return false;
     } else {
       app.on('second-instance', (event, commandLine, workingDirectory) => {
         // Someone tried to run a second instance, we should focus our window.
@@ -37,6 +39,8 @@ if (!setupEvents.handleSquirrelEvent()) {
         }
       });
     }
+
+    return true;
   };
 
   const ensureCorrectEnvironment = () => {
@@ -44,11 +48,16 @@ if (!setupEvents.handleSquirrelEvent()) {
     if (!chiaEnvironment.guessPackaged() && !('VIRTUAL_ENV' in process.env)) {
       console.log("App must be installed or in venv");
       app.quit();
-    }    
+      return false;
+    }
+
+    return true;
   };
 
-  ensureSingleInstance();
-  ensureCorrectEnvironment();
+  // if any of these checks return false, exit since the app is quitting
+  if (!ensureSingleInstance() || !ensureCorrectEnvironment()) {
+    return;
+  }
 
   // this needs to happen early in startup so all processes share the same global config
   chiaConfig.loadConfig(chiaEnvironment.getChiaVersion());

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -36,8 +36,8 @@ msgstr ""
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr ""
+#~ msgid "About Chia Blockchain"
+#~ msgstr ""
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr ""
 msgid "Accepted at time:"
 msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr ""
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr ""
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr ""
 
@@ -99,10 +99,10 @@ msgstr ""
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr ""
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr "Are you sure you want to disconnect?"
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr ""
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr ""
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr ""
+#~ msgid "Chat on KeyBase"
+#~ msgstr ""
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr ""
+#~ msgid "Chia"
+#~ msgstr ""
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr ""
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr ""
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr ""
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr ""
+#~ msgid "Confirm"
+#~ msgstr ""
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr ""
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr ""
+#~ msgid "Contribute on GitHub"
+#~ msgstr ""
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr ""
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr ""
+#~ msgid "Developer"
+#~ msgstr ""
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr ""
+#~ msgid "Developer Tools"
+#~ msgstr ""
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr ""
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr ""
+#~ msgid "Edit"
+#~ msgstr ""
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr ""
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr ""
@@ -648,13 +648,13 @@ msgstr ""
 msgid "Farming Status"
 msgstr ""
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr ""
 
@@ -680,12 +680,12 @@ msgstr ""
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr ""
+#~ msgid "File"
+#~ msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr ""
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr ""
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr ""
+#~ msgid "Follow on Twitter"
+#~ msgstr ""
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr ""
+#~ msgid "Frequently Asked Questions"
+#~ msgstr ""
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr ""
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr ""
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr ""
+#~ msgid "Help"
+#~ msgstr ""
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr ""
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr ""
 
@@ -979,9 +978,9 @@ msgstr ""
 msgid "None of your plots have passed the plot filter yet."
 msgstr ""
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr ""
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr ""
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr ""
+#~ msgid "Release Notes"
+#~ msgstr ""
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr ""
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr ""
+#~ msgid "Report an Issue..."
+#~ msgstr ""
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr ""
+#~ msgid "Speech"
+#~ msgstr ""
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr ""
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr ""
 
@@ -1540,8 +1539,8 @@ msgstr ""
 msgid "Synced"
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr ""
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr ""
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr ""
+#~ msgid "View"
+#~ msgstr ""
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr ""
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr ""
+#~ msgid "Window"
+#~ msgstr ""
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr ""
 
@@ -1912,13 +1910,13 @@ msgstr ""
 msgid "Your Harvester Network"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr ""
 
@@ -1926,18 +1924,18 @@ msgstr ""
 msgid "not synced"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr ""
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -36,8 +36,8 @@ msgstr "Un cosechador es un servicio que se ejecuta en una máquina en donde act
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr "Acerca de Chia Blockchain"
+#~ msgid "About Chia Blockchain"
+#~ msgstr "Acerca de Chia Blockchain"
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr "Aceptar"
 msgid "Accepted at time:"
 msgstr "Aceptado en el tiempo:"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr "Acción"
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr "Añadir Monedero"
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr "Añadir una Parcela"
 
@@ -99,10 +99,10 @@ msgstr "Dirección / Enigma hash"
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr "¿Está seguro que quiere salir? Sembrar y Cultivar en el GUI se detendrán."
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr "¿Está seguro que quiere salir? Sembrar y Cultivar en el GUI se detendrán."
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr "Desafío Hash"
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr "Chatear en Keybase"
+#~ msgid "Chat on KeyBase"
+#~ msgstr "Chatear en Keybase"
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr "Chia"
+#~ msgid "Chia"
+#~ msgstr "Chia"
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr "Wiki de Cadena de Bloques Chia"
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr "Wiki de Cadena de Bloques Chia"
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr "Opciones de Moneda de Color"
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr "Confirmar"
+#~ msgid "Confirm"
+#~ msgstr "Confirmar"
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr "Conexiones"
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr "Contribuir en GitHub"
+#~ msgid "Contribute on GitHub"
+#~ msgstr "Contribuir en GitHub"
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr "Borrar la llave eliminará permanentemente la llave de su ordenador, asegurase de tener una copia de seguridad. ¿Está seguro de que quiere continuar?"
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr "Desarrollador"
+#~ msgid "Developer"
+#~ msgstr "Desarrollador"
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr "Herramientas de Desarrollador"
+#~ msgid "Developer Tools"
+#~ msgstr "Herramientas de Desarrollador"
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr "Arrastra y suelta tu archivo de respaldo"
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr "Editar"
+#~ msgid "Edit"
+#~ msgstr "Editar"
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr "Introduzca las 24 palabras mnemotécnicas que has guardado en orden para restaurar su monedero Chia."
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr "El Agricultor no está funcionando"
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr "Los agricultores obtienen recompensas en bloque y tarifas de transacción al asignar espacio libre a la red para ayudar a asegurar las transacciones. Aquí es donde estará su granja una vez que agregue una parcela. <0> Más información </0>"
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr "Cultivando"
@@ -648,13 +648,13 @@ msgstr "Cultivando"
 msgid "Farming Status"
 msgstr "Estado de Cultivo"
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr "Tarifa"
 
@@ -680,12 +680,12 @@ msgstr "Monto de tarifas"
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr "Archivo"
+#~ msgid "File"
+#~ msgstr "Archivo"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr "Nombre del Archivo"
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr "Finalizado"
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr "Seguir en Twitter"
+#~ msgid "Follow on Twitter"
+#~ msgstr "Seguir en Twitter"
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr "Preguntas Frecuentes"
+#~ msgid "Frequently Asked Questions"
+#~ msgstr "Preguntas Frecuentes"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr "Estado de Nodo Completo"
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr "Pantalla Completa"
+#~ msgid "Full Screen"
+#~ msgstr "Pantalla Completa"
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr "Altura"
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr "Ayuda"
+#~ msgid "Help"
+#~ msgstr "Ayuda"
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr "Apodo"
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr "No"
 
@@ -979,9 +978,9 @@ msgstr "ID de Nodo"
 msgid "None of your plots have passed the plot filter yet."
 msgstr "Ninguna de sus parcelas a pasado un filtro de parcela aún."
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr "No Disponible"
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr "Actualizar Parcelas"
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr "Notas de lanzamiento"
+#~ msgid "Release Notes"
+#~ msgstr "Notas de lanzamiento"
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr "Renombrar"
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr "Reportar un problema..."
+#~ msgid "Report an Issue..."
+#~ msgstr "Reportar un problema..."
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr "Iniciar Sesión"
 #~ msgstr "Saltar"
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr "Habla"
+#~ msgid "Speech"
+#~ msgstr "Habla"
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr "Estado"
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr "Estado"
 
@@ -1540,8 +1539,8 @@ msgstr "Enviar"
 msgid "Synced"
 msgstr "Sincronizado"
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr "Sincronizando"
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr "Iteraciones VDF Sub Slot"
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr "Vista"
+#~ msgid "View"
+#~ msgstr "Vista"
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr "Cuando reciba el paquete de información de configuración de su administrador, ingréselo a continuación para completar la configuración de su Monedero con Tarifa Limitada:"
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr "Ventana"
+#~ msgid "Window"
+#~ msgstr "Ventana"
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr "Sin tarifas"
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr "Sí"
 
@@ -1912,13 +1910,13 @@ msgstr "Su Conexión de Nodo Completo"
 msgid "Your Harvester Network"
 msgstr "Su Red de Cosechadores"
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr "conexiones:"
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr "altura:"
 
@@ -1926,18 +1924,18 @@ msgstr "altura:"
 msgid "not synced"
 msgstr "no sincronizado"
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr "estado:"
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr "sincronizado"
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr "sincronizando"
 

--- a/src/locales/fi/messages.po
+++ b/src/locales/fi/messages.po
@@ -36,8 +36,8 @@ msgstr "Harvesteri on palvelu koneella, jolle plot-tiedostot ovat tallennettu. F
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr "Chia-lohkoketjusta"
+#~ msgid "About Chia Blockchain"
+#~ msgstr "Chia-lohkoketjusta"
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr "Hyväksy"
 msgid "Accepted at time:"
 msgstr "Hyväksyntäaika:"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr "Toiminto"
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr "Lisää Lompakko"
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr "Plottaa tiedosto"
 
@@ -99,10 +99,10 @@ msgstr "Osoite / Puzzle-tiiviste"
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr "Määrä"
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr "Haluatko lopettaa? Käyttöliittymäplottaus ja farmi sammutetaan."
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr "Haluatko lopettaa? Käyttöliittymäplottaus ja farmi sammutetaan."
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr "Haastetiiviste"
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr "Keskustele KeyBasessa"
+#~ msgid "Chat on KeyBase"
+#~ msgstr "Keskustele KeyBasessa"
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr "Chia"
+#~ msgid "Chia"
+#~ msgstr "Chia"
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr "Chia-lohkoketjun Wiki"
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr "Chia-lohkoketjun Wiki"
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr "Värikolikon Valinnat"
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr "Vahvista"
+#~ msgid "Confirm"
+#~ msgstr "Vahvista"
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr "Yhteydet"
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr "Anna panoksesi GitHubissa"
+#~ msgid "Contribute on GitHub"
+#~ msgstr "Anna panoksesi GitHubissa"
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr "Avaimen poisto poistaa sen tietokoneeltasi. Varmista että sinulla on varmuuskopio. Haluatko jatkaa?"
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr "Kehittäjälle"
+#~ msgid "Developer"
+#~ msgstr "Kehittäjälle"
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr "Kehitystyökalut"
+#~ msgid "Developer Tools"
+#~ msgstr "Kehitystyökalut"
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr "Raahaa ja pudota varmuuskopiotiedosto"
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr "Muokkaa"
+#~ msgid "Edit"
+#~ msgstr "Muokkaa"
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr "Anna tallentamasi 24 muistisanaa palauttaaksesi Chia-lompakon."
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr "Farmari ei ole käynnissä"
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr "Farmarit ansaitsevat lohkopalkkioita ja transaktioveloituksia varaamalla levytilaa vertaisverkolle ja vahvistamalla transaktioita. Farmisi näkyy täällä luotuasi plot-tiedoston. <0>Katso lisää</0>"
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr "Tuotetaan Farmissa"
@@ -648,13 +648,13 @@ msgstr "Tuotetaan Farmissa"
 msgid "Farming Status"
 msgstr "Farmituotannon Tila"
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr "Veloitus"
 
@@ -680,12 +680,12 @@ msgstr "Palkkiosumma"
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr "Tiedosto"
+#~ msgid "File"
+#~ msgstr "Tiedosto"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr "Tiedoston nimi"
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr "Valmis"
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr "Seuraa Twitterissä"
+#~ msgid "Follow on Twitter"
+#~ msgstr "Seuraa Twitterissä"
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr "Usein Kysytyt Kysymykset"
+#~ msgid "Frequently Asked Questions"
+#~ msgstr "Usein Kysytyt Kysymykset"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr "Verkkonoodin Tila"
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr "Kokoruutu"
+#~ msgid "Full Screen"
+#~ msgstr "Kokoruutu"
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr "Lohkokorkeus"
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr "Helppiä"
+#~ msgid "Help"
+#~ msgstr "Helppiä"
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr "Alias"
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr "Ei"
 
@@ -979,9 +978,9 @@ msgstr "Noodin tunnus"
 msgid "None of your plots have passed the plot filter yet."
 msgstr "Yksikään ploteistasi ei ole vielä päässyt suodatuksesta läpi."
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr "Ei Saatavilla"
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr "Päivitä Plot-tiedostot"
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr "Version Muutokset"
+#~ msgid "Release Notes"
+#~ msgstr "Version Muutokset"
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr "Nimeä Uudelleen"
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr "Raportoi Ongelma..."
+#~ msgid "Report an Issue..."
+#~ msgstr "Raportoi Ongelma..."
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr "Kirjaudu"
 #~ msgstr "Ohita"
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr "Puhe"
+#~ msgid "Speech"
+#~ msgstr "Puhe"
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr "Tila"
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr "Tila"
 
@@ -1540,8 +1539,8 @@ msgstr "Lähetä"
 msgid "Synced"
 msgstr "Synkrononissa"
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr "Synkronoi...."
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr "VDF -alaiteraatioita"
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr "Näkymä"
+#~ msgid "View"
+#~ msgstr "Näkymä"
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr "Kun saat infopaketin pääkäyttäjältä, lisää se alle viimeistelläksesi Siirtorajoitetun Lompakon asennuksen:"
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr "Ikkuna"
+#~ msgid "Window"
+#~ msgstr "Ikkuna"
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr "Ilman veloituksia"
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -1912,13 +1910,13 @@ msgstr "Noodin Yhteys"
 msgid "Your Harvester Network"
 msgstr "Harvesteriverkkosi"
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr "yhteydet:"
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr "korkeus:"
 
@@ -1926,18 +1924,18 @@ msgstr "korkeus:"
 msgid "not synced"
 msgstr "ei synkronoitu"
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr "tila:"
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr "synkronoitu"
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr "synkronoi"
 

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -36,8 +36,8 @@ msgstr "Un harvester è un servizio eseguito sulla macchina in cui i plot sono r
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr "Sulla Blockchain Chia"
+#~ msgid "About Chia Blockchain"
+#~ msgstr "Sulla Blockchain Chia"
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr "Accettare"
 msgid "Accepted at time:"
 msgstr "Accettato al tempo:"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr "Azione"
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr "Aggiungi Wallet"
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr "Aggiungi un Plot"
 
@@ -99,10 +99,10 @@ msgstr "Indirizzo / Puzzle hash"
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr "Totale"
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr "Sei sicuro di voler uscire? Il plotting ed il farming da GUI si interromperanno."
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr "Sei sicuro di voler uscire? Il plotting ed il farming da GUI si interromperanno."
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr "Hash Sfida"
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr "Chatta su KeyBase"
+#~ msgid "Chat on KeyBase"
+#~ msgstr "Chatta su KeyBase"
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr "Chia"
+#~ msgid "Chia"
+#~ msgstr "Chia"
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr "Wiki Blockchain Chia"
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr "Wiki Blockchain Chia"
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr "Opzioni Monete Colorate"
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr "Conferma"
+#~ msgid "Confirm"
+#~ msgstr "Conferma"
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr "Connessioni"
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr "Contribuisci su GitHub"
+#~ msgid "Contribute on GitHub"
+#~ msgstr "Contribuisci su GitHub"
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr "Eliminando la chiave questa sarà rimossa definitivamente dal tuo computer, assicurati di avere un backup. Sei sicuro di voler continuare?"
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr "Sviluppatore"
+#~ msgid "Developer"
+#~ msgstr "Sviluppatore"
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr "Strumenti Sviluppatore"
+#~ msgid "Developer Tools"
+#~ msgstr "Strumenti Sviluppatore"
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr "Trascina e rilascia il tuo file di backup"
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr "Modifica"
+#~ msgid "Edit"
+#~ msgstr "Modifica"
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr "Inserisci le 24 parole mnemoniche che hai salvato per poter ripristinare il tuo wallet Chia."
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr "Il farmer non è in esecuzione"
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr "I coltivatori guadagnano le ricompense del blocco e le tasse di transazione impegnando spazio inutilizzato alla rete per aiutare a rendere sicure le transazioni. Qua è dove sarà la tua coltivazione una volta aggiunto un plot. <0>Scopri di più</0>"
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr "Coltivando"
@@ -648,13 +648,13 @@ msgstr "Coltivando"
 msgid "Farming Status"
 msgstr "Stato della Coltivazione"
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr "Fee"
 
@@ -680,12 +680,12 @@ msgstr "Ammontare delle Fee"
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr "File"
+#~ msgid "File"
+#~ msgstr "File"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr "Nome file"
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr "Finito"
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr "Segui su Twitter"
+#~ msgid "Follow on Twitter"
+#~ msgstr "Segui su Twitter"
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr "Domande Frequenti"
+#~ msgid "Frequently Asked Questions"
+#~ msgstr "Domande Frequenti"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr "Stato del Full Node"
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr "Schermo Intero"
+#~ msgid "Full Screen"
+#~ msgstr "Schermo Intero"
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr "Altezza"
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr "Aiuto"
+#~ msgid "Help"
+#~ msgstr "Aiuto"
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr "Nickname"
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr "No"
 
@@ -979,9 +978,9 @@ msgstr "ID nodo"
 msgid "None of your plots have passed the plot filter yet."
 msgstr "Nessuno dei tuoi plot ha ancora passato il filtro per plot."
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr "Non Disponibile"
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr "Aggiorna Plot"
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr "Note di Rilascio"
+#~ msgid "Release Notes"
+#~ msgstr "Note di Rilascio"
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr "Rinomina"
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr "Segnala un Problema..."
+#~ msgid "Report an Issue..."
+#~ msgstr "Segnala un Problema..."
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr "Registrati"
 #~ msgstr "Salta"
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr "Speech"
+#~ msgid "Speech"
+#~ msgstr "Speech"
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr "Condizione"
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr "Stato"
 
@@ -1540,8 +1539,8 @@ msgstr "Invia"
 msgid "Synced"
 msgstr "Sincronizzato"
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr "Sincronizzando"
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr "Iterazioni Sottoslot VDF"
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr "Visualizza"
+#~ msgid "View"
+#~ msgstr "Visualizza"
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr "Quando ricevi il tuo pacchetto di informazioni di setup dal tuo amministratore, inseriscile sotto per completare il setup del tuo Wallet a Velocità Limitata (RL):"
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr "Finestra"
+#~ msgid "Window"
+#~ msgstr "Finestra"
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr "Senza tasse"
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr "Sì"
 
@@ -1912,13 +1910,13 @@ msgstr "La tua Connessione del Full Node"
 msgid "Your Harvester Network"
 msgstr "La rete del tuo Harvester"
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr "connessioni:"
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr "altezza:"
 
@@ -1926,18 +1924,18 @@ msgstr "altezza:"
 msgid "not synced"
 msgstr "non sincronizzato"
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr "stato:"
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr "sincronizzato"
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr "sincronizzando"
 

--- a/src/locales/ro/messages.po
+++ b/src/locales/ro/messages.po
@@ -36,8 +36,8 @@ msgstr "Un harvester este un serviciu care rulează pe o mașină în care plot 
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr ""
+#~ msgid "About Chia Blockchain"
+#~ msgstr ""
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr "Accept"
 msgid "Accepted at time:"
 msgstr "Acceptat la:"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr "Actiune"
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr "Adaugati portofelul"
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr "Adaugati un plot"
 
@@ -99,10 +99,10 @@ msgstr "Adresa / hash puzzle"
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr "Suma"
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr ""
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr "Hashul provocarii"
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr ""
+#~ msgid "Chat on KeyBase"
+#~ msgstr ""
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr ""
+#~ msgid "Chia"
+#~ msgstr ""
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr ""
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr ""
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr "Opțiuni monede colorate"
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr ""
+#~ msgid "Confirm"
+#~ msgstr ""
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr "Conexiuni"
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr ""
+#~ msgid "Contribute on GitHub"
+#~ msgstr ""
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr "Ștergerea tuturor cheilor va elimina definitiv cheile de pe computer, asigurați-vă că aveți copii de rezervă. Esti sigur ca vrei sa continui?"
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr ""
+#~ msgid "Developer"
+#~ msgstr ""
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr ""
+#~ msgid "Developer Tools"
+#~ msgstr ""
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr "Drag and drop fisierul backup"
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr ""
+#~ msgid "Edit"
+#~ msgstr ""
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr "Introduceti cele 24 de cuvinte din mnemmonic seed pe care le-ati salvat pentru a restaura portofelul dvs. Chia."
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr "Fermierul nu ruleaza"
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr "Fermierii câștigă recompense bloc și taxe de tranzacționare prin angajarea spațiului liber în rețea pentru a ajuta la securizarea tranzacțiilor. Aici va fi ferma dvs. după ce adăugați un plot. <0> Aflați mai multe </0>"
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr "Farmare"
@@ -648,13 +648,13 @@ msgstr "Farmare"
 msgid "Farming Status"
 msgstr "Status farmare"
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr "Taxe"
 
@@ -680,12 +680,12 @@ msgstr "Suma taxe"
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr ""
+#~ msgid "File"
+#~ msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr "Nume fisier"
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr "Terminat"
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr ""
+#~ msgid "Follow on Twitter"
+#~ msgstr ""
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr ""
+#~ msgid "Frequently Asked Questions"
+#~ msgstr ""
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr "Stare nod complet"
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr "Inaltime"
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr ""
+#~ msgid "Help"
+#~ msgstr ""
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr "Porecla"
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr "Nu"
 
@@ -979,9 +978,9 @@ msgstr "ID-ul Nodului"
 msgid "None of your plots have passed the plot filter yet."
 msgstr "Niciunul dintre ploturile tale nu a trecut inca de filtru."
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr "Indisponibil"
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr "Improspateaza ploturile"
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr ""
+#~ msgid "Release Notes"
+#~ msgstr ""
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr "Redenumeste"
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr ""
+#~ msgid "Report an Issue..."
+#~ msgstr ""
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr "Inregistreaza-te"
 #~ msgstr "Sari"
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr ""
+#~ msgid "Speech"
+#~ msgstr ""
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr "Stare"
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr "Status"
 
@@ -1540,8 +1539,8 @@ msgstr "Trimite"
 msgid "Synced"
 msgstr "Sincronizat"
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr "Se sincronizeaza"
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr "Iteratii sub slot VDF"
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr ""
+#~ msgid "View"
+#~ msgstr ""
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr "Cand primiti pachetul de informatii despre configurare de la administratorul dvs., introduceti-l mai jos pentru a finaliza configurarea portofelului dvs. limitat:"
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr ""
+#~ msgid "Window"
+#~ msgstr ""
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr "Fara taxe"
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr "Da"
 
@@ -1912,13 +1910,13 @@ msgstr "Conexiunea nodului dvs"
 msgid "Your Harvester Network"
 msgstr "Reteaua dvs. de 'Harvesteri'"
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr "conexiuni:"
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr "inaltimea:"
 
@@ -1926,18 +1924,18 @@ msgstr "inaltimea:"
 msgid "not synced"
 msgstr "nesincronizat"
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr "status:"
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr "sincronizat"
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr "se sincronizeaza"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -36,8 +36,8 @@ msgstr "Комбайн - это служба, работающая на маши
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr ""
+#~ msgid "About Chia Blockchain"
+#~ msgstr ""
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr "Принять"
 msgid "Accepted at time:"
 msgstr "Принято в:"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr "Действие"
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr "Добавить кошелек"
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr "Добавить участок"
 
@@ -99,10 +99,10 @@ msgstr "Адрес / Хэш-головоломка"
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr "Количество"
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr ""
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr "Хэш испытания"
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr ""
+#~ msgid "Chat on KeyBase"
+#~ msgstr ""
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr ""
+#~ msgid "Chia"
+#~ msgstr ""
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr ""
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr ""
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr "Настройки Цветной Монеты"
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr ""
+#~ msgid "Confirm"
+#~ msgstr ""
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr "Подключения"
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr ""
+#~ msgid "Contribute on GitHub"
+#~ msgstr ""
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr "Удаление ключа приведет к безвозвратному удалению ключа с вашего компьютера, убедитесь, что у вас есть резервные копии. Вы уверены что хотите продолжить?"
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr ""
+#~ msgid "Developer"
+#~ msgstr ""
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr ""
+#~ msgid "Developer Tools"
+#~ msgstr ""
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr "Перетащите файл резервной копии"
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr ""
+#~ msgid "Edit"
+#~ msgstr ""
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr "Введите мнемонику из 24 слов, которую вы сохранили, чтобы восстановить свой кошелек Chia."
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr "Фермер не запущен"
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr "Фарминг"
@@ -648,13 +648,13 @@ msgstr "Фарминг"
 msgid "Farming Status"
 msgstr "Статус фарминга"
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr "Комиссия"
 
@@ -680,12 +680,12 @@ msgstr "Объем коммисий"
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr ""
+#~ msgid "File"
+#~ msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr "Имя файла"
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr "Завершен"
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr ""
+#~ msgid "Follow on Twitter"
+#~ msgstr ""
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr ""
+#~ msgid "Frequently Asked Questions"
+#~ msgstr ""
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr "Статус полного узла"
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr "Высота"
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr ""
+#~ msgid "Help"
+#~ msgstr ""
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr "Псевдоним"
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr "Нет"
 
@@ -979,9 +978,9 @@ msgstr "Идентификатор узла"
 msgid "None of your plots have passed the plot filter yet."
 msgstr "Ни один из ваших участков пока не прошел через фильтр."
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr "Не определено"
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr "Обновить участки"
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr ""
+#~ msgid "Release Notes"
+#~ msgstr ""
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr "Переименовать"
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr ""
+#~ msgid "Report an Issue..."
+#~ msgstr ""
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr "Войти в систему"
 #~ msgstr "Пропускать"
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr ""
+#~ msgid "Speech"
+#~ msgstr ""
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr "Состояние"
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr "Статус"
 
@@ -1540,8 +1539,8 @@ msgstr "Подтвердить"
 msgid "Synced"
 msgstr "Синхронизован"
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr "Синхронизация"
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr "Итерации VDF суб слота"
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr ""
+#~ msgid "View"
+#~ msgstr ""
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr "Когда вы получите пакет информации о настройке от администратора, введите его ниже, чтобы завершить настройку кошелька с ограниченнием скорости вывода:"
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr ""
+#~ msgid "Window"
+#~ msgstr ""
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr "Без комиссии"
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr "Да"
 
@@ -1912,13 +1910,13 @@ msgstr "Ваше подключение к полному узлу"
 msgid "Your Harvester Network"
 msgstr "Ваша сеть комбайнов"
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr "подключения:"
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr "высота:"
 
@@ -1926,18 +1924,18 @@ msgstr "высота:"
 msgid "not synced"
 msgstr "не синхронизированный"
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr "статус:"
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr "синхр."
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr "синх-ция"
 

--- a/src/locales/sk/messages.po
+++ b/src/locales/sk/messages.po
@@ -36,8 +36,8 @@ msgstr ""
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr ""
+#~ msgid "About Chia Blockchain"
+#~ msgstr ""
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr "Akceptovať"
 msgid "Accepted at time:"
 msgstr "Akceptované o:"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr "Akcia"
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr "Pridať peňaženku"
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr "Pridať pole"
 
@@ -99,10 +99,10 @@ msgstr "Adresa"
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr "Suma"
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr ""
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr "Hash výzvy"
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr ""
+#~ msgid "Chat on KeyBase"
+#~ msgstr ""
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr ""
+#~ msgid "Chia"
+#~ msgstr ""
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr ""
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr ""
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr ""
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr ""
+#~ msgid "Confirm"
+#~ msgstr ""
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr "Pripojenia"
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr ""
+#~ msgid "Contribute on GitHub"
+#~ msgstr ""
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr "Odstránením kľúča natrvalo odstránite kľúč z počítača. Uistite sa, že máte zálohy. Ste si istý, že chcete pokračovať?"
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr ""
+#~ msgid "Developer"
+#~ msgstr ""
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr ""
+#~ msgid "Developer Tools"
+#~ msgstr ""
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr ""
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr ""
+#~ msgid "Edit"
+#~ msgstr ""
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr ""
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr "Ťažba"
@@ -648,13 +648,13 @@ msgstr "Ťažba"
 msgid "Farming Status"
 msgstr "Stav ťažby"
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr "Poplatok"
 
@@ -680,12 +680,12 @@ msgstr "Množstvo odmeny"
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr ""
+#~ msgid "File"
+#~ msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr ""
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr "Dokončené"
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr ""
+#~ msgid "Follow on Twitter"
+#~ msgstr ""
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr ""
+#~ msgid "Frequently Asked Questions"
+#~ msgstr ""
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr "Stav siete"
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr "Poradie"
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr ""
+#~ msgid "Help"
+#~ msgstr ""
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr "Prezývka"
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr "Nie"
 
@@ -979,9 +978,9 @@ msgstr "Id uzla"
 msgid "None of your plots have passed the plot filter yet."
 msgstr ""
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr "Nie je k dispozícií"
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr "Obnoviť polia"
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr ""
+#~ msgid "Release Notes"
+#~ msgstr ""
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr "Premenovať"
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr ""
+#~ msgid "Report an Issue..."
+#~ msgstr ""
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr "Prihlásiť sa"
 #~ msgstr "Preskočiť"
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr ""
+#~ msgid "Speech"
+#~ msgstr ""
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr ""
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr "Stav"
 
@@ -1540,8 +1539,8 @@ msgstr "Odoslať"
 msgid "Synced"
 msgstr "Synchronizované"
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr "Synchronizácia"
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr ""
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr ""
+#~ msgid "View"
+#~ msgstr ""
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr ""
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr ""
+#~ msgid "Window"
+#~ msgstr ""
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr "Áno"
 
@@ -1912,13 +1910,13 @@ msgstr "Vaše pripojenie k sieti"
 msgid "Your Harvester Network"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr "pripojenia:"
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr "pozícia:"
 
@@ -1926,18 +1924,18 @@ msgstr "pozícia:"
 msgid "not synced"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr ""
 

--- a/src/locales/sv/messages.po
+++ b/src/locales/sv/messages.po
@@ -36,8 +36,8 @@ msgstr "En skördare är en tjänst som körs på en maskin där plottar lagras.
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr ""
+#~ msgid "About Chia Blockchain"
+#~ msgstr ""
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -47,9 +47,9 @@ msgstr "Acceptera"
 msgid "Accepted at time:"
 msgstr "Accepterat klockan:"
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr "Åtgärd"
 
@@ -72,9 +72,9 @@ msgid "Add Wallet"
 msgstr "Lägg till plånbok"
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr "Lägg till en plott"
 
@@ -99,10 +99,10 @@ msgstr "Adress/pusselhash"
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr "Belopp"
 
@@ -124,8 +124,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr ""
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -252,16 +252,16 @@ msgid "Challenge Hash"
 msgstr "Verifieringshash"
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr ""
+#~ msgid "Chat on KeyBase"
+#~ msgstr ""
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr ""
+#~ msgid "Chia"
+#~ msgstr ""
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr ""
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr ""
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -314,8 +314,8 @@ msgid "Coloured Coin Options"
 msgstr "Alternativ för färgade mynt"
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr ""
+#~ msgid "Confirm"
+#~ msgstr ""
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -365,8 +365,8 @@ msgid "Connections"
 msgstr "Anslutningar"
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr ""
+#~ msgid "Contribute on GitHub"
+#~ msgstr ""
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -524,12 +524,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr "Om du tar bort nyckeln kommer den att permanent tas bort från datorn. Se till att du har säkerhetskopierat den. Är det säkert att du vill fortsätta?"
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr ""
+#~ msgid "Developer"
+#~ msgstr ""
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr ""
+#~ msgid "Developer Tools"
+#~ msgstr ""
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -567,17 +567,17 @@ msgid "Drag and drop your backup file"
 msgstr "Drag och släpp din säkerhetskopierade fil"
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr ""
+#~ msgid "Edit"
+#~ msgstr ""
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr "Skriv in din sparade minnesfras på 24 ord för att återställa din Chia-plånbok."
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -633,9 +633,9 @@ msgstr "Odlaren körs inte"
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr "Odlare tjänar blockbelöningar och transaktionsavgifter genom att dedikera ledigt utrymme till nätverket för att hjälpa till att säkra transaktioner. Detta är vad din odling gör när du väl har lagt till en plott. <0>Läs mer</0>"
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr "Odlar"
@@ -648,13 +648,13 @@ msgstr "Odlar"
 msgid "Farming Status"
 msgstr "Odlingsstatus"
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr "Avgift"
 
@@ -680,12 +680,12 @@ msgstr "Avgiftsbelopp"
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr ""
+#~ msgid "File"
+#~ msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr "Filnamn"
 
@@ -699,12 +699,12 @@ msgid "Finished"
 msgstr "Färdig"
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr ""
+#~ msgid "Follow on Twitter"
+#~ msgstr ""
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr ""
+#~ msgid "Frequently Asked Questions"
+#~ msgstr ""
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -716,8 +716,8 @@ msgid "Full Node Status"
 msgstr "Status för full nod"
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -742,8 +742,8 @@ msgid "Height"
 msgstr "Höjd"
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr ""
+#~ msgid "Help"
+#~ msgstr ""
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -949,7 +949,6 @@ msgid "Nickname"
 msgstr "Smeknamn"
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr "Nej"
 
@@ -979,9 +978,9 @@ msgstr "Node-ID"
 msgid "None of your plots have passed the plot filter yet."
 msgstr "Ingen av dina plottar har passerat plottfiltret ännu."
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr "Inte tillgänglig"
@@ -1319,16 +1318,16 @@ msgid "Refresh Plots"
 msgstr "Uppdatera plottar"
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr ""
+#~ msgid "Release Notes"
+#~ msgstr ""
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr "Byt namn"
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr ""
+#~ msgid "Report an Issue..."
+#~ msgstr ""
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1452,8 +1451,8 @@ msgstr "Logga in"
 #~ msgstr "Hoppa över"
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr ""
+#~ msgid "Speech"
+#~ msgstr ""
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1495,8 +1494,8 @@ msgstr "Tillstånd"
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr "Status"
 
@@ -1540,8 +1539,8 @@ msgstr "Skicka"
 msgid "Synced"
 msgstr "Synkad"
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr "Synkar"
@@ -1777,8 +1776,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr "VDF-underslot-iterationer"
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr ""
+#~ msgid "View"
+#~ msgstr ""
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1879,8 +1878,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr ""
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr ""
+#~ msgid "Window"
+#~ msgstr ""
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1888,7 +1887,6 @@ msgstr "Utan avgifter"
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr "Ja"
 
@@ -1912,13 +1910,13 @@ msgstr "Din fullständiga nods anslutning"
 msgid "Your Harvester Network"
 msgstr "Ditt nätverk av skördare"
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr "anslutningar:"
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr "höjd:"
 
@@ -1926,18 +1924,18 @@ msgstr "höjd:"
 msgid "not synced"
 msgstr "ej synkad"
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr "status:"
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr "synkad"
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr "synkar"
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -31,8 +31,8 @@ msgstr ""
 
 #: src/electron-starter.js:362
 #: src/electron-starter.js:455
-msgid "About Chia Blockchain"
-msgstr ""
+#~ msgid "About Chia Blockchain"
+#~ msgstr ""
 
 #: src/components/trading/ViewOffer.jsx:85
 msgid "Accept"
@@ -42,9 +42,9 @@ msgstr ""
 msgid "Accepted at time:"
 msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 #: src/components/plot/PlotsFailed.tsx:14
 #: src/components/plot/PlotsNotFound.tsx:14
+#: src/components/plot/overview/PlotOverviewPlots.tsx:75
 msgid "Action"
 msgstr ""
 
@@ -67,9 +67,9 @@ msgid "Add Wallet"
 msgstr ""
 
 #: src/components/farm/overview/FarmOverviewHero.tsx:35
+#: src/components/plot/PlotHeader.tsx:33
 #: src/components/plot/add/PlotAdd.tsx:54
 #: src/components/plot/overview/PlotOverviewHero.tsx:29
-#: src/components/plot/PlotHeader.tsx:33
 msgid "Add a Plot"
 msgstr ""
 
@@ -94,10 +94,10 @@ msgstr ""
 
 #: src/components/trading/CreateOffer.jsx:213
 #: src/components/trading/TradesTable.tsx:16
+#: src/components/wallet/WalletHistory.tsx:48
 #: src/components/wallet/create/createNewColouredCoin.jsx:125
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:770
 #: src/components/wallet/standard/WalletStandard.tsx:331
-#: src/components/wallet/WalletHistory.tsx:48
 msgid "Amount"
 msgstr ""
 
@@ -119,8 +119,8 @@ msgid "Are you sure you want to disconnect?"
 msgstr ""
 
 #: src/electron-starter.js:134
-msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
-msgstr ""
+#~ msgid "Are you sure you want to quit? GUI Plotting and farming will stop."
+#~ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:31
 msgid "Are you sure you want to use k={plotSize}"
@@ -247,16 +247,16 @@ msgid "Challenge Hash"
 msgstr ""
 
 #: src/electron-starter.js:341
-msgid "Chat on KeyBase"
-msgstr ""
+#~ msgid "Chat on KeyBase"
+#~ msgstr ""
 
 #: src/electron-starter.js:359
-msgid "Chia"
-msgstr ""
+#~ msgid "Chia"
+#~ msgstr ""
 
 #: src/electron-starter.js:298
-msgid "Chia Blockchain Wiki"
-msgstr ""
+#~ msgid "Chia Blockchain Wiki"
+#~ msgstr ""
 
 #: src/components/wallet/Wallets.tsx:30
 msgid "Chia Wallet"
@@ -309,8 +309,8 @@ msgid "Coloured Coin Options"
 msgstr ""
 
 #: src/electron-starter.js:132
-msgid "Confirm"
-msgstr ""
+#~ msgid "Confirm"
+#~ msgstr ""
 
 #: src/components/fullNode/FullNodeCloseConnection.tsx:22
 msgid "Confirm Disconnect"
@@ -360,8 +360,8 @@ msgid "Connections"
 msgstr ""
 
 #: src/electron-starter.js:322
-msgid "Contribute on GitHub"
-msgstr ""
+#~ msgid "Contribute on GitHub"
+#~ msgstr ""
 
 #: src/components/core/components/CopyToClipboard/CopyToClipboard.tsx:22
 msgid "Copied"
@@ -519,12 +519,12 @@ msgid "Deleting the key will permanently remove the key from your computer, make
 msgstr ""
 
 #: src/electron-starter.js:244
-msgid "Developer"
-msgstr ""
+#~ msgid "Developer"
+#~ msgstr ""
 
 #: src/electron-starter.js:247
-msgid "Developer Tools"
-msgstr ""
+#~ msgid "Developer Tools"
+#~ msgstr ""
 
 #: src/components/block/Block.jsx:213
 #: src/components/fullNode/FullNode.jsx:191
@@ -562,17 +562,17 @@ msgid "Drag and drop your backup file"
 msgstr ""
 
 #: src/electron-starter.js:203
-msgid "Edit"
-msgstr ""
+#~ msgid "Edit"
+#~ msgstr ""
 
 #: src/components/wallet/WalletImport.tsx:67
 msgid "Enter the 24 word mnemonic that you have saved in order to restore your Chia wallet."
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:20
-#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/farm/FarmerStatus.tsx:30
 #: src/components/farm/FarmerStatus.tsx:31
+#: src/components/farm/card/FarmCardStatus.tsx:20
+#: src/components/farm/card/FarmCardStatus.tsx:25
 #: src/components/plot/PlotStatus.tsx:17
 #: src/components/plot/PlotStatus.tsx:18
 #: src/components/plot/queue/PlotQueueIndicator.tsx:14
@@ -628,9 +628,9 @@ msgstr ""
 msgid "Farmers earn block rewards and transaction fees by committing spare space to the network to help secure transactions. This is where your farm will be once you add a plot. <0>Learn more</0>"
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/farm/Farm.tsx:15
 #: src/components/farm/FarmerStatus.tsx:27
+#: src/components/farm/card/FarmCardStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:14
 msgid "Farming"
 msgstr ""
@@ -643,13 +643,13 @@ msgstr ""
 msgid "Farming Status"
 msgstr ""
 
+#: src/components/wallet/WalletHistory.tsx:52
 #: src/components/wallet/create/createExistingColouredCoin.jsx:131
 #: src/components/wallet/create/createNewColouredCoin.jsx:138
 #: src/components/wallet/create/createRLAdmin.jsx:266
 #: src/components/wallet/create/createRLAdmin.jsx:298
 #: src/components/wallet/rateLimited/WalletRateLimited.jsx:783
 #: src/components/wallet/standard/WalletStandard.tsx:336
-#: src/components/wallet/WalletHistory.tsx:52
 msgid "Fee"
 msgstr ""
 
@@ -675,12 +675,12 @@ msgstr ""
 
 #: src/electron-starter.js:195
 #: src/electron-starter.js:402
-msgid "File"
-msgstr ""
+#~ msgid "File"
+#~ msgstr ""
 
-#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 #: src/components/plot/PlotsFailed.tsx:10
 #: src/components/plot/PlotsNotFound.tsx:10
+#: src/components/plot/overview/PlotOverviewPlots.tsx:67
 msgid "Filename"
 msgstr ""
 
@@ -694,12 +694,12 @@ msgid "Finished"
 msgstr ""
 
 #: src/electron-starter.js:347
-msgid "Follow on Twitter"
-msgstr ""
+#~ msgid "Follow on Twitter"
+#~ msgstr ""
 
 #: src/electron-starter.js:306
-msgid "Frequently Asked Questions"
-msgstr ""
+#~ msgid "Frequently Asked Questions"
+#~ msgstr ""
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
 #: src/components/fullNode/FullNode.jsx:325
@@ -711,8 +711,8 @@ msgid "Full Node Status"
 msgstr ""
 
 #: src/electron-starter.js:272
-msgid "Full Screen"
-msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: src/components/wallet/create/createNewColouredCoin.jsx:106
 msgid "Generate New Colour"
@@ -737,8 +737,8 @@ msgid "Height"
 msgstr ""
 
 #: src/electron-starter.js:294
-msgid "Help"
-msgstr ""
+#~ msgid "Help"
+#~ msgstr ""
 
 #: src/components/core/components/LocaleToggle/LocaleToggle.tsx:50
 msgid "Help translate"
@@ -944,7 +944,6 @@ msgid "Nickname"
 msgstr ""
 
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "No"
 msgstr ""
 
@@ -974,9 +973,9 @@ msgstr ""
 msgid "None of your plots have passed the plot filter yet."
 msgstr ""
 
+#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/farm/card/FarmCardNotAvailable.tsx:8
 #: src/components/farm/card/FarmCardNotAvailable.tsx:9
-#: src/components/farm/FarmerStatus.tsx:29
 #: src/components/plot/PlotStatus.tsx:16
 msgid "Not Available"
 msgstr ""
@@ -1314,16 +1313,16 @@ msgid "Refresh Plots"
 msgstr ""
 
 #: src/electron-starter.js:314
-msgid "Release Notes"
-msgstr ""
+#~ msgid "Release Notes"
+#~ msgstr ""
 
 #: src/components/wallet/coloured/WalletColoured.tsx:206
 msgid "Rename"
 msgstr ""
 
 #: src/electron-starter.js:333
-msgid "Report an Issue..."
-msgstr ""
+#~ msgid "Report an Issue..."
+#~ msgstr ""
 
 #: src/components/backup/BackupRestore.tsx:107
 msgid "Restore Metadata for Coloured Coins and other Smart Wallets from Backup"
@@ -1447,8 +1446,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/electron-starter.js:416
-msgid "Speech"
-msgstr ""
+#~ msgid "Speech"
+#~ msgstr ""
 
 #: src/components/wallet/create/createRLAdmin.jsx:247
 msgid "Spendable Amount"
@@ -1490,8 +1489,8 @@ msgstr ""
 #: src/components/plot/overview/PlotOverviewPlots.tsx:71
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:42
-#: src/components/wallet/Wallets.tsx:94
 #: src/components/wallet/WalletStatusCard.tsx:12
+#: src/components/wallet/Wallets.tsx:94
 msgid "Status"
 msgstr ""
 
@@ -1535,8 +1534,8 @@ msgstr ""
 msgid "Synced"
 msgstr ""
 
-#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/farm/FarmerStatus.tsx:28
+#: src/components/farm/card/FarmCardStatus.tsx:12
 #: src/components/plot/PlotStatus.tsx:15
 msgid "Syncing"
 msgstr ""
@@ -1772,8 +1771,8 @@ msgid "VDF Sub Slot Iterations"
 msgstr ""
 
 #: src/electron-starter.js:235
-msgid "View"
-msgstr ""
+#~ msgid "View"
+#~ msgstr ""
 
 #: src/components/plot/queue/PlotQueueActions.tsx:49
 #: src/components/plot/queue/PlotQueueLogDialog.tsx:20
@@ -1874,8 +1873,8 @@ msgid "When you receive the setup info packet from your admin, enter it below to
 msgstr ""
 
 #: src/electron-starter.js:280
-msgid "Window"
-msgstr ""
+#~ msgid "Window"
+#~ msgstr ""
 
 #: src/components/farm/card/FarmCardBlockRewards.tsx:18
 msgid "Without fees"
@@ -1883,7 +1882,6 @@ msgstr ""
 
 #: src/components/plot/add/PlotAddChooseSize.tsx:30
 #: src/components/trading/TradingOverview.jsx:212
-#: src/electron-starter.js:131
 msgid "Yes"
 msgstr ""
 
@@ -1907,13 +1905,13 @@ msgstr ""
 msgid "Your Harvester Network"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:122
 #: src/components/wallet/WalletStatusCard.tsx:31
+#: src/components/wallet/Wallets.tsx:122
 msgid "connections:"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:116
 #: src/components/wallet/WalletStatusCard.tsx:25
+#: src/components/wallet/Wallets.tsx:116
 msgid "height:"
 msgstr ""
 
@@ -1921,18 +1919,18 @@ msgstr ""
 msgid "not synced"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:99
 #: src/components/wallet/WalletStatusCard.tsx:17
+#: src/components/wallet/Wallets.tsx:99
 msgid "status:"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:108
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:108
 msgid "synced"
 msgstr ""
 
-#: src/components/wallet/Wallets.tsx:106
 #: src/components/wallet/WalletStatusCard.tsx:20
+#: src/components/wallet/Wallets.tsx:106
 msgid "syncing"
 msgstr ""
 


### PR DESCRIPTION
If either the two checks at the top of electron-starter call `app.quit()` return right away and stop running start-up code. `app.quit` runs asynchronously and further start-up code is unnecessary, might result in confusing messages on `stdout` and could result in race conditions that are hard to debug (i.e. app still trying to start while electron is trying to quit).