### PR TITLE
fix number of log lines

### DIFF
--- a/src/modules/plotQueue.ts
+++ b/src/modules/plotQueue.ts
@@ -8,7 +8,7 @@ import PlotStatus from '../constants/PlotStatus';
 import { stopService } from './daemon_messages';
 import { service_plotter } from '../util/service_names';
 
-const FINISHED_LOG_LINES = 2083;
+const FINISHED_LOG_LINES = 2630;
 
 export function plotQueueAdd(
   config: PlotAdd,


### PR DESCRIPTION
As of 1.0.4, Phase 3 of the plotter outputs more lines to the log, making a typical K32 log file 2630 lines. This makes sure the GUI progress indicator stays below or equal to 100.

Should fix #255 and #256 