### PR TITLE
Add formatting for large numbers

### DIFF
--- a/src/components/core/components/FormatLargeNumber/FormatLargeNumber.tsx
+++ b/src/components/core/components/FormatLargeNumber/FormatLargeNumber.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Tooltip } from '@material-ui/core';
+
+import useLocale from '../../../../hooks/useLocale';
+import { defaultLocale } from '../../../../config/locales';
+
+const LARGE_NUMBER_THRESHOLD = 1000;
+
+type Props = {
+  value: number;
+};
+
+export default function FormatLargeNumber(props: Props) {
+  const { value } = props;
+  const [locale] = useLocale(defaultLocale);
+
+  if (value < LARGE_NUMBER_THRESHOLD) {
+    return value;
+  }
+
+  return (
+    <Tooltip title={value}>
+      <span>
+        {new Intl.NumberFormat(locale, {
+          maximumFractionDigits: 1,
+          minimumFractionDigits: 1,
+          notation: 'compact',
+        }).format(value)}
+      </span>
+    </Tooltip>
+  );
+}

--- a/src/components/core/components/FormatLargeNumber/index.ts
+++ b/src/components/core/components/FormatLargeNumber/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FormatLargeNumber';

--- a/src/components/core/components/index.ts
+++ b/src/components/core/components/index.ts
@@ -17,6 +17,7 @@ export { default as Flex } from './Flex';
 export { default as Form } from './Form';
 export { default as FormatBytes } from './FormatBytes';
 export { default as FormatConnectionStatus } from './FormatConnectionStatus';
+export { default as FormatLargeNumber } from './FormatLargeNumber';
 export { default as GuestRoute } from './GuestRoute';
 export { default as IconButton } from './IconButton';
 export { default as Indicator } from './Indicator';

--- a/src/components/fullNode/FullNode.jsx
+++ b/src/components/fullNode/FullNode.jsx
@@ -3,6 +3,7 @@ import { Trans } from '@lingui/macro';
 import { get } from 'lodash';
 import {
   FormatBytes,
+  FormatLargeNumber,
   Flex,
   Card,
   Loading,
@@ -183,13 +184,13 @@ const getStatusItems = (state, connected, latestPeakTimestamp, networkInfo) => {
   const { sub_slot_iters } = state;
   status_items.push({
     label: <Trans>VDF Sub Slot Iterations</Trans>,
-    value: sub_slot_iters,
+    value: <FormatLargeNumber value={sub_slot_iters} />,
   });
 
   const totalIters = state.peak?.total_iters ?? 0;
   status_items.push({
     label: <Trans>Total Iterations</Trans>,
-    value: totalIters,
+    value: <FormatLargeNumber value={totalIters} />,
     tooltip: <Trans>Total iterations since the start of the blockchain</Trans>,
   });
 

--- a/src/locales/cs-CZ/messages.po
+++ b/src/locales/cs-CZ/messages.po
@@ -202,7 +202,7 @@ msgstr "Blok s hashem {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Blok s hashem {headerHash} neexistuje."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Bloky"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Připojit k dalším peerům"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Připojeno"
 
@@ -359,7 +359,7 @@ msgstr "Připojeno"
 msgid "Connecting to wallet"
 msgstr "Připojuje se peněženka"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Stav připojení"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Vývojářské nástroje"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Obtížnost"
 
@@ -613,11 +613,11 @@ msgstr "Chyba: Chia nelze odeslat na barevnou adresu. Zadejte prosím běžnou C
 msgid "Estimated Time to Win"
 msgstr "Odhadovaný čas do výhry"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Odhadované úložiště v síti"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Odhadovaný součet všech polí na discích všech farmářů v síti"
 
@@ -722,8 +722,8 @@ msgstr "Název souboru"
 msgid "Final folder location"
 msgstr "Umístění konečné složky"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Dokončeno"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Často kladené otázky"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Uzel"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Stav uzlu"
 
@@ -760,7 +760,7 @@ msgstr "HD nebo Hierarchické Deterministické klíče jsou typy veřejného/sou
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hash hlavičky"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hash hlavičky"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Výška"
@@ -815,7 +815,7 @@ msgstr "Importovat peněženku"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Import pomocí 24 slov"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Probíhá"
 
@@ -953,7 +953,7 @@ msgstr "Více paměti mírně zvyšuje rychlost"
 msgid "My Pubkey"
 msgstr "Můj Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Název sítě"
 
@@ -1022,7 +1022,7 @@ msgstr "Žádné z vašich polí dosud neprošlo filtrem poli."
 msgid "Not Available"
 msgstr "Nedostupný"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr " Není synchronizováno"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Dosud nepotvrzeno"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Nepřipojeno"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Odchozí"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Maximální výška"
 
@@ -1080,7 +1080,7 @@ msgstr "Maximální výška"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Vrchol křivky"
 
@@ -1547,14 +1547,14 @@ msgstr "Délka intervalu výdajů (počet bloků)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limit výdajů (chia na interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Stav"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Stav:"
 msgid "Submit"
 msgstr "Odeslat"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synchronizováno"
 
@@ -1609,7 +1609,7 @@ msgstr "Synchronizováno"
 msgid "Syncing"
 msgstr "Synchronizace"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synchronizace {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Uzel ke kterému je váš farmer (farmář) připojen. <0>Zjistit více<
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Minimální požadovaná velikost sítě je k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Node není synchronizován"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Uzel se synchronizuje, což znamená, že stahuje bloky z jiných uzlů, aby se dostal k nejnovějšímu bloku řetězce"
 
@@ -1704,7 +1704,7 @@ msgstr "Dosud nezpracovaná změna vlastního převodu, která ještě nebyla po
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Souhrn příchozích a odchozích nezpracovaných změn (zatím nejsou obsaženy v blockchainu). Neobsahuje odměny za farmaření."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr ""
 
@@ -1720,7 +1720,7 @@ msgstr "Celkový počet Chia v blockchainu při aktuální sub bloku kontrolovan
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Celkový zůstatek plus čekající transakce. Jinými slovy: celkový zůstatek po schválení čekajících transakcí."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Jste plně synchronizováni se sítí"
 
@@ -1744,7 +1744,7 @@ msgstr "Tento obchod byl zahrnut do blockchainu v této výšce bloku"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Tato verze Chia již není kompatibilní s blockchainem a nemůže bezpečně farmit."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Vytvořeno"
 
@@ -1770,7 +1770,7 @@ msgstr "Celkový zůstatek"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Celkové iterace"
 
@@ -1790,7 +1790,7 @@ msgstr "Celková velikost polí"
 msgid "Total VDF Iterations"
 msgstr "Celkové VDF iterace"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Počet opakování od začátku blockchainu"
 
@@ -1834,7 +1834,7 @@ msgstr "Hash filtru transakcí"
 msgid "Type"
 msgstr "Typ"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Nedokončeno"
 
@@ -1851,7 +1851,7 @@ msgstr "Neznámé"
 msgid "User Pubkey"
 msgstr "Uživatelský veřejný klíč"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF dílčí iterace slotu"
 

--- a/src/locales/da-DK/messages.po
+++ b/src/locales/da-DK/messages.po
@@ -202,7 +202,7 @@ msgstr "Blokke med hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Blok med hash {headerHash} eksisterer ikke."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blokke"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Forbind til andre noder"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Forbundet"
 
@@ -359,7 +359,7 @@ msgstr "Forbundet"
 msgid "Connecting to wallet"
 msgstr "Forbinder pung"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Forbindelses Status"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Udvikler Værktøjer"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Sværhed"
 
@@ -613,11 +613,11 @@ msgstr "Fejl: Kan ikke sende chia til en farvet addresse. Venligst indtast en ch
 msgid "Estimated Time to Win"
 msgstr "Estimeret Tid til Gevinst"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Estimeret netværk størrelse"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Estimeret sum af alt plottet drev plads af alle farmerer på netværket"
 
@@ -722,8 +722,8 @@ msgstr "Filnavn"
 msgid "Final folder location"
 msgstr "Endelig folder placering"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Færdig"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Ofte Stillet Spørgsmål"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Fuld Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Fuld Node Status"
 
@@ -760,7 +760,7 @@ msgstr "HD eller Hierarkisk Deterministiske nøgler er en type a offentlig nøgl
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Header Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Header hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Højde"
@@ -815,7 +815,7 @@ msgstr "Importer Pung fra mnemonik"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importer fra mnemonik (24 ord)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Igangværende"
 
@@ -953,7 +953,7 @@ msgstr "Mere hukommelse øger hastighed en smule"
 msgid "My Pubkey"
 msgstr "Min Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Netværksnavn"
 
@@ -1022,7 +1022,7 @@ msgstr "Ingen af dine plotfiler har passeret plotfilteret endnu."
 msgid "Not Available"
 msgstr "Ikke Tilgængelig"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Ikke Synkroniseret"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Ikke bekrætet endnu"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Ikke forbundet"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Udgående"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Top Højde"
 
@@ -1080,7 +1080,7 @@ msgstr "Top Højde"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Top Tidspunkt"
 
@@ -1547,14 +1547,14 @@ msgstr "Forbrugsinterval Længde (nummer af blokke)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Forbrugsgrænse (chia per interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Status"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Indsend"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synkroniseret"
 
@@ -1609,7 +1609,7 @@ msgstr "Synkroniseret"
 msgid "Syncing"
 msgstr "Synkroniserer"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synkroniserer {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Den fulder node som din farmer er forbundet til herunder. <0>Lær mere</
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Den mindste tilladte størrelse for mainnet er k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Noden er ikke synkroniseret"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Noden Synkroniserer, hvilket betyder at den er ved at hente blokke fra andre noder, for at nå den sidste blok i kæden"
 
@@ -1704,7 +1704,7 @@ msgstr "Dette er den afventende ændring, som er vekslet til dig selv, men ikke 
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Dette er summen af indkommende og udgående afventende transaktioner (ikke skrevet ind i blokkæden endnu). Dette er ekslusivt farmede gevinster."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Dette er tidstemplet for den sidste blok."
 
@@ -1720,7 +1720,7 @@ msgstr "Dette er det totale beløb af chia i blokkæden ved den nuværende sidst
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Dette er den totalle + afventende saldo: det er hvad din balance vil være når alle afventende transaktioner er bekræftet."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Denne node er fuldt synkroniseret og validerer netværket"
 
@@ -1744,7 +1744,7 @@ msgstr "Denne handel blev inkluderet i blokkæden i denne blok"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Denne version af Chia er ikke længere kompatibel med netværket og kan ikke farme."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Tid Oprettet"
 
@@ -1770,7 +1770,7 @@ msgstr "Total Saldo"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Total iterationer"
 
@@ -1790,7 +1790,7 @@ msgstr "Total Størrelse af Plotfiler"
 msgid "Total VDF Iterations"
 msgstr "Total VDF Iterationer"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total iterationer siden blokkædens start"
 
@@ -1834,7 +1834,7 @@ msgstr "Transaktionsfilter Hash"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Ikke Afsluttet"
 
@@ -1851,7 +1851,7 @@ msgstr "Ukendt"
 msgid "User Pubkey"
 msgstr "Bruger Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF blok iterationer"
 

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -202,7 +202,7 @@ msgstr "Block mit hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block mit hash {headerHash} existiert nicht."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blöcke"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Mit anderen Peers verbinden"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Verbunden"
 
@@ -359,7 +359,7 @@ msgstr "Verbunden"
 msgid "Connecting to wallet"
 msgstr "Verbinde mit Wallet"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Verbindungsstatus"
 
@@ -550,7 +550,7 @@ msgid "Developer Tools"
 msgstr "Entwickler Werkzeuge"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Schwierigkeit"
 
@@ -619,11 +619,11 @@ msgstr "Fehler: Chia kann nicht zu der farbigen Adresse geschickt werden. Bitte 
 msgid "Estimated Time to Win"
 msgstr "Geschätzte Zeit bis Gewinn"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Geschätzte Netzwerkgröße"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Geschätzter Speicherplatzverbrauch der Summe aller Plots aller Farmer"
 
@@ -728,8 +728,8 @@ msgstr "Dateiname"
 msgid "Final folder location"
 msgstr "Finaler Speicherort"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Beendet"
 
@@ -742,11 +742,11 @@ msgid "Frequently Asked Questions"
 msgstr "Häufig gestellte Fragen"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Full Node Status"
 
@@ -766,7 +766,7 @@ msgstr "HD oder hierarchische determenistische Schlüssel sind eine Art öffentl
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Header Hash"
 
@@ -775,7 +775,7 @@ msgid "Header hash"
 msgstr "Header hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Höhe"
@@ -821,7 +821,7 @@ msgstr "Wallet aus Mnemonics importieren"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Import aus Mnemonics (24 Wörter)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "In Bearbeitung"
 
@@ -959,7 +959,7 @@ msgstr "Mehr Speicher erhöht etwas die Geschwindigkeit"
 msgid "My Pubkey"
 msgstr "Mein öffentlicher Schlüssel"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Netzwerkname"
 
@@ -1028,7 +1028,7 @@ msgstr "Keiner deiner Plots hat den Plotfilter bisher bestanden."
 msgid "Not Available"
 msgstr "Nicht verfübar"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Nicht synchronisiert"
 
@@ -1041,8 +1041,8 @@ msgid "Not confirmed yet"
 msgstr "Bisher nicht bestätigt"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Nicht verbunden"
 
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Ausgehend"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Spitzenhöhe"
 
@@ -1086,7 +1086,7 @@ msgstr "Spitzenhöhe"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Spitzenzeit"
 
@@ -1555,14 +1555,14 @@ msgstr "Länge des Ausgabenintervalls (Anzahl der Blöcke)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Ausgabenlimit (Chia pro Intervall): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Status"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1607,7 +1607,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Einreichen"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synchronisiert"
 
@@ -1617,7 +1617,7 @@ msgstr "Synchronisiert"
 msgid "Syncing"
 msgstr "Synchronisieren"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synchronisieren {progress}/{tip}"
 
@@ -1662,11 +1662,11 @@ msgstr "Der vollständige Node, mit dem dein Farmer verbunden ist, befindet sich
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Die minimal benötigte Größe für das Mainnet ist k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Die Node ist nicht synchronisiert"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Der Node wird synchronisiert, d.h. er lädt Blöcke von anderen Nodes herunter, um den neuesten Block in der Kette zu erreichen"
 
@@ -1712,7 +1712,7 @@ msgstr "Dies ist die ausstehende Änderung. Hierbei handelt es sich um Wechselco
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Dies ist die Summe der eingehenden und ausgehenden ausstehenden Transaktionen (noch nicht in der Blockchain enthalten). Dies beinhaltet keine Farming Belohnungen."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Dies ist die Zeit des letzten Peak-Unterblocks."
 
@@ -1728,7 +1728,7 @@ msgstr "Dies ist die Gesamtmenge an Chia in der Blockchaim im aktuellen Peak-Unt
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Dies ist das Gesamtguthaben + ausstehende Guthaben: Das ist dein Guthaben nachdem alle ausstehenden Transaktionen bestätigt wurden."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Dieser node ist vollständig eingeholt und validiert das Netzwerk"
 
@@ -1752,7 +1752,7 @@ msgstr "Dieser Handel wurde auf der Blockchain in dieser Blockhöhe aufgenommen"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Diese Version von Chia ist nicht mehr kompatibel mit der Blockchain und kann nicht sicher farmen."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Erstellungszeitpunkt"
 
@@ -1778,7 +1778,7 @@ msgstr "Gesamtes Guthaben"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Gesamte Iterationen"
 
@@ -1798,7 +1798,7 @@ msgstr "Gesamtgröße der Plots"
 msgid "Total VDF Iterations"
 msgstr "Totale VDF Iterationen"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Gesamte Iterationen seit Start der Blockchain"
 
@@ -1842,7 +1842,7 @@ msgstr "Transaktions Filter Hash"
 msgid "Type"
 msgstr "Typ"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Unvollendet"
 
@@ -1859,7 +1859,7 @@ msgstr "Unbekannt"
 msgid "User Pubkey"
 msgstr "Benutzer Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub Slot Iterationen"
 

--- a/src/locales/el-GR/messages.po
+++ b/src/locales/el-GR/messages.po
@@ -202,7 +202,7 @@ msgstr "Block with hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block με hash {headerHash} δεν υπάρχει."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocks"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Σύνδεση με άλλους υπολογιστές"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Συνδέθηκε"
 
@@ -359,7 +359,7 @@ msgstr "Συνδέθηκε"
 msgid "Connecting to wallet"
 msgstr "Σύνδεση σε πορτοφόλι"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Κατάσταση Σύνδεσης"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Εργαλεία Προγραμματιστή"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Eπίπεδο Δυσκολίας"
 
@@ -613,11 +613,11 @@ msgstr "Σφάλμα: Δεν μπορείτε να στείλετε chia σε χ
 msgid "Estimated Time to Win"
 msgstr "Εκτιμώμενος χρόνος για να κερδίσετε:"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Εκτιμώμενος χώρος δικτύου"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Εκτιμώμενο άθροισμα του συνόλου του plotted disk space όλων των farmers στο δίκτυο"
 
@@ -722,8 +722,8 @@ msgstr "Όνομα αρχείου"
 msgid "Final folder location"
 msgstr "Τελική τοποθεσία φακέλου"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Ολοκληρώθηκε"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Συχνές ερωτήσεις"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Πλήρης Κόμβος"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Κατάσταση Πλήρους Κόμβου"
 
@@ -760,7 +760,7 @@ msgstr "Τα HD ή τα Hierarchical Deterministic keys είναι ένας τύ
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Header Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Header Hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Ύψος"
@@ -815,7 +815,7 @@ msgstr "Εισαγωγή πορτοφολιού από Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Εισαγωγή από Mnemonics (24 λέξεις)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Σε Εξέλιξη"
 
@@ -953,7 +953,7 @@ msgstr "Περισσότερη μνήμη αυξάνει ελαφρώς την �
 msgid "My Pubkey"
 msgstr "Αντιγραφή Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Όνομα Δικτύου"
 
@@ -1022,7 +1022,7 @@ msgstr "Κανένα από τα οικόπεδά σας δεν έχει περ�
 msgid "Not Available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Δεν Είναι Συγχρονισμένο"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Δεν έχει επιβεβαιωθεί ακόμη"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Χωρίς σύνδεση"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Εξερχόμενες"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Peak Height"
 
@@ -1080,7 +1080,7 @@ msgstr "Peak Height"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Peak Time"
 
@@ -1547,14 +1547,14 @@ msgstr "Spending Interval Length (number of blocks)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Όριο δαπανών (chia ανά διάστημα): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "State"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Κατάσταση:"
 msgid "Submit"
 msgstr "Υποβολή"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Συγχρονίστηκε"
 
@@ -1609,7 +1609,7 @@ msgstr "Συγχρονίστηκε"
 msgid "Syncing"
 msgstr "Συγχρονισμός..."
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Γίνεται συγχρονισμός {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Ο πλήρης κόμβος στον οποίο είναι συνδεδ
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Το ελάχιστο απαιτούμενο μέγεθος για το mainnet είναι k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Ο κόμβος δεν είναι συγχρονισμένος"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Ο κόμβος συγχρονίζεται, πράγμα που σημαίνει ότι γίνεται λήψη μπλοκ από άλλους κόμβους, για να φτάσει το τελευταίο μπλοκ στην αλυσίδα"
 
@@ -1704,7 +1704,7 @@ msgstr "Αυτή είναι η αλλαγή που εκκρεμεί, η οποί
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Αυτό είναι το άθροισμα των εισερχόμενων και εξερχόμενων συναλλαγών (που δεν περιλαμβάνονται ακόμη στο blockchain). Αυτό δεν περιλαμβάνει τις farming ανταμοιβές."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Αυτή είναι η ώρα του τελευταίου υπο-μπλοκ κορυφής."
 
@@ -1720,7 +1720,7 @@ msgstr "Αυτή είναι η συνολική ποσότητα chia στο blo
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Αυτό είναι το συνολικό υπόλοιπο + το εκκρεμές υπόλοιπο: αυτό είναι που θα είναι το υπόλοιπό σας μετά από όλες τις εκκρεμείς συναλλαγές που θα επιβεβαιωθούν."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Αυτός ο κόμβος είναι πλήρως παγιδευμένος και επικυρώνει το δίκτυο"
 
@@ -1744,7 +1744,7 @@ msgstr "Αυτή η συναλλαγή συμπεριλήφθηκε στο block
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Αυτή η έκδοση του Chia δεν είναι πλέον συμβατή με το blockchain και δεν μπορεί να γίνει farm με ασφάλεια."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Ώρα δημιουργίας"
 
@@ -1770,7 +1770,7 @@ msgstr "Συνολικό Υπόλοιπο"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Σύνολο Επαναλήψεων"
 
@@ -1790,7 +1790,7 @@ msgstr "Συνολικό μέγεθος των plots"
 msgid "Total VDF Iterations"
 msgstr "Σύνολο Επαναλήψεων VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Συνολικές επαναλήψεις από την αρχή του blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Hash Φίλτρο Συναλλαγών"
 msgid "Type"
 msgstr "Τύπος"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Μη Ολοκληρωμένο"
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "User Pubkey"
 msgstr "Pubkey Χρήστη"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub Slot Iterations"
 

--- a/src/locales/en-AU/messages.po
+++ b/src/locales/en-AU/messages.po
@@ -202,7 +202,7 @@ msgstr "Block with hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block with hash {headerHash} does not exists."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocks"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Connect to other peers"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Connected"
 
@@ -359,7 +359,7 @@ msgstr "Connected"
 msgid "Connecting to wallet"
 msgstr "Connecting to wallet"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Connection Status"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Developer Tools"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Difficulty"
 
@@ -613,11 +613,11 @@ msgstr "Error: Cannot send chia to coloured address. Please enter a chia address
 msgid "Estimated Time to Win"
 msgstr "Estimated Time to Win"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Estimated network space"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Estimated sum of all the plotted disk space of all farmers in the network"
 
@@ -722,8 +722,8 @@ msgstr "Filename"
 msgid "Final folder location"
 msgstr "Final folder location"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Finished"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Full Node Status"
 
@@ -760,7 +760,7 @@ msgstr "HD or Hierarchical Deterministic keys are a type of public key/private k
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Header Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Header hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Height"
@@ -815,7 +815,7 @@ msgstr "Import Wallet from Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Import from Mnemonics (24 words)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "In Progress"
 
@@ -953,7 +953,7 @@ msgstr "More memory slightly increases speed"
 msgid "My Pubkey"
 msgstr "My Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Network Name"
 
@@ -1022,7 +1022,7 @@ msgstr "None of your plots have passed the plot filter yet:(."
 msgid "Not Available"
 msgstr "Not Available"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Not Synced, no beer money for you"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Not confirmed yet"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Not connected"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Outgoing"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Peak Height"
 
@@ -1080,7 +1080,7 @@ msgstr "Peak Height"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Peak Time"
 
@@ -1547,14 +1547,14 @@ msgstr "Spending Interval Length (number of blocks)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Spending Limit (chia per interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "State"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synced, earning beer money"
 
@@ -1609,7 +1609,7 @@ msgstr "Synced, earning beer money"
 msgid "Syncing"
 msgstr "Syncing, not yet getting beer money"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Syncing {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "The full node that your farmer is connected to is below. <0>Learn more</
 msgid "The minimum required size for mainnet is k=32"
 msgstr "The minimum required size for mainnet is k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "The node is not synced, no beer money for you"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 
@@ -1704,7 +1704,7 @@ msgstr "This is the pending change, which are change coins which you have sent t
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "This is the time of the latest peak sub block."
 
@@ -1720,7 +1720,7 @@ msgstr "This is the total amount of chia in the blockchain at the current peak s
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "This node is fully caught up and validating the network"
 
@@ -1744,7 +1744,7 @@ msgstr "This trade was included on blockchain at this block height"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "This version of Chia is no longer compatible with the blockchain and can not safely farm, no beer money for you."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Time Created"
 
@@ -1770,7 +1770,7 @@ msgstr "Total Beer Balance"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Total Iterations"
 
@@ -1790,7 +1790,7 @@ msgstr "Total Size of Plots"
 msgid "Total VDF Iterations"
 msgstr "Total VDF Iterations"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total iterations since the start of the blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Transactions Filter Hash"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Unfinished"
 
@@ -1851,7 +1851,7 @@ msgstr "Unknown"
 msgid "User Pubkey"
 msgstr "User Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub Slot Iterations"
 

--- a/src/locales/en-NZ/messages.po
+++ b/src/locales/en-NZ/messages.po
@@ -202,7 +202,7 @@ msgstr "Block with hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block with hash {headerHash} does not exists."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocks"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Connect to other peers"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Connected"
 
@@ -359,7 +359,7 @@ msgstr "Connected"
 msgid "Connecting to wallet"
 msgstr "Connecting to wallet"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Connection Status"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Developer Tools"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Difficulty"
 
@@ -613,11 +613,11 @@ msgstr "Error: Cannot send chia to coloured address. Please enter a chia address
 msgid "Estimated Time to Win"
 msgstr "Estimated Time to Win"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Estimated network space"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Estimated sum of all the plotted disk space of all farmers in the network"
 
@@ -722,8 +722,8 @@ msgstr "Filename"
 msgid "Final folder location"
 msgstr "Final folder location"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Finished"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Full Node Status"
 
@@ -760,7 +760,7 @@ msgstr "HD or Hierarchical Deterministic keys are a type of public key/private k
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Header Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Header hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Height"
@@ -815,7 +815,7 @@ msgstr "Import Wallet from Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Import from Mnemonics (24 words)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "In Progress"
 
@@ -953,7 +953,7 @@ msgstr "More memory slightly increases speed"
 msgid "My Pubkey"
 msgstr "My Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Network Name"
 
@@ -1022,7 +1022,7 @@ msgstr "None of your plots have passed the plot filter yet."
 msgid "Not Available"
 msgstr "Not available"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Not Synced"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Not confirmed yet"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Not connected"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Outgoing"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Peak Height"
 
@@ -1080,7 +1080,7 @@ msgstr "Peak Height"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Peak Time"
 
@@ -1547,14 +1547,14 @@ msgstr "Spending Interval Length (number of blocks)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Spending Limit (chia per interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "State"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synced"
 
@@ -1609,7 +1609,7 @@ msgstr "Synced"
 msgid "Syncing"
 msgstr "Syncing"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Syncing {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "The full node that your farmer is connected to is below. <0>Learn more</
 msgid "The minimum required size for mainnet is k=32"
 msgstr "The minimum required size for mainnet is k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "The node is not synced"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 
@@ -1704,7 +1704,7 @@ msgstr "This is the pending change, which are change coins which you have sent t
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "This is the time of the latest peak sub block."
 
@@ -1720,7 +1720,7 @@ msgstr "This is the total amount of chia in the blockchain at the current peak s
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "This node is fully caught up and validating the network"
 
@@ -1744,7 +1744,7 @@ msgstr "This trade was included on blockchain at this block height"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Time Created"
 
@@ -1770,7 +1770,7 @@ msgstr "Total Balance"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Total Iterations"
 
@@ -1790,7 +1790,7 @@ msgstr "Total Size of Plots"
 msgid "Total VDF Iterations"
 msgstr "Total VDF Iterations"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total iterations since the start of the blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Transactions Filter Hash"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Unfinished"
 
@@ -1851,7 +1851,7 @@ msgstr "Unknown"
 msgid "User Pubkey"
 msgstr "User Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub Slot Iterations"
 

--- a/src/locales/en-PT/messages.po
+++ b/src/locales/en-PT/messages.po
@@ -202,7 +202,7 @@ msgstr "Booty wit' hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Booty wit' hash {headerHash} does nah exist."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Booties"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Say ahoy to other peers"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Natter'd wit' me hearties jus' now"
 
@@ -359,7 +359,7 @@ msgstr "Natter'd wit' me hearties jus' now"
 msgid "Connecting to wallet"
 msgstr "Lookin' fer treasure chest"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Contact t' other Capt'ns"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Builder Tools"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Pirate-hunting fleets"
 
@@ -613,11 +613,11 @@ msgstr "Arrgh: Can nah send chia 't jinxed coordinates. Give chia coordinates."
 msgid "Estimated Time to Win"
 msgstr "Fortune Teller's Next Prize Prophecy"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Strength o' all pirates on the seas"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Guessed strength of all pirates on the seas"
 
@@ -722,8 +722,8 @@ msgstr "Filename"
 msgid "Final folder location"
 msgstr "Final folder"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Done"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Oftentimes Asked Questions"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Capt'n"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Report o' yer Capt'n"
 
@@ -760,7 +760,7 @@ msgstr "HD or Hierarchical Deterministic treasure maps are a type o' public trea
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Header Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Header hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Booty Number"
@@ -815,7 +815,7 @@ msgstr "Get Treasure Chest from Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Get from Mnemonics (24 words)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Workin' on it"
 
@@ -953,7 +953,7 @@ msgstr "More memory makes it wee faster"
 msgid "My Pubkey"
 msgstr "My Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Ocean"
 
@@ -1022,7 +1022,7 @@ msgstr "None of your barrages has hit a ship."
 msgid "Not Available"
 msgstr "Nothin' 'ere"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Not Over the Horizon Yet"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Not yet let through"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Arrgh, can see naught in this fog"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Goin' Out"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Ships taken all o'er the seas"
 
@@ -1080,7 +1080,7 @@ msgstr "Ships taken all o'er the seas"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Time o' last lucky boardin'"
 
@@ -1547,14 +1547,14 @@ msgstr "Spendin' Interval Length (number o' booties)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Squanderin' Limit (chia per interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "State"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "State o' t'ings:"
 msgid "Submit"
 msgstr "Go Ahead"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Everythin' jolly"
 
@@ -1609,7 +1609,7 @@ msgstr "Everythin' jolly"
 msgid "Syncing"
 msgstr "Catchin' up wit' other Capt'ns"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Catchin' up {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "The Capt'n that yer Plunderer be connected t' be below. <0>Look fer more
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Minimum size fer mainnet be k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "The Capt'n be three sheets to the wind"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "The capt'n be collectin' reports, which means he's gettin' information o' other capt'ns' boarded ships"
 
@@ -1704,7 +1704,7 @@ msgstr "'tis the pendin' change, which are change doubloons which ye 'ave sent t
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "'tis the sum o' the incomin' 'n outgoin' pendin' transactions (nah yet included into the blockchain). This be nah includin' lootin' rewards."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "'tis the time o' the latest peak sub booty."
 
@@ -1720,7 +1720,7 @@ msgstr "'tis the total amount o' chia in the blockchain at the current peak sub 
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "'tis ye whole treasure + ye under way treasure: 'tis wha' yer trasure will be aft all under way treasure be let through."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "This pirate be fully caught up 'n scannin' the ocean"
 
@@ -1744,7 +1744,7 @@ msgstr "This trade was added t' the blockchain at this booty number"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "T'is version o' Chia is no longer workin' wit' the blockchain 'n no good fer plunderin'."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Time o' Boardin'"
 
@@ -1770,7 +1770,7 @@ msgstr "Ye Whole Treasure"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Thumbs twiddled"
 
@@ -1790,7 +1790,7 @@ msgstr "Yer Strength o' Crew"
 msgid "Total VDF Iterations"
 msgstr "Combined Thumbs Twiddled"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Thumbs twiddled since the beginnin' o' time"
 
@@ -1834,7 +1834,7 @@ msgstr "Transactions Filter Hash"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Fightin'"
 
@@ -1851,7 +1851,7 @@ msgstr "Unknown"
 msgid "User Pubkey"
 msgstr "Scallywag Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Shots fired"
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -202,7 +202,7 @@ msgstr "Block with hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block with hash {headerHash} does not exists."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocks"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Connect to other peers"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Connected"
 
@@ -359,7 +359,7 @@ msgstr "Connected"
 msgid "Connecting to wallet"
 msgstr "Connecting to wallet"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Connection Status"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Developer Tools"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Difficulty"
 
@@ -613,11 +613,11 @@ msgstr "Error: Cannot send chia to colored address. Please enter a chia address.
 msgid "Estimated Time to Win"
 msgstr "Estimated Time to Win"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Estimated network space"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Estimated sum of all the plotted disk space of all farmers in the network"
 
@@ -722,8 +722,8 @@ msgstr "Filename"
 msgid "Final folder location"
 msgstr "Final folder location"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Finished"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Full Node Status"
 
@@ -760,7 +760,7 @@ msgstr "HD or Hierarchical Deterministic keys are a type of public key/private k
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Header Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Header hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Height"
@@ -815,7 +815,7 @@ msgstr "Import Wallet from Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Import from Mnemonics (24 words)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "In Progress"
 
@@ -953,7 +953,7 @@ msgstr "More memory slightly increases speed"
 msgid "My Pubkey"
 msgstr "My Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Network Name"
 
@@ -1022,7 +1022,7 @@ msgstr "None of your plots have passed the plot filter yet."
 msgid "Not Available"
 msgstr "Not Available"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Not Synced"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Not confirmed yet"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Not connected"
 
@@ -1072,7 +1072,7 @@ msgstr "On average there is one minute between each transaction block. Unless th
 msgid "Outgoing"
 msgstr "Outgoing"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Peak Height"
 
@@ -1080,7 +1080,7 @@ msgstr "Peak Height"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Peak Time"
 
@@ -1547,14 +1547,14 @@ msgstr "Spending Interval Length (number of blocks)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Spending Limit (chia per interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "State"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synced"
 
@@ -1609,7 +1609,7 @@ msgstr "Synced"
 msgid "Syncing"
 msgstr "Syncing"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Syncing {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "The full node that your farmer is connected to is below. <0>Learn more</
 msgid "The minimum required size for mainnet is k=32"
 msgstr "The minimum required size for mainnet is k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "The node is not synced"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 
@@ -1704,7 +1704,7 @@ msgstr "This is the pending change, which are change coins which you have sent t
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "This is the time of the latest peak sub block."
 
@@ -1720,7 +1720,7 @@ msgstr "This is the total amount of chia in the blockchain at the current peak s
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "This node is fully caught up and validating the network"
 
@@ -1744,7 +1744,7 @@ msgstr "This trade was included on blockchain at this block height"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Time Created"
 
@@ -1770,7 +1770,7 @@ msgstr "Total Balance"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Total Iterations"
 
@@ -1790,7 +1790,7 @@ msgstr "Total Size of Plots"
 msgid "Total VDF Iterations"
 msgstr "Total VDF Iterations"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total iterations since the start of the blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Transactions Filter Hash"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Unfinished"
 
@@ -1851,7 +1851,7 @@ msgstr "Unknown"
 msgid "User Pubkey"
 msgstr "User Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub Slot Iterations"
 

--- a/src/locales/es-ES/messages.po
+++ b/src/locales/es-ES/messages.po
@@ -202,7 +202,7 @@ msgstr "Bloque con hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "No existe bloque con hash {headerHash}."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Bloques"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Conectar a otros pares"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Conectado"
 
@@ -359,7 +359,7 @@ msgstr "Conectado"
 msgid "Connecting to wallet"
 msgstr "Conectar al Monedero"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Estado de Conexión"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Herramientas de Desarrollador"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Dificultad"
 
@@ -613,11 +613,11 @@ msgstr "Error: No se puede enviar chia a la dirección de color. Por favor intro
 msgid "Estimated Time to Win"
 msgstr "Tiempo Estimado para Ganar"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Espacio estimado de red"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Suma estimada de todo el espacio en disco trazado de todos los agricultores de la red"
 
@@ -722,8 +722,8 @@ msgstr "Nombre del Archivo"
 msgid "Final folder location"
 msgstr "Ubicación de la Carpeta Final"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Finalizado"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Nodo Completo"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Estado de Nodo Completo"
 
@@ -760,7 +760,7 @@ msgstr "HD o llaves Jerárquicamente Determinísticas son un tipo de esquema de 
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Encabezado de Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Encabezado de hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Altura"
@@ -815,7 +815,7 @@ msgstr "Importar Cartera desde Mnemotécnica"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importar desde Mnemotécnica (24 palabras)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "En Progreso"
 
@@ -953,7 +953,7 @@ msgstr "Más memoria aumenta ligeramente la velocidad"
 msgid "My Pubkey"
 msgstr "Mi Llave Pública"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nombre de Red"
 
@@ -1022,7 +1022,7 @@ msgstr "Ninguna de sus parcelas a pasado un filtro de parcela aún."
 msgid "Not Available"
 msgstr "No Disponible"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "No sincronizado"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "No confirmado todavía"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "No conectado"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Enviado"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Altura del Pico"
 
@@ -1080,7 +1080,7 @@ msgstr "Altura del Pico"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Hora del Pico"
 
@@ -1547,14 +1547,14 @@ msgstr "Duración del Intervalo de Gasto (cantidad de bloques)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limite de gasto (chia por intervalo): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Estado"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Estado:"
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Sincronizado"
 
@@ -1609,7 +1609,7 @@ msgstr "Sincronizado"
 msgid "Syncing"
 msgstr "Sincronizando"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Sincronizando {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "El nodo completo al que está conectado su agricultor se encuentra a con
 msgid "The minimum required size for mainnet is k=32"
 msgstr "El tamaño mínimo requerido para mainnet es k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "El nodo no está sincronizado"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "El nodo se está sincronizando, lo que significa que está descargando bloques de otros nodos, para alcanzar el último bloque de la cadena"
 
@@ -1704,7 +1704,7 @@ msgstr "Esto es un cambio pendiente, los cuales son cambios de monedas que usted
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Esta es la suma de las transacciones pendientes entrantes y salientes (aún no incluidas en la cadena de bloques). Esto no incluye las recompensas de cultivo."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Este es la hora del último sub-bloque pico."
 
@@ -1720,7 +1720,7 @@ msgstr "Esta es la cantidad total de chía en la cadena de bloques en el sub-blo
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Este es el saldo total + saldo pendiente: es lo que será su saldo después de que se confirmen todas las transacciones pendientes."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Este nodo esta al día y validando la red"
 
@@ -1744,7 +1744,7 @@ msgstr "Esta operación fue incluida en la cadena de bloques a esta altura de bl
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Esta versión de Chia ya no es compatible con la cadena de bloques y no puede cultivar de manera segura."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Hora de Creación"
 
@@ -1770,7 +1770,7 @@ msgstr "Saldo Total"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Total de iteraciones"
 
@@ -1790,7 +1790,7 @@ msgstr "Tamaño Total de Parcelas"
 msgid "Total VDF Iterations"
 msgstr "Total de iteraciones VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total de iteraciones desde el principio de la cadena de bloques"
 
@@ -1834,7 +1834,7 @@ msgstr "Filtro de Transacciones Hash"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Inconcluso"
 
@@ -1851,7 +1851,7 @@ msgstr "Desconocido"
 msgid "User Pubkey"
 msgstr "Llave Pública de Usuario"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Iteraciones VDF Sub Slot"
 

--- a/src/locales/es-MX/messages.po
+++ b/src/locales/es-MX/messages.po
@@ -202,7 +202,7 @@ msgstr "Bloque con hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "No existe bloque con hash {headerHash}."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Bloques"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Conectar a otros pares"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Conectado"
 
@@ -359,7 +359,7 @@ msgstr "Conectado"
 msgid "Connecting to wallet"
 msgstr "Conectar al Monedero"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Estado de Conexión"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Herramientas de Desarrollador"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Dificultad"
 
@@ -613,11 +613,11 @@ msgstr "Error: No se puede enviar chia a la dirección de color. Por favor intro
 msgid "Estimated Time to Win"
 msgstr "Tiempo Estimado para Ganar"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Espacio estimado de red"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Suma estimada de todo el espacio en disco cultivado de todos los granjeros de la red"
 
@@ -722,8 +722,8 @@ msgstr "Nombre del Archivo"
 msgid "Final folder location"
 msgstr "Ubicación de la Carpeta Final"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Finalizado"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Nodo Completo"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Estado de Nodo Completo"
 
@@ -760,7 +760,7 @@ msgstr "HD o llaves Jerárquicamente Determinísticas son un tipo de esquema de 
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Encabezado de Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Encabezado de hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Altura"
@@ -815,7 +815,7 @@ msgstr "Importar cartera de Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importar de Mnemonics (24 palabras)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "En curso"
 
@@ -953,7 +953,7 @@ msgstr "Más memoria aumenta ligeramente la velocidad"
 msgid "My Pubkey"
 msgstr "Mi Llave Pública"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nombre de Red"
 
@@ -1022,7 +1022,7 @@ msgstr "Ninguna de sus parcelas a pasado un filtro de parcela aún."
 msgid "Not Available"
 msgstr "No Disponible"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "No sincronizado"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "No confirmado todavía"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Sin conexión"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Enviado"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Altura de cima"
 
@@ -1080,7 +1080,7 @@ msgstr "Altura de cima"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Tiempo de cima"
 
@@ -1547,14 +1547,14 @@ msgstr "Duración del Intervalo de Gasto (cantidad de bloques)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limite de gasto (chia por intervalo): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Estado"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Estado:"
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Sincronizado"
 
@@ -1609,7 +1609,7 @@ msgstr "Sincronizado"
 msgid "Syncing"
 msgstr "Sincronizando"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Sincronizando {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "El nodo completo al que está conectado su agricultor se encuentra a con
 msgid "The minimum required size for mainnet is k=32"
 msgstr "El tamaño mínimo requerido para mainnet es k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "El nodo no está sincronizado"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "El nodo se está sincronizando, lo que significa que está descargando bloques de otros nodos, para alcanzar el último bloque de la cadena"
 
@@ -1704,7 +1704,7 @@ msgstr "Esto es un cambio pendiente, los cuales son cambios de monedas que usted
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Esta es la suma de las transacciones pendientes entrantes y salientes (aún no incluidas en la cadena de bloques). Esto no incluye las recompensas de cultivo."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Este es la hora del último sub-bloque pico."
 
@@ -1720,7 +1720,7 @@ msgstr "Esta es la cantidad total de chía en la cadena de bloques en el sub-blo
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Este es el saldo total + saldo pendiente: es lo que será su saldo después de que se confirmen todas las transacciones pendientes."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Este nodo esta al día y validando la red"
 
@@ -1744,7 +1744,7 @@ msgstr "Esta operación fue incluida en la cadena de bloques a esta altura de bl
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Esta versión de Chia ya no es compatible con la cadena de bloques y no puede cultivar de manera segura."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Hora de Creación"
 
@@ -1770,7 +1770,7 @@ msgstr "Saldo Total"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Total de iteraciones"
 
@@ -1790,7 +1790,7 @@ msgstr "Tamaño Total de Parcelas"
 msgid "Total VDF Iterations"
 msgstr "Total de iteraciones VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total de iteraciones desde el principio de la cadena de bloques"
 
@@ -1834,7 +1834,7 @@ msgstr "Filtro de Transacciones Hash"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Inacabado"
 
@@ -1851,7 +1851,7 @@ msgstr "Desconocido"
 msgid "User Pubkey"
 msgstr "Llave Pública de Usuario"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Iteraciones de subranura VDF"
 

--- a/src/locales/fa-IR/messages.po
+++ b/src/locales/fa-IR/messages.po
@@ -206,7 +206,7 @@ msgstr "بلوک با هش {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "بلوکی با هش {headerHash} موجود نیست."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "بلوک ها"
 
@@ -355,7 +355,7 @@ msgid "Connect to other peers"
 msgstr "اتصال به سایر همسان‌ ها"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "متصل شد"
 
@@ -363,7 +363,7 @@ msgstr "متصل شد"
 msgid "Connecting to wallet"
 msgstr "اتصال به کیف پول"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "وضعیت اتصال"
 
@@ -550,7 +550,7 @@ msgid "Developer Tools"
 msgstr "ابزارهای توسعه دهنده"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "سختی"
 
@@ -619,11 +619,11 @@ msgstr "خطا: چیـا را به آدرس رنگی نمی‌توان ارسا�
 msgid "Estimated Time to Win"
 msgstr "زمان تقریبی برنده شدن"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "فضای تقریبی کل شبکه"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "تخمین مجموع دیسک های پلات شده همه مزرعه داران در شبکه"
 
@@ -728,8 +728,8 @@ msgstr "نام فايل"
 msgid "Final folder location"
 msgstr "مکان پوشه نهایی"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "تمام شد"
 
@@ -742,11 +742,11 @@ msgid "Frequently Asked Questions"
 msgstr "سوالات متداول"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "گره کامل"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "وضعیت گره کامل"
 
@@ -766,7 +766,7 @@ msgstr "کلید های سلسله مراتب قطعی(HD)، نوعی طرح ک�
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "عنوان هش"
 
@@ -775,7 +775,7 @@ msgid "Header hash"
 msgstr "عنوان هش"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "ارتفاع"
@@ -821,7 +821,7 @@ msgstr "وارد کردن کیف پول از رمزینه حفظی"
 msgid "Import from Mnemonics (24 words)"
 msgstr "رمزینه حفظی را وارد کنید(24 کلمه)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "در حال انجام"
 
@@ -959,7 +959,7 @@ msgstr "حافظه بیشتر سرعت را کمی افزایش می دهد"
 msgid "My Pubkey"
 msgstr "کلید عمومی من"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "نام شبکه"
 
@@ -1028,7 +1028,7 @@ msgstr "هنوز هیچ یک از پلات های شما از فیلتر طرح 
 msgid "Not Available"
 msgstr "در دسترس نیست"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "همگام سازی نشده است"
 
@@ -1041,8 +1041,8 @@ msgid "Not confirmed yet"
 msgstr "هنوز تایید نشده"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "متصل نیست"
 
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "در حال خروج"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "حداکثر ارتفاع"
 
@@ -1086,7 +1086,7 @@ msgstr "حداکثر ارتفاع"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "حداکثر زمان"
 
@@ -1553,14 +1553,14 @@ msgstr "مدت فاصله خرج کردن (تعداد بلوک ها)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "محدودیت خرج کردن (چیـا بر فاصله): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "حالت"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1605,7 +1605,7 @@ msgstr "وضعیت:"
 msgid "Submit"
 msgstr "ثبت و ارسال"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "همگام سازی شده"
 
@@ -1615,7 +1615,7 @@ msgstr "همگام سازی شده"
 msgid "Syncing"
 msgstr "در حال همگام سازی"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "همگام سازی {progress}/{tip}"
 
@@ -1660,11 +1660,11 @@ msgstr "گره کاملی که مزرعه شما به آن متصل است. <0>�
 msgid "The minimum required size for mainnet is k=32"
 msgstr "حداقل اندازه مورد نیاز برای شبکه اصلی k = 32 است"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "گره همگام سازی نشده"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "گره در حال همگام سازی است ، به این معنی که بلوک ها را از گره های دیگر بارگیری می کند تا به آخرین بلوک در زنجیره برسد"
 
@@ -1712,7 +1712,7 @@ msgstr ""
 "این مجموع تراکنش های در حال ورود و در حال خروج شماست که هنوز در صف انجام هستند( هنوز وارد زنجیره بلوکی نشده‌اند).\n"
 "این شامل پاداش های مزرعه داری نمیشود."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "این مدت زمان به حداکثر رسیدن آخرین زیر بلوک است."
 
@@ -1728,7 +1728,7 @@ msgstr "این مقدار کل چیـا در زنجیره بلوکی در نقط
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "این مقدار موجودی کل + موجودی در حال انتظار است: یعنی موجودی شما در زمانی که تمام تراکنش های در انتظار انجام به تایید برسند."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "این گره کاملا درگیر و در حال اعتبار سنجی شبکه است"
 
@@ -1754,7 +1754,7 @@ msgstr "این معامله در این ارتفاع بلوکی شامل زنج�
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "این ورژن از چیـا دیگر با با شبکه بلوکی سازگاری ندارد و نمی‌تواند با امنیت به مزرعه داری بپردازد."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "زمان ایجاد"
 
@@ -1780,7 +1780,7 @@ msgstr "موجودی کل"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "کل تکرار ها"
 
@@ -1800,7 +1800,7 @@ msgstr "جمع اندازه پلات ها"
 msgid "Total VDF Iterations"
 msgstr "کل تکرار های VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "کل تکرارها از زمان شروع زنجیره بلوکی"
 
@@ -1844,7 +1844,7 @@ msgstr "هشِ فیلتر تراکنش ها"
 msgid "Type"
 msgstr "نوع"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "ناتمام"
 
@@ -1861,7 +1861,7 @@ msgstr "ناشناخته"
 msgid "User Pubkey"
 msgstr "کلید عمومی کاربر"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "تکرارهای زیر شکافی VDF"
 

--- a/src/locales/fi-FI/messages.po
+++ b/src/locales/fi-FI/messages.po
@@ -202,7 +202,7 @@ msgstr "Lohko tiivisteellä {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Lohkoa tunnistetiivisteellä {headerHash} ei ole olemassa."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Lohkot"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Yhdistä muihin verkkonoodeihin"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Yhdistetty"
 
@@ -359,7 +359,7 @@ msgstr "Yhdistetty"
 msgid "Connecting to wallet"
 msgstr "Yhdistetään lompakkoon"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Yhteyden Tila"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Kehitystyökalut"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Vaikeusaste"
 
@@ -613,11 +613,11 @@ msgstr "Virhe: Chioja ei voi lähettää värikolikko-osoitteeseen. Anna Chialom
 msgid "Estimated Time to Win"
 msgstr "Laskennallinen Voittoaika"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Estimoitu verkkoavaruus"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Kaikkien farmien sisältämien plot-tiedostojen arvoitu yhteiskoko"
 
@@ -722,8 +722,8 @@ msgstr "Tiedoston nimi"
 msgid "Final folder location"
 msgstr "Lopullinen hakemisto"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Valmis"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Usein Kysytyt Kysymykset"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Verkkonoodi"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Verkkonoodin Tila"
 
@@ -760,7 +760,7 @@ msgstr "HD- eli hierarkis-deterministiset avaimet ovat julkisen ja salaisen avai
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Lohkotunniste"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Lohkotunniste"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Lohkokorkeus"
@@ -815,7 +815,7 @@ msgstr "Tuo Lompakko Muistisanoista"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Tuo Muistisanoista (24)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Käynnissä"
 
@@ -953,7 +953,7 @@ msgstr "Lisää muistia nopeuttaa hieman"
 msgid "My Pubkey"
 msgstr "Julkinen Avaimeni"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Verkon Nimi"
 
@@ -1022,7 +1022,7 @@ msgstr "Yksikään ploteistasi ei ole vielä päässyt suodatuksesta läpi."
 msgid "Not Available"
 msgstr "Ei Saatavilla"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Ei Synkronoitu"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Vahvistamatta vielä"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Ei yhteyttä"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Lähtevä"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Lakikorkeus"
 
@@ -1080,7 +1080,7 @@ msgstr "Lakikorkeus"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Lakiajankohta"
 
@@ -1547,14 +1547,14 @@ msgstr "Käyttöajanjakson pituus (lohkojen määrä)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Käyttöraja (Chiaa/ajanjakso):{0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Tila"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Tila:"
 msgid "Submit"
 msgstr "Lähetä"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synkrononissa"
 
@@ -1609,7 +1609,7 @@ msgstr "Synkrononissa"
 msgid "Syncing"
 msgstr "Synkronoi...."
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synkronoi {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Alla noodi, johon farmarisi on yhteydessä. <0>Katso lisää</0>"
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Lohkoketjun hyväksymä minimiarvo on k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Noodi ei ole synkronoitu"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Noodi synkronoi. Se lataa lohkoketjua muilta solmuilta"
 
@@ -1704,7 +1704,7 @@ msgstr "Avoimet siirrot ovat kolikoita, jotka olet siirtänyt, mutta joiden siir
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Lähtevien ja saapuvien avointen transaktioiden summa (ei vielä lohkoketjussa). Ei sisällä farmarin palkkioita."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Viimeisimmän lohkon aikaleima."
 
@@ -1720,7 +1720,7 @@ msgstr "Yksityisten avaimiesi hallinoimien Chiojen kokonaissumma lohkoketjussa. 
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Nykyinen saldo + avoin saldo, eli tuleva saldo avointen transaktioiden jälkeen."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Noodi on ajan tasalla ja todentaa lohkoketjuverkkoa"
 
@@ -1744,7 +1744,7 @@ msgstr "Kauppa on sisällytetty lohkoketjuun tässä lohkokorkeudessa"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Tämä Chian versio ei ole enää yhteensopiva lohkoketjun kanssa."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Luontiaika"
 
@@ -1770,7 +1770,7 @@ msgstr "Kokonaissaldo"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Iteraatioita"
 
@@ -1790,7 +1790,7 @@ msgstr "Plottien Yhteiskoko"
 msgid "Total VDF Iterations"
 msgstr "VDF-iteraatioiden Määrä"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Iteraatioiden määrä lohkoketjun alusta asti"
 
@@ -1834,7 +1834,7 @@ msgstr "Transaktion Filtteritiiviste"
 msgid "Type"
 msgstr "Tyyppi"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Kesken"
 
@@ -1851,7 +1851,7 @@ msgstr "Tuntematon"
 msgid "User Pubkey"
 msgstr "Käyttäjän julkinen avain"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF -alaiteraatioita"
 

--- a/src/locales/fr-FR/messages.po
+++ b/src/locales/fr-FR/messages.po
@@ -202,7 +202,7 @@ msgstr "Bloc avec hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Le bloc possédant le hash {headerHash} n'existe pas."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocs"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Se connecter à d'autres pairs"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Connecté"
 
@@ -359,7 +359,7 @@ msgstr "Connecté"
 msgid "Connecting to wallet"
 msgstr "En cours de connexion au porte-monnaie"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Statut de la connexion"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Outils Développeur"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Difficulté"
 
@@ -613,11 +613,11 @@ msgstr "Erreur: Impossible d'envoyer du chia à une adresse colorée. Merci d'en
 msgid "Estimated Time to Win"
 msgstr "Durée prévue pour gagner"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Taille du réseau estimé"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Espace disque total de tous les fermiers du réseau"
 
@@ -722,8 +722,8 @@ msgstr "Nom du fichier"
 msgid "Final folder location"
 msgstr "Emplacement du dossier final"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Terminé"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Question fréquentes"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Statut du Full Node"
 
@@ -760,7 +760,7 @@ msgstr "HD ou clés à déterministes hiérachiques sont un type de schéma clé
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hachage de l'en-tête"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hachage de l'en-tête"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Hauteur"
@@ -815,7 +815,7 @@ msgstr "Importer le Wallet depuis les Mnémoniques"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importer depuis les Mnémoniques (24 mots)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "En cours"
 
@@ -953,7 +953,7 @@ msgstr "Plus de mémoire augmente légèrement la vitesse"
 msgid "My Pubkey"
 msgstr "Ma clé publique"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nom du réseau"
 
@@ -1022,7 +1022,7 @@ msgstr "Encore aucune de vos parcelles n'a passé le filtre."
 msgid "Not Available"
 msgstr "Non Disponible"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Non Synchronisé"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Encore non confirmé"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Non connecté"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Sortant"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Pic Hauteur"
 
@@ -1080,7 +1080,7 @@ msgstr "Pic Hauteur"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Pic Temps"
 
@@ -1547,14 +1547,14 @@ msgstr "Intervalle de dépense (nombre de blocs)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limite de dépense (chia par intervalle): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "État"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Statut:"
 msgid "Submit"
 msgstr "Envoyer"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synchronisé"
 
@@ -1609,7 +1609,7 @@ msgstr "Synchronisé"
 msgid "Syncing"
 msgstr "Synchronisation"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synchronisation {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Le nœud complet auquel votre fermier est connecté est ci-dessous. <0>E
 msgid "The minimum required size for mainnet is k=32"
 msgstr "La taille minimum requise pour le mainnet est k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Le nœud n'est pas synchronisé"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Votre nœud se synchronise, ce qui veut dire qu'il télécharge les blocs depuis les autres nœuds, pour atteindre le dernier bloc de la chaîne"
 
@@ -1704,7 +1704,7 @@ msgstr "Il s'agit des échanges en attente, ce sont des pièces de monnaies d'é
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Il s'agit de la somme des transactions entrantes et sortantes en attente (pas encore incluses dans la blockchain). Cela n'inclut pas les récompenses de culture."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "C'est l'heure du dernier sous-bloc de pic."
 
@@ -1720,7 +1720,7 @@ msgstr "Il s'agit de la quantité totale de Chia dans la blockchain au plus réc
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Ceci est le solde total + solde en attente : c'est ce que votre solde sera après que toutes les transactions en attente seront confirmées."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Ce nœud est complètement à jour et valide le réseau"
 
@@ -1744,7 +1744,7 @@ msgstr "Cette transaction a été incluse sur la blockchain à cette hauteur de 
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Cette version de Chia n'est plus compatible avec la blockchain et ne peut pas cultiver de façon sûre."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Créé le"
 
@@ -1770,7 +1770,7 @@ msgstr "Solde total"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Itérations totales"
 
@@ -1790,7 +1790,7 @@ msgstr "Taille totale des parcelles"
 msgid "Total VDF Iterations"
 msgstr "Itérations VDF totales"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total d'itérations depuis le début de la blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Hash du filtre de transactions"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Non terminé"
 
@@ -1851,7 +1851,7 @@ msgstr "Inconnu"
 msgid "User Pubkey"
 msgstr "Clé publique utilisateur"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Itération du sous emplacement VDF"
 

--- a/src/locales/id-ID/messages.po
+++ b/src/locales/id-ID/messages.po
@@ -202,7 +202,7 @@ msgstr "Blok dengan hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Blok dengan hash {headerHash} tidak ada."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blok-blok"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Sambung ke peer lain"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Tersambung"
 
@@ -359,7 +359,7 @@ msgstr "Tersambung"
 msgid "Connecting to wallet"
 msgstr "Menyambungkan ke wallet"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Status Koneksi"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Developer Tools"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Tingkat kesulitan"
 
@@ -613,11 +613,11 @@ msgstr "Error: Tidak dapat mengirim Chia ke alamat berwarna. Mohon masukkan sebu
 msgid "Estimated Time to Win"
 msgstr "Perkiraan waktu untuk menang"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Estimasi besar network"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Estimasi jumlah total ruang penyimpanan yang sudah diplot oleh seluruh farmer di network"
 
@@ -722,8 +722,8 @@ msgstr "Nama file"
 msgid "Final folder location"
 msgstr "Lokasi folder akhir"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Selesai"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Status Full Node"
 
@@ -760,7 +760,7 @@ msgstr "HD atau kunci Hierarchical Deterministic adalah salah satu skema kunci p
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Kepala hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Kepala hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Tinggi"
@@ -815,7 +815,7 @@ msgstr "Impor Dompet elektronik dari Mnemonik"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Impor dari Mnemonic (24 kata)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Sedang Berlangsung"
 
@@ -953,7 +953,7 @@ msgstr "Lebih banyak memori sedikit meningkatkan kecepatan"
 msgid "My Pubkey"
 msgstr "Pubkey saya"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nama jaringan"
 
@@ -1022,7 +1022,7 @@ msgstr "Anda tidak ada plot yang telah lulus plot filter."
 msgid "Not Available"
 msgstr "Tidak Tersedia"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Tidak Disinkronkan"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Belum dikonfirmasi lagi"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Tidak terhubung"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Keluar"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Puncak tertinggi"
 
@@ -1080,7 +1080,7 @@ msgstr "Puncak tertinggi"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Puncak Masa"
 
@@ -1549,14 +1549,14 @@ msgstr "Durasi Interval Pengeluaran (jumlah blok)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Batas Pengeluaran (chia per jarak waktu): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Keadaan"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1601,7 +1601,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Kirim"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Sinkron"
 
@@ -1611,7 +1611,7 @@ msgstr "Sinkron"
 msgid "Syncing"
 msgstr "Sinkronisasi"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Sinkronisasi {progress}/{tip}"
 
@@ -1656,11 +1656,11 @@ msgstr ""
 msgid "The minimum required size for mainnet is k=32"
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Node tidak sinkron"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr ""
 
@@ -1706,7 +1706,7 @@ msgstr ""
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Ini adalah waktu dari ketinggian terakhir sub block."
 
@@ -1722,7 +1722,7 @@ msgstr ""
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr ""
 
@@ -1746,7 +1746,7 @@ msgstr "Perdagangan ini sudah termasuk di blockchain pada ketinggian block ini"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Versi Chia anda tidak serasi kepada blockchain dan tidak boleh ditransaksi."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Waktu Dibuat"
 
@@ -1772,7 +1772,7 @@ msgstr "Jumlah Saldo"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Jumlah iterasi"
 
@@ -1792,7 +1792,7 @@ msgstr "Jumlah Ukuran Plot-Plot"
 msgid "Total VDF Iterations"
 msgstr "Jumlah iterasi VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Jumlah bilangan sejak mula blockchain"
 
@@ -1836,7 +1836,7 @@ msgstr "Seleksi Hash Transaksi"
 msgid "Type"
 msgstr "Jenis"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Belum Selesai"
 
@@ -1853,7 +1853,7 @@ msgstr "Diketahui"
 msgid "User Pubkey"
 msgstr "Pubkey User"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Iterasi VDF Sub Slot"
 

--- a/src/locales/it-IT/messages.po
+++ b/src/locales/it-IT/messages.po
@@ -202,7 +202,7 @@ msgstr "Blocco con hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Il blocco con hash {headerHash} non esiste."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocchi"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Connettiti ad altri peer"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Connesso"
 
@@ -359,7 +359,7 @@ msgstr "Connesso"
 msgid "Connecting to wallet"
 msgstr "Connettendo al portafoglio"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Stato della Connessione"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Strumenti per sviluppatori"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Difficoltà"
 
@@ -613,11 +613,11 @@ msgstr "Errore: impossibile inviare chia ad un indirizzo colorato. Perfavore ins
 msgid "Estimated Time to Win"
 msgstr "Tempo Stimato per Vincere"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Dimensioni stimate della rete"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Stima delle dimensioni di tutta la memoria allocata da tutti i farmer della rete"
 
@@ -722,8 +722,8 @@ msgstr "Nome del file"
 msgid "Final folder location"
 msgstr "Seleziona la destinazione finale per la tua cartella plot"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Finito"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Domande Frequenti"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Stato del Full Node"
 
@@ -760,7 +760,7 @@ msgstr "HD o Hierarchical Deterministic keys sono un tipo di schema a chiave pub
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hash Header"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hash Header"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Altezza"
@@ -815,7 +815,7 @@ msgstr "Importa Wallet dalle Mnemonic"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importa dalle Mnemonic (24 parole)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "In Corso"
 
@@ -953,7 +953,7 @@ msgstr "Più memoria aumenta leggermente la velocità"
 msgid "My Pubkey"
 msgstr "La mia Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nome della Rete"
 
@@ -1022,7 +1022,7 @@ msgstr "Nessuno dei tuoi plot ha ancora passato il filtro per plot."
 msgid "Not Available"
 msgstr "Non Disponibile"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Non Sincronizzato"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Ancora non confermato"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Non connesso"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "In uscita"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Altezza Picco"
 
@@ -1080,7 +1080,7 @@ msgstr "Altezza Picco"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Tempo Picco"
 
@@ -1547,14 +1547,14 @@ msgstr "Lunghezza Intervallo di Spesa (numero di blocchi)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limite di Spesa (chia per intervallo): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Condizione"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Stato:"
 msgid "Submit"
 msgstr "Invia"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Sincronizzato"
 
@@ -1609,7 +1609,7 @@ msgstr "Sincronizzato"
 msgid "Syncing"
 msgstr "Sincronizzando"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Sincronizzando {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Il full node a cui è connesso il tuo farmer è di seguito. <0>Per saper
 msgid "The minimum required size for mainnet is k=32"
 msgstr "La dimensione minima richiesta per la mainnet è k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Il nodo non è sincronizzato"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Il nodo si sta sincronizzando, ovvero sta scaricando i blocchi da altri nodi, per raggiungere l'ultimo blocco nella blockchain"
 
@@ -1704,7 +1704,7 @@ msgstr "Questa è la modifica in sospeso, ovvero le monete di cambio che hai inv
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Questa è la somma delle transazioni in sospeso in entrata e in uscita (non ancora incluse nella blockchain). Questo non include le ricompense coltivate."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Questo è il tempo dell'ultimo sottoblocco di picco."
 
@@ -1720,7 +1720,7 @@ msgstr "Questo è l'ammontare totale di chia nella blockchain nell'attuale sotto
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Questo è il bilancio totale + il bilancio in attesa: questo è il bilancio che apparirà dopo che tutte le transazioni in attesa saranno confermate."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Questo nodo è pronto e sta validando la rete"
 
@@ -1744,7 +1744,7 @@ msgstr "Questo commercio è stato incluso sulla blockchain a questa altezza di b
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Questa versione di Chia non è più compatibile con la blockchain e non può coltivare in modo sicuro."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Creato al Tempo"
 
@@ -1770,7 +1770,7 @@ msgstr "Bilancio Totale"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Iterazioni in Totale"
 
@@ -1790,7 +1790,7 @@ msgstr "Dimensione Totale dei Plot"
 msgid "Total VDF Iterations"
 msgstr "Totale Iterazioni VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Totale iterazioni dall'inizio della blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Filtro Hash Transazioni"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Non completato"
 
@@ -1851,7 +1851,7 @@ msgstr "Sconosciuto"
 msgid "User Pubkey"
 msgstr "Pubkey utente"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Iterazioni Sottoslot VDF"
 

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -202,7 +202,7 @@ msgstr "ハッシュ値 {headerHash} のブロック"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "ハッシュ値 {headerHash} のブロックは存在しません。"
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "ブロック"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "手動で接続"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "接続済み"
 
@@ -359,7 +359,7 @@ msgstr "接続済み"
 msgid "Connecting to wallet"
 msgstr "ウォレットに接続中"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "接続状態"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "開発者向けツール"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "難易度"
 
@@ -613,11 +613,11 @@ msgstr "エラー: チアは色付きのアドレスには送れません。チ�
 msgid "Estimated Time to Win"
 msgstr "報酬が当たるまでの推定時間"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "推定ネットワーク容量"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "ネットワーク上の全農家が耕した全容量の推定値"
 
@@ -722,8 +722,8 @@ msgstr "ファイル名"
 msgid "Final folder location"
 msgstr "最終フォルダの場所"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "完成"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "よくある質問"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "フルノード"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "フルノードの状態"
 
@@ -760,7 +760,7 @@ msgstr "階層的決定性鍵、または HD 鍵とは、一つの秘密鍵に�
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "ヘッダーのハッシュ値"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "ヘッダーのハッシュ値"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "高さ"
@@ -815,7 +815,7 @@ msgstr "合言葉でウォレットをインポート"
 msgid "Import from Mnemonics (24 words)"
 msgstr "合言葉 (24語) で鍵をインポート"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "進行中"
 
@@ -953,7 +953,7 @@ msgstr "メモリ使用量を増やすと速度が微上昇します"
 msgid "My Pubkey"
 msgstr "私の公開鍵"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "ネットワーク名"
 
@@ -1022,7 +1022,7 @@ msgstr "お持ちの耕地は現在、どれも耕地フィルターを通過で
 msgid "Not Available"
 msgstr "該当なし"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "同期されていません"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "未承認"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "未接続"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "出金"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "先端の高さ"
 
@@ -1080,7 +1080,7 @@ msgstr "先端の高さ"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "先端の日時"
 
@@ -1547,14 +1547,14 @@ msgstr "支払いインターバル長 (ブロック数)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "支払い額上限 (チア毎インターバル): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "状態"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "状態:"
 msgid "Submit"
 msgstr "提出"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "同期完了"
 
@@ -1609,7 +1609,7 @@ msgstr "同期完了"
 msgid "Syncing"
 msgstr "同期中"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "同期中 {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "以下が農家の接続先のフルノードです。<0>詳しく</0>"
 msgid "The minimum required size for mainnet is k=32"
 msgstr "メインネットで必要な最小サイズは k=32 です"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "ノードが同期されていません"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "ノードが同期中です。ブロックチェーンの先端に辿り着くまで他のノードからブロックをダウンロードします。"
 
@@ -1704,7 +1704,7 @@ msgstr "保留中のお釣り、つまり自己送信したが、まだ承認さ
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "これが (まだブロックチェーンに含まれていない) 保留中の入出金の合計です。耕作報酬は含まれていません。"
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "最新のピークサブブロックの日時です。"
 
@@ -1720,7 +1720,7 @@ msgstr "現在の先端サブブロックにおいて、あなたの秘密鍵が
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "これが全残高 + 保留中残高です: 全ての保留中の取引が承認されたら、残高はこの額になります。"
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "このノードは先端に辿り着いて、ネットワークの検証に携わっています"
 
@@ -1744,7 +1744,7 @@ msgstr "このトレードはこのブロック高でブロックチェーンに
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "ご使用のバージョンのチアアプリはブロックチェーンと互換性が無く、安全に耕作できません。"
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "作成日時"
 
@@ -1770,7 +1770,7 @@ msgstr "全残高"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "全評価回数"
 
@@ -1790,7 +1790,7 @@ msgstr "全ての耕地の容量の合計"
 msgid "Total VDF Iterations"
 msgstr "全 VDF 評価回数"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "ブロックチェーンの開始からの合計評価回数"
 
@@ -1834,7 +1834,7 @@ msgstr "取引フィルターハッシュ値"
 msgid "Type"
 msgstr "種類"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "未完成"
 
@@ -1851,7 +1851,7 @@ msgstr "不明"
 msgid "User Pubkey"
 msgstr "ユーザー公開鍵"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF サブスロット評価回数"
 

--- a/src/locales/ko-KR/messages.po
+++ b/src/locales/ko-KR/messages.po
@@ -202,7 +202,7 @@ msgstr "해쉬 {headerHash} 의 블록"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "해쉬 {headerHash} 의 블록이 존재하지 않습니다."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "블록"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "다른 피어에 연결"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "연결됨"
 
@@ -359,7 +359,7 @@ msgstr "연결됨"
 msgid "Connecting to wallet"
 msgstr "지갑 연결"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "연결 상태"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "개발자 도구"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "난이도"
 
@@ -613,11 +613,11 @@ msgstr "에러: 치아를 컬러드 주소로 보낼 수 없습니다. 치아 �
 msgid "Estimated Time to Win"
 msgstr "블록 보상을 얻기까지 남은 시간"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "전체 네트워크 용량 추정치"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "네트워크에 있는 모든 농부의 총 플롯된 디스크 용량의 총합 예측치"
 
@@ -722,8 +722,8 @@ msgstr "파일 이름"
 msgid "Final folder location"
 msgstr "최종 폴더 위치"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "완료됨"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "자주 묻는 질문"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "전체 노드"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "전체 노드 현황"
 
@@ -760,7 +760,7 @@ msgstr "HD 또는 계층 적 결정 론적 키는 공개 키 / 개인 키 타입
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "헤더 해시"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "해더 해시"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "높이"
@@ -815,7 +815,7 @@ msgstr "니모닉으로부터 지갑 가져오기"
 msgid "Import from Mnemonics (24 words)"
 msgstr "니모닉에서 불러오기 (24단어)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "처리 중"
 
@@ -953,7 +953,7 @@ msgstr "많은 메모리는 약간의 속도 향상을 가져옵니다"
 msgid "My Pubkey"
 msgstr "나의 공개 키"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "네트워크 이름"
 
@@ -1022,7 +1022,7 @@ msgstr "아직 플롯 필터를 통과 한 플롯이 없습니다."
 msgid "Not Available"
 msgstr "사용할 수 없음"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "동기화 되지 않음"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "아직 확인되지 않음"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "연결되지 않음"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "내보내는 중"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "최종 높이"
 
@@ -1080,7 +1080,7 @@ msgstr "최종 높이"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "최고 시간"
 
@@ -1547,14 +1547,14 @@ msgstr "지출 간격 길이 (블록 수)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "지출 한도 (간격 당 chia): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "상태"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "상태:"
 msgid "Submit"
 msgstr "제출"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "동기화됨"
 
@@ -1609,7 +1609,7 @@ msgstr "동기화됨"
 msgid "Syncing"
 msgstr "동기화 중"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "동기화 중: {progress}/{tip} 완료"
 
@@ -1654,11 +1654,11 @@ msgstr "농부가 연결된 전체 노드는 다음과 같습니다. <0> 자세�
 msgid "The minimum required size for mainnet is k=32"
 msgstr "mainnet을 위한 최소 사이즈는 k=32입니다."
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "노드가 동기화되지 않았습니다"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "노드가 동기화 중입니다. 즉, 체인의 최신 블록에 도달하기 위해 다른 노드에서 블록을 다운로드하고 있습니다."
 
@@ -1704,7 +1704,7 @@ msgstr "이것은 귀하가 자신에게 보냈지만 아직 확인되지 않은
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "이것은 들어오고 나가는 보류 트랜잭션의 합계입니다 (아직 블록 체인에 포함되지 않음). 여기에는 농업 보상이 포함되지 않습니다."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "이것은 최신 피크 서브 블록의 시간입니다."
 
@@ -1720,7 +1720,7 @@ msgstr "이것은 개인 키에 의해 제어되는 현재 피크 하위 블록�
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "이것은 총 잔액 + 보류 잔액입니다. 모든 보류중인 거래가 확인 된 후 잔액이 됩니다."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "이 노드는 완전히 포착되어 네트워크를 확인하고 있습니다."
 
@@ -1744,7 +1744,7 @@ msgstr "이 거래는이 block height 에서 블록 체인에 포함되었습니
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "이 버전의 Chia는 더 이상 블록 체인과 호환되지 않으며 안전하게 파밍 할 수 없습니다."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "생성 시간"
 
@@ -1770,7 +1770,7 @@ msgstr "총 잔고"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "총 반복"
 
@@ -1790,7 +1790,7 @@ msgstr "총 구성 크기"
 msgid "Total VDF Iterations"
 msgstr "총 VDF 반복"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "블록체인 시작 후 총 반복"
 
@@ -1834,7 +1834,7 @@ msgstr "거래 필터 해시"
 msgid "Type"
 msgstr "종류"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "미완성"
 
@@ -1851,7 +1851,7 @@ msgstr "알 수 없음"
 msgid "User Pubkey"
 msgstr "사용자 공개 키"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF 서브 슬롯 반복"
 

--- a/src/locales/nl-NL/messages.po
+++ b/src/locales/nl-NL/messages.po
@@ -202,7 +202,7 @@ msgstr "Block met hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block met hash {headerHash} bestaat niet."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blokken"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Verbind met andere peers"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Verbonden"
 
@@ -359,7 +359,7 @@ msgstr "Verbonden"
 msgid "Connecting to wallet"
 msgstr "Aan het verbinden met de wallet"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Verbindingsstatus"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Ontwikkelaarstools"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Moeilijkheid"
 
@@ -613,11 +613,11 @@ msgstr "Fout: Kan Chia niet naar gekleurd adres verzenden. Gelieve een Chia adre
 msgid "Estimated Time to Win"
 msgstr "Verwachte tijd om te winnen"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Geschatte netwerk grootte"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Geschatte som van alle geplotte shijfruimte van alle farmers in het netwerk"
 
@@ -722,8 +722,8 @@ msgstr "Bestandsnaam"
 msgid "Final folder location"
 msgstr "Finale locatie map"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Beëindigd"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Veel gestelde vragen"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Volledige Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Status Volledige Node"
 
@@ -760,7 +760,7 @@ msgstr ""
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Koptekst Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Koptekst Hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Hoogte"
@@ -815,7 +815,7 @@ msgstr "Importeer portemonnee via Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importeer via Mnomonics (24 woorden)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Bezig"
 
@@ -953,7 +953,7 @@ msgstr "Meer geheugen kan de snelheid een beetje verhogen"
 msgid "My Pubkey"
 msgstr "Mijn publieke sleutel"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Netwerk naam"
 
@@ -1022,7 +1022,7 @@ msgstr "Geen van je plots hebben de plot filter gepasseerd."
 msgid "Not Available"
 msgstr "Niet beschikbaar"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Niet gesynchroniseerd"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Nog niet bevestigd"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Niet verbonden"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Uitgaand"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Piek hoogte"
 
@@ -1080,7 +1080,7 @@ msgstr "Piek hoogte"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Piek tijd"
 
@@ -1547,14 +1547,14 @@ msgstr "Bestedingsinterval Lengte (aantal Blocks)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Bestedingslimiet (Chia per Interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Toestand"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Verzend"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Gesynchroniseerd"
 
@@ -1609,7 +1609,7 @@ msgstr "Gesynchroniseerd"
 msgid "Syncing"
 msgstr "Aan het synchroniseren"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Aan het synchroniseren {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr ""
 msgid "The minimum required size for mainnet is k=32"
 msgstr "De minimaal vereiste grootte voor mainnet is k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "De node is niet gesynchroniseerd"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr ""
 
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr ""
 
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr ""
 
@@ -1744,7 +1744,7 @@ msgstr "Deze transactie is opgenomen in de blockchain op de hoogte van deze blok
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Deze versie van Chia is niet langer compatibel met de blockchain, en je kan niet meer veilig farmen."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Tijd gecreëerd"
 
@@ -1770,7 +1770,7 @@ msgstr "Totaal saldo"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Totaal # Iteraties"
 
@@ -1790,7 +1790,7 @@ msgstr "Totale grootte van jou plot bestanden"
 msgid "Total VDF Iterations"
 msgstr "Totale VDF Iteraties"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Totale iteraties sinds de start van de Blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Transacties filter hash"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Onafgewerkt"
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "User Pubkey"
 msgstr "Pubkey gebruiker"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub-slot herhalingen"
 

--- a/src/locales/no-NO/messages.po
+++ b/src/locales/no-NO/messages.po
@@ -202,7 +202,7 @@ msgstr "Blokk med hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Blokk med hash {headerHash} eksisterer ikke."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blokker"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Koble til andre servere"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Koble til"
 
@@ -359,7 +359,7 @@ msgstr "Koble til"
 msgid "Connecting to wallet"
 msgstr "Kobler til lommebok"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Tilkoblingsstatus"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Utviklerverktøy"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Vanskelighetsgrad"
 
@@ -613,11 +613,11 @@ msgstr "Feil: Kan ikke sende chia til farget adresse. Vennligst skriv inn en chi
 msgid "Estimated Time to Win"
 msgstr "Beregnet tid til belønning"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Estimert nettverksplass"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Anslått sum av all plottet diskplass for alle bønder i nettverket"
 
@@ -722,8 +722,8 @@ msgstr "Filnavn"
 msgid "Final folder location"
 msgstr "Endelig mappeplassering"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Fullført"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Ofte Stilte Spørsmål"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Full node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Full node status"
 
@@ -760,7 +760,7 @@ msgstr ""
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Overskrift Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Overskrift Hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Høyde"
@@ -815,7 +815,7 @@ msgstr "Importer lommebok fra Mnemonics"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importer fra Mnemonics (24 ord)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Pågående"
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "My Pubkey"
 msgstr "Min Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Not Available"
 msgstr "Ikke tilgjengelig"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Ikke synkronisert"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr ""
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Ikke tilkoblet"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Utgående"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr ""
 
@@ -1547,14 +1547,14 @@ msgstr ""
 msgid "Spending Limit (chia per interval): {0}"
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Send"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synkronisert"
 
@@ -1609,7 +1609,7 @@ msgstr "Synkronisert"
 msgid "Syncing"
 msgstr "Synkroniserer"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synkroniserer {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Full node som bonden din er koblet til, er nedenfor. <0>Lær mer </0>"
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Minimum nødvendig størrelse for mainnet er k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Noden er ikke synkronisert"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Noden synkroniseres, som betyr at den laster ned blokker fra andre noder, for å nå den siste blokken i kjeden"
 
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr ""
 
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr ""
 
@@ -1744,7 +1744,7 @@ msgstr "Denne handelen ble inkludert på blokkjeden i denne blokkhøyden"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Denne versjonen av Chia er ikke lenger kompatibel med blokkjeden og kan ikke sikkert gjennomføre jobb."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Opprettelsestidspunkt"
 
@@ -1770,7 +1770,7 @@ msgstr "Total saldo"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Totalt antall Iterasjoner"
 
@@ -1790,7 +1790,7 @@ msgstr "Total størrelse av plotter"
 msgid "Total VDF Iterations"
 msgstr "Total VDF Iterasjoner"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Totalt antall iterasjoner siden starten av blokkjeden"
 
@@ -1834,7 +1834,7 @@ msgstr "Transaksjonsfilter Hash"
 msgid "Type"
 msgstr "Type"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Uferdig"
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "User Pubkey"
 msgstr "Bruker Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub Slot Iterasjoner"
 

--- a/src/locales/pl-PL/messages.po
+++ b/src/locales/pl-PL/messages.po
@@ -202,7 +202,7 @@ msgstr "Blok z haszem {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Blok o haszu {headerHash} nie istnieje."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Bloki"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Połącz się z innymi peerami"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Połączono"
 
@@ -359,7 +359,7 @@ msgstr "Połączono"
 msgid "Connecting to wallet"
 msgstr "Łączenie z portfelem"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Status Połączenia"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Narzędzia Programistyczne"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Trudność"
 
@@ -613,11 +613,11 @@ msgstr "Błąd: Nie można wysłać chia na adres colored. Proszę podać adres 
 msgid "Estimated Time to Win"
 msgstr "Szacunkowy czas oczekiwania na wygraną"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Przybliżona przestrzeń sieci"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Szacunkowa suma przestrzeni dyskowej wykorzystanej na działki wszystkich rolników w sieci"
 
@@ -722,8 +722,8 @@ msgstr "Nazwa pliku"
 msgid "Final folder location"
 msgstr "Lokalizacja folderu docelowego"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Zakończono"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Często zadawane pytania"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Pełen węzeł"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Stan pełnego węzła"
 
@@ -760,7 +760,7 @@ msgstr "HD lub Hierarchiczne klucze Deterministyczne to rodzaj systemu klucza pu
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hash Nagłówka"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hash Nagłówka"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Wysokość"
@@ -815,7 +815,7 @@ msgstr "Importuj portfel z ziarna mnemonicznego"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importuj z ziarna mnemonicznego (24 słowa)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "W toku"
 
@@ -953,7 +953,7 @@ msgstr "Więcej pamięci lekko zwiększa prędkość"
 msgid "My Pubkey"
 msgstr "Mój publiczny klucz"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nazwa sieci"
 
@@ -1022,7 +1022,7 @@ msgstr "Żadna z twoich działek nie przeszła jeszcze przez filtr."
 msgid "Not Available"
 msgstr "Nie dostępne"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Nie zsynchronizowane"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Nie zostało jeszcze potwierdzone"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Nie połączono"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Wychodzące"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Wysokość szczytowa"
 
@@ -1080,7 +1080,7 @@ msgstr "Wysokość szczytowa"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Czas szczytu"
 
@@ -1547,14 +1547,14 @@ msgstr "Długość ograniczenia wydawania (number bloków)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limit wydawania (chia/interwał): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Stan"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Stan:"
 msgid "Submit"
 msgstr "Zatwierdź"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Zsynchronizowano"
 
@@ -1609,7 +1609,7 @@ msgstr "Zsynchronizowano"
 msgid "Syncing"
 msgstr "Synchronizowanie"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synchronizowanie {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Poniżej pełen węzeł do którego jest podłączony twój rolnik. <0>D
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Najmniejszy dopuszczalny rozmiar w mainnecie to k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Węzeł nie jest zsynchronizowany"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Węzeł jest w trakcie synchronizacji, co znaczy że pobiera bloki z innych węzłów, aby osiągnąć najświeższy element blockchaina"
 
@@ -1704,7 +1704,7 @@ msgstr "To oczekująca zmiana, czyli monety reszty, które wysłałeś do siebie
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Jest to suma przychodzących i wychodzących transakcji oczekujących (jeszcze nie uwzględnionych w łańcuchu bloków). Nie obejmuje to nagród za farmę."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "To jest czas ostatniego podbloku szczytowego."
 
@@ -1720,7 +1720,7 @@ msgstr "Jest to całkowita ilość chia w łańcuchu blokowym w bieżącym bloku
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "To jest całkowite saldo + oczekujące saldo: taki będzie twój stan konta po potwierdzeniu oczekujących transakcji."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Ten węzeł jest w pełni zsynchronizowany i sprawdza poprawność sieci"
 
@@ -1744,7 +1744,7 @@ msgstr "To zlecenie zostało uwzględnione w blockchainie na tej wysokości"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Ta wersja Chia nie jest już kompatybilna z blockchain i nie może bezpiecznie uprawiać."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Czas utworzenia"
 
@@ -1770,7 +1770,7 @@ msgstr "Aktualne saldo"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Wszystkie powtórzenia"
 
@@ -1790,7 +1790,7 @@ msgstr "Całkowity rozmiar działek"
 msgid "Total VDF Iterations"
 msgstr "Wszystkie powtórzenia VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Wszystkie powtórzenia od początku blockchainu"
 
@@ -1834,7 +1834,7 @@ msgstr "Hash filtra transakcji"
 msgid "Type"
 msgstr "Typ"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Niedokończony"
 
@@ -1851,7 +1851,7 @@ msgstr "Nieznany"
 msgid "User Pubkey"
 msgstr "Publiczny Klucz Użytkownika"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Podrzędne Iteracje VDF"
 

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -202,7 +202,7 @@ msgstr "Bloco com hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Bloco com hash {headerHash} não existe."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocos"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Conecte-se a outros pares"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Conectado"
 
@@ -359,7 +359,7 @@ msgstr "Conectado"
 msgid "Connecting to wallet"
 msgstr "Conectando à carteira"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Status da conexão"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Ferramentas de desenvolvimento"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Dificuldade"
 
@@ -613,11 +613,11 @@ msgstr "Erro: Não é possível enviar chia para endereço colorido. Por favor, 
 msgid "Estimated Time to Win"
 msgstr "Tempo estimado para ganhar"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Espaço de rede estimado"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Soma estimada de todo o espaço em disco loteado por todos os agricultores na rede"
 
@@ -722,8 +722,8 @@ msgstr "Nome do arquivo"
 msgid "Final folder location"
 msgstr "Local da pasta final"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Concluído"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Perguntas Frequentes"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Nó Completo"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Estado do nó completo"
 
@@ -760,7 +760,7 @@ msgstr "HD (Hierarchical Deterministic) ou chaves determinísticas hierárquicas
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hash do cabeçalho"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hash do cabeçalho"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Altura"
@@ -815,7 +815,7 @@ msgstr "Importar carteira de Mnemônicos"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importar do Mnemônico (24 palavras)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Em andamento"
 
@@ -953,7 +953,7 @@ msgstr "Mais memória aumenta ligeiramente a velocidade"
 msgid "My Pubkey"
 msgstr "Minha Pubkey"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nome da rede"
 
@@ -1022,7 +1022,7 @@ msgstr "Nenhum de seus lotes passou pelo filtro de lotes ainda."
 msgid "Not Available"
 msgstr "Não disponível"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Não sincronizado"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Ainda não confirmado"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Não conectado"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Enviado"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Altura do pico"
 
@@ -1080,7 +1080,7 @@ msgstr "Altura do pico"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Hora do pico"
 
@@ -1547,14 +1547,14 @@ msgstr "Intervalo de gastos (número de blocos)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limite de gastos (chia por intervalo): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Estado"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Estado:"
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Sincronizado"
 
@@ -1609,7 +1609,7 @@ msgstr "Sincronizado"
 msgid "Syncing"
 msgstr "Sincronizando"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Sincronizando {progress} / {tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "O nó completo ao qual seu fazendeiro está conectado está abaixo. <0> 
 msgid "The minimum required size for mainnet is k=32"
 msgstr "O tamanho mínimo necessário para mainnet é k = 32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "O nó não está sincronizado"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "O nó está sincronizando, o que significa que está baixando blocos de outros nós, para chegar ao bloco mais recente da cadeia"
 
@@ -1704,7 +1704,7 @@ msgstr "Esta é a mudança pendente, que são moedas de troca que você enviou p
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Esta é a soma das transações pendentes de entrada e saída (ainda não incluídas no blockchain). Isto não inclui as recompensas dos fazendeiros."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Esta é a hora do último sub bloco."
 
@@ -1720,7 +1720,7 @@ msgstr "Essa é a quantidade total de chia na blockchain o pico do sub bloco atu
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Este é o saldo total + saldo pendente: é isso que o seu saldo será depois que todas as transações pendentes forem confirmadas."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Este nó está totalmente preso e validando a rede"
 
@@ -1744,7 +1744,7 @@ msgstr "Esta negociação foi incluída no blockchain nesta altura do bloco"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Essa versão do Chia não é mais compatível com a blockchain e não pode fazer um cultivo seguro."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Hora de Criação"
 
@@ -1770,7 +1770,7 @@ msgstr "Balanço Total"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Iterações Totais"
 
@@ -1790,7 +1790,7 @@ msgstr "Tamanho Total de Lotes"
 msgid "Total VDF Iterations"
 msgstr "Total de iterações VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total de iterações desde o início do blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Hash do filtro de transações"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Inacabado"
 
@@ -1851,7 +1851,7 @@ msgstr "Desconhecido"
 msgid "User Pubkey"
 msgstr "Pubkey do Usuário"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF Sub Slot Iterações"
 

--- a/src/locales/pt-PT/messages.po
+++ b/src/locales/pt-PT/messages.po
@@ -202,7 +202,7 @@ msgstr "Bloco com hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Bloco com hash {headerHash} não existe."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocos"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Conecte-se a outros pares"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Conectado"
 
@@ -359,7 +359,7 @@ msgstr "Conectado"
 msgid "Connecting to wallet"
 msgstr "Conectando à carteira"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Status da conexão"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Ferramentas de desenvolvimento"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Dificuldade"
 
@@ -613,11 +613,11 @@ msgstr "Erro: Não é possível enviar chia para endereço colorido. Por favor, 
 msgid "Estimated Time to Win"
 msgstr "Tempo Estimado para ganhar"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Espaço de rede estimado"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Soma estimada de todo o espaço em disco plotado de todos os farmers na rede"
 
@@ -722,8 +722,8 @@ msgstr "Nome do ficheiro"
 msgid "Final folder location"
 msgstr "Localização final da pasta"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Finalizado"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Perguntas frequentes"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Nó Completo"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Status de nó completo"
 
@@ -760,7 +760,7 @@ msgstr "HD ou chaves determinísticas hierárquicas são um tipo de esquema de c
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hash do cabeçalho"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hash do cabeçalho"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Altura"
@@ -815,7 +815,7 @@ msgstr "Importar carteira de Mnemônicos"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importar do Mnemônico (24 palavras)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Em andamento"
 
@@ -953,7 +953,7 @@ msgstr "Mais memória aumenta ligeiramente a velocidade"
 msgid "My Pubkey"
 msgstr "A minha chave pública"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nome da rede"
 
@@ -1022,7 +1022,7 @@ msgstr "Nenhum de seus plots passou pelo filtro de plots."
 msgid "Not Available"
 msgstr "Não disponível"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Não sincronizado"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Ainda não confirmado"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Não conectado"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Enviado"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Altura do pico"
 
@@ -1080,7 +1080,7 @@ msgstr "Altura do pico"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Hora do pico"
 
@@ -1547,14 +1547,14 @@ msgstr "Comprimento do intervalo de gasto (número de blocos)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limite de gastos (chia por intervalo): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Estado"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Estado:"
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Sincronizado"
 
@@ -1609,7 +1609,7 @@ msgstr "Sincronizado"
 msgid "Syncing"
 msgstr "Sincronizando"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Sincronizando {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "O nó completo ao qual seu farmer está conectado está abaixo. <0>Saiba
 msgid "The minimum required size for mainnet is k=32"
 msgstr "O tamanho mínimo necessário para mainnet é k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "O nó não está sincronizado"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "O nó está sincronizando, o que significa que está baixando blocos de outros nós, para chegar ao bloco mais recente da cadeia"
 
@@ -1704,7 +1704,7 @@ msgstr "Esta é a alteração pendente, que são moedas de alteração que você
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Esta é a soma das transações pendentes de entrada e saída (ainda não incluídas no blockchain). Isso não inclui recompensas agrícolas."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Esta é a hora do último sub-bloco de pico."
 
@@ -1720,7 +1720,7 @@ msgstr "Esta é a quantidade total de chia no blockchain no sub-bloco de pico at
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Este é o saldo total + saldo pendente: é o seu saldo após a confirmação de todas as transações pendentes."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Este nó está totalmente atualizado e validando a rede"
 
@@ -1744,7 +1744,7 @@ msgstr "Esta operação foi incluída na blockchain nesta altura do bloco"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Esta versão do Chia já não é mais compatível com a blockchain e não pode fazer farming com segurança."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Hora de Criação"
 
@@ -1770,7 +1770,7 @@ msgstr "Balanço Total"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Iterações Totais"
 
@@ -1790,7 +1790,7 @@ msgstr "Tamanho total dos Plots"
 msgid "Total VDF Iterations"
 msgstr "Total de iterações VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Total de iterações desde o início do blockchain"
 
@@ -1834,7 +1834,7 @@ msgstr "Filtro de transações Hash"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Inacabado"
 
@@ -1851,7 +1851,7 @@ msgstr "Desconhecido"
 msgid "User Pubkey"
 msgstr "Pubkey do Utilizador"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Iterações VDF Sub Slot"
 

--- a/src/locales/ro-RO/messages.po
+++ b/src/locales/ro-RO/messages.po
@@ -202,7 +202,7 @@ msgstr "Bloc cu hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Blocul cu hash-ul {headerHash} nu există."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Blocuri"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Conectare la alți parteneri"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Conectat"
 
@@ -359,7 +359,7 @@ msgstr "Conectat"
 msgid "Connecting to wallet"
 msgstr "Se conectează la portofel"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Statutul conexiunii"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Unelte Dezvoltator"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Dificultate"
 
@@ -613,11 +613,11 @@ msgstr "Eroare: Nu se poate trimite chia la adresa colorată. Vă rugăm să int
 msgid "Estimated Time to Win"
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Spațiu estimat în rețea"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Suma estimată a întregului spațiu pe disc reprezentat de toți fermierii din rețea"
 
@@ -722,8 +722,8 @@ msgstr "Nume fisier"
 msgid "Final folder location"
 msgstr "Locatia folderului final"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Terminat"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Întrebări frecvente"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Nod complet"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Stare nod complet"
 
@@ -760,7 +760,7 @@ msgstr "Cheile DI sau Deterministic Ierarhice sunt un tip de schemă de cheie pu
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hash-ul Antetului"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hash-ul Antetului"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Înălțime"
@@ -815,7 +815,7 @@ msgstr "Importă portofelul din Mnemonice"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importă din Mnemonice (24 cuvinte)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "În Desfășurare"
 
@@ -953,7 +953,7 @@ msgstr "Mai multă memorie crește ușor viteza"
 msgid "My Pubkey"
 msgstr "Cheia mea publică"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nume Rețea"
 
@@ -1022,7 +1022,7 @@ msgstr "Niciuna din parcelele tale nu a trecut încă filtrul."
 msgid "Not Available"
 msgstr "Indisponibil"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Nesincronizat"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Nu a fost confirmat încă"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Neconectat"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Expedieri"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Înălțimea Vârfului"
 
@@ -1080,7 +1080,7 @@ msgstr "Înălțimea Vârfului"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Timpul Vârfului"
 
@@ -1547,14 +1547,14 @@ msgstr "Lungimea intervalului pentru cheltuieli (număr de blocuri)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limită de cheltuieli (Chia per interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Stare"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Trimite"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Sincronizat"
 
@@ -1609,7 +1609,7 @@ msgstr "Sincronizat"
 msgid "Syncing"
 msgstr "Se sincronizează"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Sincronizare {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Nodul la care este conectat fermierul tău este mai jos. <0> Află mai m
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Dimensiunea minimă necesară pentru mainnet este k = 32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Nodul nu este sincronizat"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Nodul se sincronizează, ceea ce înseamnă că descarcă blocuri din alte noduri, pentru a ajunge la cel mai recent bloc din lanț"
 
@@ -1704,7 +1704,7 @@ msgstr "Aceasta este schimbarea în așteptare, care sunt monede de schimb pe ca
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Aceasta este suma tranzacțiilor în așteptare primite și expediate (neincluse încă în blockchain). Aceasta nu include recompensele."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Acesta este momentul celui mai recent subbloc peak."
 
@@ -1720,7 +1720,7 @@ msgstr "Aceasta este cantitatea totală de chia din blockchain la subblocul peak
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Acesta este soldul total + soldul în așteptare: acesta va fi soldul dvs. după confirmarea tuturor tranzacțiilor în așteptare."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Acest nod este complet prins și validează rețeaua"
 
@@ -1744,7 +1744,7 @@ msgstr "Această tranzacție a fost inclusă pe blockchain la această înălți
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Creata in timp"
 
@@ -1770,7 +1770,7 @@ msgstr "Sold Total"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Iteratii totale"
 
@@ -1790,7 +1790,7 @@ msgstr "Dimensiunea totală a parcelelor"
 msgid "Total VDF Iterations"
 msgstr "Totalul iteratiilor VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Totalul iteratiilor de la inceputul blockchain-ului"
 
@@ -1834,7 +1834,7 @@ msgstr "Filtru Hash Tranzacții"
 msgid "Type"
 msgstr "Tip"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Neterminat"
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "User Pubkey"
 msgstr "Pubkey Utilizator"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Iteratii sub slot VDF"
 

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -202,7 +202,7 @@ msgstr "Блок с хэшем {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Блок с хешем {headerHash} не существует."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Блоки"
 
@@ -523,7 +523,7 @@ msgid "Connect to other peers"
 msgstr "Подключиться к другим узлам"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Подключен"
 
@@ -531,7 +531,7 @@ msgstr "Подключен"
 msgid "Connecting to wallet"
 msgstr "Подключение к кошельку"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Состояние соединения"
 
@@ -716,7 +716,7 @@ msgid "Developer Tools"
 msgstr "Инструменты разработчика"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Сложность"
 
@@ -785,11 +785,11 @@ msgstr "Ошибка: не удается отправить чиа на цве�
 msgid "Estimated Time to Win"
 msgstr "Ожидаемое время до выигрыша"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Расчетное пространство сети"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Оценка размера всего дискового пространства, занимаемого участками суммарно всех фермеров в сети"
 
@@ -894,8 +894,8 @@ msgstr "Имя файла"
 msgid "Final folder location"
 msgstr "Путь к папке для окончательного хранения"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Завершен"
 
@@ -908,11 +908,11 @@ msgid "Frequently Asked Questions"
 msgstr "Часто задаваемые вопросы"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Полный узел"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Статус полного узла"
 
@@ -932,7 +932,7 @@ msgstr "HD или иерархические детерминированные 
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Хэш заголовка"
 
@@ -941,7 +941,7 @@ msgid "Header hash"
 msgstr "Хэш заголовка"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Высота"
@@ -987,7 +987,7 @@ msgstr "Импортировать кошелек из мнемоники"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Импорт мнемоники (24 слова)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "В процессе"
 
@@ -1125,7 +1125,7 @@ msgstr "Больше количество памяти немного увели
 msgid "My Pubkey"
 msgstr "Мой публичный ключ"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Имя сети"
 
@@ -1194,7 +1194,7 @@ msgstr "Ни один из ваших участков пока не проше�
 msgid "Not Available"
 msgstr "Не определено"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Не синхронизирован"
 
@@ -1207,8 +1207,8 @@ msgid "Not confirmed yet"
 msgstr "Еще не подтверждено"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Нет подключения"
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Исходящие"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Пиковая высота"
 
@@ -1252,7 +1252,7 @@ msgstr "Пиковая высота"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Пиковое время"
 
@@ -1719,14 +1719,14 @@ msgstr "Длина интервала расходования (количест
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Лимит расходования (chia за интервал): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Состояние"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1771,7 +1771,7 @@ msgstr "Статус:"
 msgid "Submit"
 msgstr "Подтвердить"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Синхронизован"
 
@@ -1781,7 +1781,7 @@ msgstr "Синхронизован"
 msgid "Syncing"
 msgstr "Синхронизация"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Синхронизация {progress}/{tip}"
 
@@ -1826,11 +1826,11 @@ msgstr "Полный узел, к которому подключен ваш ф�
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Минимальный требуемый размер участка для основной сети равен k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Узел не синхронизирован с сетью"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Узел синхронизируется, что означает, что он загружает блоки с других узлов, чтобы достичь последнего блока в цепи"
 
@@ -1876,7 +1876,7 @@ msgstr "Здесь рассчитан размер ожидаемой сдачи
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Здесь рассчитана сумма входящих и исходящих ожидающих транзакций (еще не включенных в цепь блоков). Награды за фарминг не включены в сумму."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Это время последнего пикового суб блока."
 
@@ -1892,7 +1892,7 @@ msgstr "Это общее количество монет Чиа в блокче
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Это общий баланс + отложенный баланс: это то, каким будет ваш баланс после подтверждения всех ожидающих транзакций."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Этот узел полностью догнал соседние узлы и выполняет валидацию в сети"
 
@@ -1916,7 +1916,7 @@ msgstr "Сделка была включена в блокчейн на указ
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Эта версия Chia больше не совместима с блокчейном и не может безопасно фармить."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Время создания"
 
@@ -1942,7 +1942,7 @@ msgstr "Итоговый баланс"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Всего итераций"
 
@@ -1962,7 +1962,7 @@ msgstr "Общий объем участков"
 msgid "Total VDF Iterations"
 msgstr "Общее количество итерации VDF"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Общее количество итераций с момента запуска блокчейна"
 
@@ -2006,7 +2006,7 @@ msgstr "Хэш фильтра транзакций"
 msgid "Type"
 msgstr "Тип"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Незаконченный"
 
@@ -2023,7 +2023,7 @@ msgstr "Неизвестный"
 msgid "User Pubkey"
 msgstr "Пользовательский публичный ключ"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Итерации VDF суб слота"
 

--- a/src/locales/sk-SK/messages.po
+++ b/src/locales/sk-SK/messages.po
@@ -202,7 +202,7 @@ msgstr "Blok s hashom {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block s hashom {headerHash} neexistuje."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Bloky"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Pripojiť k iným uzlom"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Pripojené"
 
@@ -359,7 +359,7 @@ msgstr "Pripojené"
 msgid "Connecting to wallet"
 msgstr "Pripájanie k peňaženke"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Stav Pripojenia"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Nástroje pre vývojárov"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Zložitosť"
 
@@ -613,11 +613,11 @@ msgstr "Chyba: Prosím zadajte platnú adresu."
 msgid "Estimated Time to Win"
 msgstr "Očakávaný čas na výhru"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Odhadovaná velkosť siete"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Odhadovaný súčet všetkého obsadeného miesta na disku všetkých ťažiarov v sieti"
 
@@ -722,8 +722,8 @@ msgstr "Meno súboru"
 msgid "Final folder location"
 msgstr "Cieľový adresár"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Dokončené"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Často kladené otázky (FAQ)"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Celý Uzol"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Stav Celého Uzla"
 
@@ -760,7 +760,7 @@ msgstr "HD alebo Hierarchické Deterministické kľúče sú typ schémy verejn�
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Hash hlavičky"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Hash hlavičky"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Poradie"
@@ -815,7 +815,7 @@ msgstr "Obnoviť peňaženku pomocou mnemotechnickej pomôcky"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Obnoviť z mnemotechniky (24 slov)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Prebieha"
 
@@ -953,7 +953,7 @@ msgstr "Viac pamäte mierne zvyšuje rýchlosť"
 msgid "My Pubkey"
 msgstr "Môj verejný kľúč"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Názov siete"
 
@@ -1022,7 +1022,7 @@ msgstr "Žiadne z vašich polí zatiaľ neprešlo filtrom polí."
 msgid "Not Available"
 msgstr "Nie Je K Dispozícií"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Nesynchronizované"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Zatiaľ nepotvrdené"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Nepripojené"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Odchádzajúce"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Najvyššia pozícia"
 
@@ -1080,7 +1080,7 @@ msgstr "Najvyššia pozícia"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Vrchol Času"
 
@@ -1547,14 +1547,14 @@ msgstr "Dĺžka disponibilného intervalu (počet blokov)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Limit výdavkov (chia na interval): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Stav"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Stav:"
 msgid "Submit"
 msgstr "Odoslať"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synchronizované"
 
@@ -1609,7 +1609,7 @@ msgstr "Synchronizované"
 msgid "Syncing"
 msgstr "Synchronizácia"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synchronizácia {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Celý uzol, ku ktorému je váš farmár pripojený, je uvedený nižši
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Minimálna požadovaná veľkosť pre sieť mainnet je k = 32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Uzol nie je synchronizovaný"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Uzol sa synchronizuje, čo znamená, že sťahuje bloky z iných uzlov, aby sa dostal k najnovšiemu bloku v reťazci"
 
@@ -1704,7 +1704,7 @@ msgstr "Toto je nespracovaná zmena. Sú to mince, ktoré ste si poslali, ale za
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Toto je súčet prichádzajúcich a odchádzajúcich nespracovaných transakcií (ešte nezahrnutých do blockchainu). To nezahŕňa odmeny za ťažbu."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Toto je čas posledného najvyššieho podbloku."
 
@@ -1720,7 +1720,7 @@ msgstr "Toto je celkové množstvo Chia v blockchaine v aktuálne najnovšom či
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Toto je celkový zostatok + nespracovaný zostatok alebo to, aký bude váš zostatok po potvrdení všetkých nespracovaných transakcií."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Tento uzol je plne aktualizovaný a overuje sieť"
 
@@ -1744,7 +1744,7 @@ msgstr "Tento obchod bol zahrnutý v blockchaine na tejto pozícii"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Táto verzia Chii nie je kompatibilná s blockchainom a farmenie na nej nie je bezpečné."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Čas Vytvorenia"
 
@@ -1770,7 +1770,7 @@ msgstr "Celkový Zostatok"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Celkový Počet Iterácií"
 
@@ -1790,7 +1790,7 @@ msgstr "Celková Veľkosť Polí"
 msgid "Total VDF Iterations"
 msgstr "Celkový Počet VDF Iterácií"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Celkový počet iterácií od začiatku blockchainu"
 
@@ -1834,7 +1834,7 @@ msgstr "Hash filtra transakcií"
 msgid "Type"
 msgstr "Typ"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Nedokončené"
 
@@ -1851,7 +1851,7 @@ msgstr "Neznáme"
 msgid "User Pubkey"
 msgstr "Používateľov verejný kľúč"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF dielčie Iterácie slotu"
 

--- a/src/locales/sv-SE/messages.po
+++ b/src/locales/sv-SE/messages.po
@@ -202,7 +202,7 @@ msgstr "Block med hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Block med hash {headerHash} existerar inte."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Block"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Anslut till andra peer-datorer"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Ansluten"
 
@@ -359,7 +359,7 @@ msgstr "Ansluten"
 msgid "Connecting to wallet"
 msgstr "Ansluter till plånbok"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Anslutningsstatus"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Utvecklarverktyg"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Svårighetsgrad"
 
@@ -613,11 +613,11 @@ msgstr "Fel: det går inte att skicka chia till färgad adress. Ange en chia-adr
 msgid "Estimated Time to Win"
 msgstr "Förväntad tid till vinst"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Uppskattat nätverksutrymme"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Uppskattad summa av allt plottat diskutrymme hos alla odlare i nätverket"
 
@@ -722,8 +722,8 @@ msgstr "Filnamn"
 msgid "Final folder location"
 msgstr "Sökväg till slutlig mapp"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Färdigt"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Vanliga frågor"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Fullständig nod"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Status för full nod"
 
@@ -760,7 +760,7 @@ msgstr "HD eller Hierarkiska Deterministiska nycklar är en typ av schema med pu
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Huvudhash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Huvudhash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Höjd"
@@ -815,7 +815,7 @@ msgstr "Importera plånbok från minnesfras"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Importera från minnesfras (24 ord)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Pågår"
 
@@ -953,7 +953,7 @@ msgstr "Mer minne ökar hastigheten något"
 msgid "My Pubkey"
 msgstr "Min publika nyckel"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Nätverksnamn"
 
@@ -1022,7 +1022,7 @@ msgstr "Ingen av dina plottar har passerat plottfiltret ännu."
 msgid "Not Available"
 msgstr "Inte tillgänglig"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Ej synkad"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Ej bekräftat ännu"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Inte ansluten"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Utgående"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Topphöjd"
 
@@ -1080,7 +1080,7 @@ msgstr "Topphöjd"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Topptid"
 
@@ -1547,14 +1547,14 @@ msgstr "Längd på spenderintervall (antal block)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Spenderbegränsning (chia per intervall): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Tillstånd"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Status:"
 msgid "Submit"
 msgstr "Skicka"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Synkad"
 
@@ -1609,7 +1609,7 @@ msgstr "Synkad"
 msgid "Syncing"
 msgstr "Synkar"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Synkroniserar {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Den fullständiga nod din odlare är ansluten till är nedan. <0>Läs me
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Den minsta storlek som krävs för mainnet är k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Noden är inte synkad"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Noden synkroniserar, vilket betyder att den laddar ner block från andra noder, för att nå det sista blocket i kedjan"
 
@@ -1704,7 +1704,7 @@ msgstr "Detta är väntande växel, det vill säga de växelmynt du har skickat 
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Detta är summan av inkommande och utgående väntande transaktioner (som ännu inte inkluderats i blockkedjan). Den innefattar inte odlingsbelöningar."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Detta är tidpunkten för det senaste topp-underblocket."
 
@@ -1720,7 +1720,7 @@ msgstr "Detta är den sammanlagda mängden chia i blockkedjan vid det aktuella t
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Detta är totalt saldo + väntande saldo: det är vad ditt saldo kommer att vara när alla väntande transaktioner har bekräftats."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Denna nod är helt uppdaterad och validerar nätverket"
 
@@ -1744,7 +1744,7 @@ msgstr "Denna affärstransaktion lades till i blockkedjan vid denna blockhöjd"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Denna version av Chia är inte längre kompatibel med blockkedjan och kan därför inte användas för odling."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Skapad"
 
@@ -1770,7 +1770,7 @@ msgstr "Totalt saldo"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Totalt antal iterationer"
 
@@ -1790,7 +1790,7 @@ msgstr "Sammanlagd storlek hos alla plottar"
 msgid "Total VDF Iterations"
 msgstr "Totalt antal VDF-iterationer"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Totalt antal iterationer sedan blockkedjan startade"
 
@@ -1834,7 +1834,7 @@ msgstr "Transaktionsfilterhash"
 msgid "Type"
 msgstr "Typ"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Ej färdigt"
 
@@ -1851,7 +1851,7 @@ msgstr "Okänd"
 msgid "User Pubkey"
 msgstr "Publik nyckel för användare"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF-underslot-iterationer"
 

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -202,7 +202,7 @@ msgstr "Blok Hash {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "{headerHash} Hash'li blok mevcut değil."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Bloklar"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Diğer eşlere bağlan"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Bağlandı"
 
@@ -359,7 +359,7 @@ msgstr "Bağlandı"
 msgid "Connecting to wallet"
 msgstr "Cüzdana bağlanılıyor"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Bağlantı durumu"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Geliştirici araçları"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Zorluk"
 
@@ -613,11 +613,11 @@ msgstr "Hata: Renkli adrese chia gönderemiyorum. Lütfen bir chia adresi girin.
 msgid "Estimated Time to Win"
 msgstr "Tahmini kazanma süresi"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Tahmini Ağ büyüklüğü"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Ağ üzerindeki toplam bölümlendirilmiş disk alanı büyüklüğü"
 
@@ -722,8 +722,8 @@ msgstr "Dosya Adı"
 msgid "Final folder location"
 msgstr "Dosya Adresi"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Bitti"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Sıkça Sorulan Sorular"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Tam Node"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Tam Node Durumu"
 
@@ -760,7 +760,7 @@ msgstr "HD veya Hiyerarşik Deterministik anahtarlar, bir public key/private ana
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Baştaki Hash"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Baştaki hash"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Yükseklik"
@@ -815,7 +815,7 @@ msgstr "Cüzdanı Mnemonics'ten içe aktar"
 msgid "Import from Mnemonics (24 words)"
 msgstr "Mneminocs'ten içe aktar. (24 kelime)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "İşlem Sürüyor"
 
@@ -953,7 +953,7 @@ msgstr "Daha fazla memory hızı bir miktar artırır"
 msgid "My Pubkey"
 msgstr "Herkese Açık Anahtarım"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Network Adı"
 
@@ -1022,7 +1022,7 @@ msgstr "Henüz plot'larınızdan hiçbiri plot filtresinden geçemedi."
 msgid "Not Available"
 msgstr "Uygun Değil"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Senkronize değil"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Henüz Onaylanmadı"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Bağlantı Yok"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Giden"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Tepe Yüksekliği"
 
@@ -1080,7 +1080,7 @@ msgstr "Tepe Yüksekliği"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "En Yoğun Zaman"
 
@@ -1547,14 +1547,14 @@ msgstr "Harcama Aralığı Uzunluğu (blokların sayısı)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Harcama Limiti (aralık başına chia): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Bölge"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Durum:"
 msgid "Submit"
 msgstr "Onayla"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Senkronize Edildi"
 
@@ -1609,7 +1609,7 @@ msgstr "Senkronize Edildi"
 msgid "Syncing"
 msgstr "Senkronize ediliyor"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Senkronize ediliyor {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Çiftçinizin bağlı olduğu tam düğüm aşağıdadır. <0> Daha fazl
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Ana ağ için gerekli minimum boyut k=32'dir"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Düğüm senkronize edilmedi"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Düğüm senkronize oluyor, ki bu zincirdeki en son bloğa ulaşmak için diğer düğümlerden bloklar indirildiği anlamına geliyor"
 
@@ -1704,7 +1704,7 @@ msgstr "Bu, kendinize gönderdiğiniz fakat henüz onaylanmayan değişim conile
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Bu toplam, gelen, giden ve bekleyen işlemlerin toplamıdır (henüz blok zincirine dahil edilmemiştir). Bu, çiftçilik ödüllerini içermez."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Bu, en son tepe alt bloğunun zamanıdır."
 
@@ -1720,7 +1720,7 @@ msgstr "Bu, özel anahtarlarınız tarafından kontrol edilen mevcut en yüksek 
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Bu, toplam bakiye + bekleyen bakiyedir: ki bu tüm bekleyen işlemler onaylandıktan sonra bakiyenizin oluşacak bakiyedir."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Bu düğüm tamamen yakalandı ve ağı doğruluyor"
 
@@ -1744,7 +1744,7 @@ msgstr "Bu ticaret, bu blok yüksekliğindeki blok zincirine dahil edildi"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Chia'nın bu sürümü artık blockchain ile uyumlu değil ve güvenli bir şekilde hasat yapamıyor."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Oluşturulma Zamanı"
 
@@ -1770,7 +1770,7 @@ msgstr "Toplam Bakiye"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Toplam Yineleme"
 
@@ -1790,7 +1790,7 @@ msgstr "Plot'ların Toplam Boyutu"
 msgid "Total VDF Iterations"
 msgstr "Toplam VDF Yinelemeleri"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Blok zincirinin başlangıcından bu yana toplam yineleme"
 
@@ -1834,7 +1834,7 @@ msgstr "Karma Transfer Filtresi"
 msgid "Type"
 msgstr "Tür"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Bitmemiş"
 
@@ -1851,7 +1851,7 @@ msgstr "Bilinmeyen"
 msgid "User Pubkey"
 msgstr "Herkese Açık Kullanıcı Anahtarı"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF alt alan yinelemeleri"
 

--- a/src/locales/uk-UA/messages.po
+++ b/src/locales/uk-UA/messages.po
@@ -202,7 +202,7 @@ msgstr "Блок з хешем {headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "Блок з хешем {headerHash} не існує."
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "Блоки"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "Підключитися до інших вузлів"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "Підключено"
 
@@ -359,7 +359,7 @@ msgstr "Підключено"
 msgid "Connecting to wallet"
 msgstr "Підключення до гаманця"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "Стан підключення"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "Інструменти розробника"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "Складність"
 
@@ -613,11 +613,11 @@ msgstr "Помилка: Не вдалося надіслати chia на кол�
 msgid "Estimated Time to Win"
 msgstr "Очікуваний час до виграшу"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "Приблизний обсяг мережі"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "Орієнтовна сума обсягу всіх ділянок на дисковому просторі всіх фермерів у мережі"
 
@@ -722,8 +722,8 @@ msgstr "Ім'я файлу"
 msgid "Final folder location"
 msgstr "Розташування кінцевої теки"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "Завершено"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "Найчастіші питання"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "Повний вузол"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "Статус повного вузла"
 
@@ -760,7 +760,7 @@ msgstr "Ієрархічні детерміновані ключі або HD - �
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "Хеш заголовка"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "Хеш заголовка"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "Висота"
@@ -815,7 +815,7 @@ msgstr "Імпортувати гаманець за допомогою мнем
 msgid "Import from Mnemonics (24 words)"
 msgstr "Імпортувати за допомогою мнемоніки (24 слова)"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "Виконується"
 
@@ -953,7 +953,7 @@ msgstr "Більший обсяг пам'яті трохи збільшує шв
 msgid "My Pubkey"
 msgstr "Мій публічний ключ"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "Назва мережі"
 
@@ -1022,7 +1022,7 @@ msgstr "Жодна з ваших ділянок ще не пройшла філ�
 msgid "Not Available"
 msgstr "Не доступно"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "Не синхронізовано"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "Ще не підтверджено"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "Немає з'єднання"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "Вихідні"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "Найбільша висота"
 
@@ -1080,7 +1080,7 @@ msgstr "Найбільша висота"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "Найбільший час"
 
@@ -1547,14 +1547,14 @@ msgstr "Інтервал витрат (кількість блоків)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "Ліміт витрат (chia на інтервал): {0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "Стан"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "Стан:"
 msgid "Submit"
 msgstr "Надіслати"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "Синхронізовано"
 
@@ -1609,7 +1609,7 @@ msgstr "Синхронізовано"
 msgid "Syncing"
 msgstr "Синхронізація"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "Синхронізація {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "Повний вузол, до якого підключено вашог
 msgid "The minimum required size for mainnet is k=32"
 msgstr "Мінімальний необхідний розмір для головної мережі (mainnet) – k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "Вузол не синхронізовано"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "Вузол синхронізований, це означає, що він завантажує блоки з інших вузлів, щоб досягти останнього блоку в ланцюжку"
 
@@ -1704,7 +1704,7 @@ msgstr "Це зміна, яка очікує очікування. Змінює 
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "Це сума вхідних та вихідних відкладених транзакцій (не включена в блокчейну). Це не включає винагороди фермерства."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "Це час останнього пікового блоку."
 
@@ -1720,7 +1720,7 @@ msgstr "Це загальна кількість chia в блокчейку на
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "Це сукупний баланс + очікуваний баланс: це ваш майбутній баланс після підтвердження усіх очікуючих транзакцій."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "Цей вузел повністю підіймається і перевіряє мережу"
 
@@ -1744,7 +1744,7 @@ msgstr "Ця угода включена в blockchain на вказаній в�
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "Ця версія Chia більше не сумісна з blockchain і не може безпечно фармити."
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "Час створення"
 
@@ -1770,7 +1770,7 @@ msgstr "Загальний баланс"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "Всього ітерацій"
 
@@ -1790,7 +1790,7 @@ msgstr "Загальний розмір ділянок"
 msgid "Total VDF Iterations"
 msgstr "Загальна кількість VDF ітерацій"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "Загальна ітерація з початку блокчейн"
 
@@ -1834,7 +1834,7 @@ msgstr "Хеш фільтру транзакцій"
 msgid "Type"
 msgstr "Тип"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "Незавершений"
 
@@ -1851,7 +1851,7 @@ msgstr "Невідомо"
 msgid "User Pubkey"
 msgstr "Публічний ключ користувача"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "Ітерації підслотів VDF"
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -202,7 +202,7 @@ msgstr "区块哈希{headerHash}"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "哈希为 {headerHash} 的区块不存在。"
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "区块"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "连接到其他节点"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "已连接"
 
@@ -359,7 +359,7 @@ msgstr "已连接"
 msgid "Connecting to wallet"
 msgstr "正在连接到钱包"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "连接状态"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "开发工具"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "难度"
 
@@ -613,11 +613,11 @@ msgstr "错误：无法发送奇亚到染色地址。请输入奇亚钱包地址
 msgid "Estimated Time to Win"
 msgstr "预计区块发现时间"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "全网已占用空间（估算）"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "估计网络中所有农场主已开垦农田占用磁盘空间量"
 
@@ -722,8 +722,8 @@ msgstr "文件名"
 msgid "Final folder location"
 msgstr "最终输出文件夹位置"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "已完成"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "常见问题解答"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "全节点"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "全节点状态"
 
@@ -760,7 +760,7 @@ msgstr "分层确定性钱包中的私钥可以对应有无限多个公钥（也
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "头部哈希"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "头部哈希"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "高度"
@@ -815,7 +815,7 @@ msgstr "使用助记词导入钱包"
 msgid "Import from Mnemonics (24 words)"
 msgstr "自助记词导入（24个词）"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "处理中"
 
@@ -953,7 +953,7 @@ msgstr "增加内存可以略微提高速度"
 msgid "My Pubkey"
 msgstr "我的公钥"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "网络名称"
 
@@ -1022,7 +1022,7 @@ msgstr "你的农田还没有通过过滤器检查."
 msgid "Not Available"
 msgstr "不可用"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "未同步"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "尚未被确认"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "未连接"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "支出"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "最高高度"
 
@@ -1080,7 +1080,7 @@ msgstr "最高高度"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "最高时间"
 
@@ -1547,14 +1547,14 @@ msgstr "支出迭代长度(区块数)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "消费限额（单位时间可消费的奇亚币）：{0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "状态"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "状态："
 msgid "Submit"
 msgstr "提交"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "已同步"
 
@@ -1609,7 +1609,7 @@ msgstr "已同步"
 msgid "Syncing"
 msgstr "正在同步"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "正在同步 {progress}/{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "你的农场连接的全节点如下.<0>了解更多</0>"
 msgid "The minimum required size for mainnet is k=32"
 msgstr "主网要求的最小农田大小为k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "节点没有同步"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "节点正在同步中, 也就是说它正在从其他节点下载区块, 以便达到最新的区块高度"
 
@@ -1704,7 +1704,7 @@ msgstr "处理中的找零钱, 是你发送支出的找回, 但是没有被链�
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "待处理的收入与支出总和(还未上链). 不包括农场耕种奖励."
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "最新的子块时间."
 
@@ -1720,7 +1720,7 @@ msgstr "这里是你的私钥所控制的, 到目前最新子块高度为止的�
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "目前结余+待处理的结余: 在链上确认完成后就是你的最终总结余."
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "本节点完全同步好了"
 
@@ -1744,7 +1744,7 @@ msgstr "该交易在链上的区块高度"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "此版本的奇亚客户端与区块链已经不再兼容，无法安全地种植。"
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "创建时间"
 
@@ -1770,7 +1770,7 @@ msgstr "总余额"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "总迭代次数"
 
@@ -1790,7 +1790,7 @@ msgstr "总农田大小："
 msgid "Total VDF Iterations"
 msgstr "总VDF迭代数"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "自区块开始以来的迭代数"
 
@@ -1834,7 +1834,7 @@ msgstr "交易过滤器哈希"
 msgid "Type"
 msgstr "类别"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "未完成"
 
@@ -1851,7 +1851,7 @@ msgstr "未知"
 msgid "User Pubkey"
 msgstr "用户公钥"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF子项迭代数"
 

--- a/src/locales/zh-TW/messages.po
+++ b/src/locales/zh-TW/messages.po
@@ -202,7 +202,7 @@ msgstr "帶雜湊值 {headerHash} 的區塊"
 msgid "Block with hash {headerHash} does not exists."
 msgstr "帶雜湊值 {headerHash} 的區塊不存在。"
 
-#: src/components/fullNode/FullNode.jsx:298
+#: src/components/fullNode/FullNode.jsx:299
 msgid "Blocks"
 msgstr "區塊"
 
@@ -351,7 +351,7 @@ msgid "Connect to other peers"
 msgstr "連線到其他同儕"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:47
-#: src/components/fullNode/FullNode.jsx:143
+#: src/components/fullNode/FullNode.jsx:144
 msgid "Connected"
 msgstr "已連線"
 
@@ -359,7 +359,7 @@ msgstr "已連線"
 msgid "Connecting to wallet"
 msgstr "連線至錢包中"
 
-#: src/components/fullNode/FullNode.jsx:141
+#: src/components/fullNode/FullNode.jsx:142
 msgid "Connection Status"
 msgstr "連線狀態"
 
@@ -544,7 +544,7 @@ msgid "Developer Tools"
 msgstr "開發者工具"
 
 #: src/components/block/Block.jsx:216
-#: src/components/fullNode/FullNode.jsx:178
+#: src/components/fullNode/FullNode.jsx:179
 msgid "Difficulty"
 msgstr "難度"
 
@@ -613,11 +613,11 @@ msgstr "錯誤：不能發送 Chia 到有色地址。請輸入 Chia 地址。"
 msgid "Estimated Time to Win"
 msgstr "預計贏取時間"
 
-#: src/components/fullNode/FullNode.jsx:197
+#: src/components/fullNode/FullNode.jsx:198
 msgid "Estimated network space"
 msgstr "估計的網路空間"
 
-#: src/components/fullNode/FullNode.jsx:200
+#: src/components/fullNode/FullNode.jsx:201
 msgid "Estimated sum of all the plotted disk space of all farmers in the network"
 msgstr "網路中所有農夫的所有耕地磁盤空間估計總和"
 
@@ -722,8 +722,8 @@ msgstr "檔案名稱"
 msgid "Final folder location"
 msgstr "最終資料夾位置"
 
-#: src/components/fullNode/FullNode.jsx:41
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:42
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Finished"
 msgstr "已完成"
 
@@ -736,11 +736,11 @@ msgid "Frequently Asked Questions"
 msgstr "常見問題"
 
 #: src/components/dashboard/DashboardSideBar.tsx:23
-#: src/components/fullNode/FullNode.jsx:312
+#: src/components/fullNode/FullNode.jsx:313
 msgid "Full Node"
 msgstr "完整節點"
 
-#: src/components/fullNode/FullNode.jsx:255
+#: src/components/fullNode/FullNode.jsx:256
 msgid "Full Node Status"
 msgstr "完整節點狀態"
 
@@ -760,7 +760,7 @@ msgstr "層及式確定性金鑰是一種公鑰/私鑰格式，一個私鑰可�
 #~ msgid "Harvester ID"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:59
+#: src/components/fullNode/FullNode.jsx:60
 msgid "Header Hash"
 msgstr "表頭雜湊值"
 
@@ -769,7 +769,7 @@ msgid "Header hash"
 msgstr "表頭雜湊值"
 
 #: src/components/block/Block.jsx:194
-#: src/components/fullNode/FullNode.jsx:75
+#: src/components/fullNode/FullNode.jsx:76
 #: src/components/fullNode/FullNodeConnections.tsx:54
 msgid "Height"
 msgstr "高度"
@@ -815,7 +815,7 @@ msgstr "以助記符號匯入錢包"
 msgid "Import from Mnemonics (24 words)"
 msgstr "從助記符號（24 字）匯入"
 
-#: src/components/fullNode/FullNode.jsx:43
+#: src/components/fullNode/FullNode.jsx:44
 msgid "In Progress"
 msgstr "進行中"
 
@@ -953,7 +953,7 @@ msgstr "更多記憶體可略微提高速度"
 msgid "My Pubkey"
 msgstr "我的公鑰"
 
-#: src/components/fullNode/FullNode.jsx:160
+#: src/components/fullNode/FullNode.jsx:161
 msgid "Network Name"
 msgstr "網路名稱"
 
@@ -1022,7 +1022,7 @@ msgstr "你還沒有任何的耕地通過篩選。"
 msgid "Not Available"
 msgstr "尚無"
 
-#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:123
 msgid "Not Synced"
 msgstr "未同步"
 
@@ -1035,8 +1035,8 @@ msgid "Not confirmed yet"
 msgstr "還未確認"
 
 #: src/components/core/components/FormatConnectionStatus/FormatConnectionStatus.tsx:48
-#: src/components/fullNode/FullNode.jsx:145
-#: src/components/fullNode/FullNode.jsx:152
+#: src/components/fullNode/FullNode.jsx:146
+#: src/components/fullNode/FullNode.jsx:153
 msgid "Not connected"
 msgstr "未連線"
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr "匯出"
 
-#: src/components/fullNode/FullNode.jsx:166
+#: src/components/fullNode/FullNode.jsx:167
 msgid "Peak Height"
 msgstr "峰值高度"
 
@@ -1080,7 +1080,7 @@ msgstr "峰值高度"
 #~ msgid "Peak Sub-block Height"
 #~ msgstr "Peak Sub-block Height"
 
-#: src/components/fullNode/FullNode.jsx:171
+#: src/components/fullNode/FullNode.jsx:172
 msgid "Peak Time"
 msgstr "峰值時間"
 
@@ -1547,14 +1547,14 @@ msgstr "花費間隔長度 (區塊數量)"
 msgid "Spending Limit (chia per interval): {0}"
 msgstr "花用限制（每間隔可用 Chia）：{0}"
 
-#: src/components/fullNode/FullNode.jsx:94
+#: src/components/fullNode/FullNode.jsx:95
 msgid "State"
 msgstr "狀態"
 
-#: src/components/fullNode/FullNode.jsx:104
-#: src/components/fullNode/FullNode.jsx:121
-#: src/components/fullNode/FullNode.jsx:129
-#: src/components/fullNode/FullNode.jsx:151
+#: src/components/fullNode/FullNode.jsx:105
+#: src/components/fullNode/FullNode.jsx:122
+#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:152
 #: src/components/plot/overview/PlotOverviewPlots.tsx:65
 #: src/components/trading/TradingOverview.jsx:128
 #: src/components/wallet/WalletHistory.tsx:43
@@ -1599,7 +1599,7 @@ msgstr "狀態："
 msgid "Submit"
 msgstr "確認"
 
-#: src/components/fullNode/FullNode.jsx:130
+#: src/components/fullNode/FullNode.jsx:131
 msgid "Synced"
 msgstr "已同步"
 
@@ -1609,7 +1609,7 @@ msgstr "已同步"
 msgid "Syncing"
 msgstr "同步中"
 
-#: src/components/fullNode/FullNode.jsx:106
+#: src/components/fullNode/FullNode.jsx:107
 msgid "Syncing {progress}/{tip}"
 msgstr "同步中 {progress}／{tip}"
 
@@ -1654,11 +1654,11 @@ msgstr "你的塊農連接上的完整節點列在下方。<0>了解更多</0>"
 msgid "The minimum required size for mainnet is k=32"
 msgstr "主網最小要求的大小是 k=32"
 
-#: src/components/fullNode/FullNode.jsx:124
+#: src/components/fullNode/FullNode.jsx:125
 msgid "The node is not synced"
 msgstr "此節點尚未同步"
 
-#: src/components/fullNode/FullNode.jsx:112
+#: src/components/fullNode/FullNode.jsx:113
 msgid "The node is syncing, which means it is downloading blocks from other nodes, to reach the latest block in the chain"
 msgstr "節點同步中，這代表正從其他節點中下載區塊，直到到達區塊鏈的最新區塊"
 
@@ -1704,7 +1704,7 @@ msgstr "這是待處理的改變，是你發送給自己的但還沒確認的改
 msgid "This is the sum of the incoming and outgoing pending transactions (not yet included into the blockchain). This does not include farming rewards."
 msgstr "這是匯入和匯出的未結交易的總和（還沒包含在區塊鏈中）。這不包括耕種獎勵。"
 
-#: src/components/fullNode/FullNode.jsx:173
+#: src/components/fullNode/FullNode.jsx:174
 msgid "This is the time of the latest peak sub block."
 msgstr "這是最後的峰值子區塊的時間。"
 
@@ -1720,7 +1720,7 @@ msgstr "這是由你的私鑰控制的目前峰值子區塊中區塊鏈中 Chia 
 msgid "This is the total balance + pending balance: it is what your balance will be after all pending transactions are confirmed."
 msgstr "這是總餘額 + 未結餘額：這是在全部未結交易結清後你的餘額。"
 
-#: src/components/fullNode/FullNode.jsx:133
+#: src/components/fullNode/FullNode.jsx:134
 msgid "This node is fully caught up and validating the network"
 msgstr "此節點已完全跟上和驗證網路"
 
@@ -1744,7 +1744,7 @@ msgstr "此貿易已包含在區塊鏈中的這個區塊高度"
 msgid "This version of Chia is no longer compatible with the blockchain and can not safely farm."
 msgstr "此版本的 Chia 不再與區塊鏈相容，因此無法安全地進行耕種。"
 
-#: src/components/fullNode/FullNode.jsx:86
+#: src/components/fullNode/FullNode.jsx:87
 msgid "Time Created"
 msgstr "建立時間"
 
@@ -1770,7 +1770,7 @@ msgstr "總餘額"
 #~ msgid "Total Chia Farmed"
 #~ msgstr ""
 
-#: src/components/fullNode/FullNode.jsx:191
+#: src/components/fullNode/FullNode.jsx:192
 msgid "Total Iterations"
 msgstr "總疊代次數"
 
@@ -1790,7 +1790,7 @@ msgstr "總耕地大小"
 msgid "Total VDF Iterations"
 msgstr "總 VDF 疊代次數"
 
-#: src/components/fullNode/FullNode.jsx:193
+#: src/components/fullNode/FullNode.jsx:194
 msgid "Total iterations since the start of the blockchain"
 msgstr "從區塊鏈開始後的總疊代次數"
 
@@ -1834,7 +1834,7 @@ msgstr "交易過濾雜湊值"
 msgid "Type"
 msgstr "類型"
 
-#: src/components/fullNode/FullNode.jsx:92
+#: src/components/fullNode/FullNode.jsx:93
 msgid "Unfinished"
 msgstr "未完成"
 
@@ -1851,7 +1851,7 @@ msgstr "未知"
 msgid "User Pubkey"
 msgstr "使用者公鑰"
 
-#: src/components/fullNode/FullNode.jsx:185
+#: src/components/fullNode/FullNode.jsx:186
 msgid "VDF Sub Slot Iterations"
 msgstr "VDF 子欄位疊代次數"
 


### PR DESCRIPTION
This adds a new `FormatLargeNumber` component that uses the current locale to format large numbers in the UI. Defaults to showing the full number when under 1000, and show a compact number with one decimal place (and a tooltip with the full value) otherwise.

Screenshots:
![Screen Shot 2021-05-10 at 8 50 46 PM](https://user-images.githubusercontent.com/7409244/117755908-ffa1b100-b1d1-11eb-84a4-4fb859dab57d.png)
![Screen Shot 2021-05-10 at 8 47 05 PM](https://user-images.githubusercontent.com/7409244/117755910-00d2de00-b1d2-11eb-97c7-ed163c0e2aef.png)
![Screen Shot 2021-05-10 at 8 46 49 PM](https://user-images.githubusercontent.com/7409244/117755912-029ca180-b1d2-11eb-9233-77f2f7cd675f.png)
![Screen Shot 2021-05-10 at 8 46 37 PM](https://user-images.githubusercontent.com/7409244/117755916-03cdce80-b1d2-11eb-9db1-d89062410065.png)


Closes: https://github.com/Chia-Network/chia-blockchain-gui/issues/351

I wasn't sure if when the translation files changed if they should also be PR-ed out with the UI changes. It looks like the comments indicating the lines in code changed, so figured they might need to come along.

to: @seeden 
cc: @darkwebdev