### PR TITLE
Improve plotting progress accuracy

### DIFF
--- a/src/modules/plotQueue.ts
+++ b/src/modules/plotQueue.ts
@@ -12,6 +12,28 @@ const FINISHED_LOG_LINES = 2626; // 128
 // const FINISHED_LOG_LINES_64 = 1379; // 64
 // const FINISHED_LOG_LINES_32 = 754; // 32
 
+const LOG_CHECKPOINTS: Record<string, number> = {
+  'Computing table 1': 0.01,
+  'Computing table 2': 0.06,
+  'Computing table 3': 0.12,
+  'Computing table 4': 0.2,
+  'Computing table 5': 0.28,
+  'Computing table 6': 0.36,
+  'Computing table 7': 0.42,
+  'Backpropagating on table 7': 0.43,
+  'Backpropagating on table 6': 0.48,
+  'Backpropagating on table 5': 0.51,
+  'Backpropagating on table 4': 0.55,
+  'Backpropagating on table 3': 0.58,
+  'Backpropagating on table 2': 0.61,
+  'Compressing tables 1 and 2': 0.66,
+  'Compressing tables 2 and 3': 0.73,
+  'Compressing tables 3 and 4': 0.79,
+  'Compressing tables 4 and 5': 0.85,
+  'Compressing tables 5 and 6': 0.92,
+  'Compressing tables 6 and 7': 0.98,
+};
+
 type PlotQueueItemPartial = PlotQueueItem & {
   log_new?: string;
 };
@@ -165,8 +187,37 @@ function addPlotProgress(queue: PlotQueueItem[]): PlotQueueItem[] {
     let progress = 0;
 
     if (log) {
-      const lines = log.trim().split(/\r\n|\r|\n/).length;
-      progress = lines > FINISHED_LOG_LINES ? 1 : lines / FINISHED_LOG_LINES;
+      const lines = log.trim().split(/\r\n|\r|\n/);
+      const lineSet = new Set(lines);
+
+      // Find the last checkpoint the log has reached, then increment
+      // additional progress based on the log length of a 128 bucket plot.
+      let currentCheckpoint: string | undefined;
+      let nextCheckpoint: string | undefined;
+      for (const checkpoint in LOG_CHECKPOINTS) {
+        if (lineSet.has(checkpoint)) {
+          currentCheckpoint = checkpoint;
+          progress = LOG_CHECKPOINTS[checkpoint];
+        } else {
+          nextCheckpoint = checkpoint;
+          break;
+        }
+      }
+
+      if (currentCheckpoint) {
+        progress +=
+          (lines.length -
+            lines.findIndex((line) => line === currentCheckpoint)) /
+          FINISHED_LOG_LINES;
+
+        // Once buckets can be > 128, this prevents the progress bar from
+        // ever decreasing
+        progress = nextCheckpoint
+          ? Math.min(progress, LOG_CHECKPOINTS[nextCheckpoint])
+          : progress;
+      }
+
+      progress = Math.min(1, progress);
     }
 
     return {


### PR DESCRIPTION
Improves the algorithm used to calculate plotting progress. Previously, we only checked the number of lines in the log file to determine plotting progress. This was problematic because:
1. The number of log lines depends on the number of buckets selected
2. Certain steps print fewer logs but take longer (causing the stuck on 31% for ages bug)

This new approach uses the progress points denoted in https://github.com/Chia-Network/chia-blockchain/wiki/Beginners-Guide#how-plots-are-created to create checkpoints within the plotting process that the progress bar will adhere to. Then we additionally increment the percentage as more lines are printed until we get to the next checkpoint.

Progress bars are [_hard_](https://www.youtube.com/watch?v=iZnLZFRylbs) so this solution still has a couple issues:
- Progress is no longer continuous, but can result in jumps from one percent to the next (especially during the backpropagation phase)
- We still use 128 buckets as the default for calculating additional percentage increments. This means greater jumps in progress for buckets < 128. This is going to exist until we add the bucket count information to the plot queue, which I believe requires a change to the plotter itself (a bit outside my wheelhouse)

However, I think even with those issues, this measure of progress is more accurate and will fix the linked bugs.

Test plan:
Test k25 plotting for bucket values of 64 and 128. Ensure that in both cases, the progress bar is always incrementing, and is hitting the checkpoint percentages as the proper log lines pass

Closes: https://github.com/Chia-Network/chia-blockchain-gui/issues/397
Closes: https://github.com/Chia-Network/chia-blockchain-gui/issues/354

to: @seeden 
cc: @richackard, @leewi9