### PR TITLE
Add transaction time tooltip

### DIFF
--- a/src/components/wallet/standard/WalletStandard.tsx
+++ b/src/components/wallet/standard/WalletStandard.tsx
@@ -438,7 +438,14 @@ function SendCard(props: SendCardProps) {
   }
 
   return (
-    <Card title={<Trans>Create Transaction</Trans>}>
+    <Card
+      title={<Trans>Create Transaction</Trans>}
+      tooltip={(
+        <Trans>
+          On average there is one minute between each transaction block. Unless there is congestion you can expect your transaction to be included in less than a minute.
+        </Trans>
+      )}
+    >
       {result_message && (
         <Grid item xs={12}>
           <p className={result_class}>{result_message}</p>


### PR DESCRIPTION
Adds a tooltip to the Create Transaction card with details about how long the transaction should take.

Unfortunately I wasn't able to get a test environment working locally; running `npm run dev` resulted in the dev server crashing. Do I need to also be running other chia-blockchain repos to test locally? Advice would be much appreciated, thanks!

See https://github.com/Chia-Network/chia-blockchain-gui/issues/72

to: @hoffmang9 @seeden 
