### PR TITLE
This PR fixes the problem of adding a button to save the drawing file path selection style error when using Chinese

### DIFF
--- a/src/components/plot/add/PlotAddNumberOfPlots.tsx
+++ b/src/components/plot/add/PlotAddNumberOfPlots.tsx
@@ -206,7 +206,7 @@ export default function PlotAddNumberOfPlots() {
                     {' '}
                     <TooltipIcon>
                       <Trans>
-                        Disable bifield plotting when your temporary directory is on fast storage like SSD or you need lower per process RAM requirements. Plotting with bitfield enabled has about 20% less overall writes.
+                        You may see reduced memory requirements with bifield plotting disabled. Plotting with bitfield enabled has about 30% less overall writes and is now almost always faster.
                       </Trans>
                     </TooltipIcon>
                   </>

--- a/src/components/plot/add/PlotAddSelectFinalDirectory.tsx
+++ b/src/components/plot/add/PlotAddSelectFinalDirectory.tsx
@@ -58,7 +58,7 @@ export default function PlotAddSelectFinalDirectory() {
           }}
           required
         />
-        <ButtonSelected onClick={handleSelect} size="large" variant="contained" selected={hasFinalLocation}>
+        <ButtonSelected onClick={handleSelect} style={{ minWidth: '92px' }} size="large" variant="contained" selected={hasFinalLocation}>
           {hasFinalLocation ? (
             <Trans>Selected</Trans>
           ) : (

--- a/src/components/plot/add/PlotAddSelectTemporaryDirectory.tsx
+++ b/src/components/plot/add/PlotAddSelectTemporaryDirectory.tsx
@@ -69,7 +69,7 @@ export default function PlotAddSelectTemporaryDirectory() {
           }}
           required
         />
-        <ButtonSelected onClick={handleSelect} size="large" variant="contained" selected={hasWorkspaceLocation}>
+        <ButtonSelected onClick={handleSelect} style={{ minWidth: '92px' }} size="large" variant="contained" selected={hasWorkspaceLocation}>
           {hasWorkspaceLocation ? (
             <Trans>Selected</Trans>
           ) : (
@@ -100,7 +100,7 @@ export default function PlotAddSelectTemporaryDirectory() {
               }}
               variant="outlined"
             />
-            <ButtonSelected onClick={handleSelect2} size="large" variant="contained" selected={hasWorkspaceLocation2}>
+            <ButtonSelected onClick={handleSelect2} style={{ minWidth: '92px' }} size="large" variant="contained" selected={hasWorkspaceLocation2}>
               {hasWorkspaceLocation2 ? (
                 <Trans>Selected</Trans>
               ) : (

--- a/src/constants/plotSizes.ts
+++ b/src/constants/plotSizes.ts
@@ -8,17 +8,17 @@ type PlotSize = {
 export const defaultPlotSize: PlotSize = {
   label: '101.4GiB',
   value: 32,
-  workspace: '332GiB',
-  defaultRam: 4608,
+  workspace: '238.3GiB',
+  defaultRam: 3389,
 };
 
 const plotSizes: PlotSize[] = [
   { label: '600MiB', value: 25, workspace: '1.8GiB', defaultRam: 512 },
   defaultPlotSize,
-  { label: '208.8GiB', value: 33, workspace: '589GiB', defaultRam: 9216 },
+  { label: '208.8GiB', value: 33, workspace: '430GiB', defaultRam: 7400 },
   // workspace are guesses using 55.35% - rounded up - past here
-  { label: '429.8GiB', value: 34, workspace: '1177GiB', defaultRam: 18432 },
-  { label: '884.1GiB', value: 35, workspace: '2355GiB', defaultRam: 36864 },
+  { label: '429.8GiB', value: 34, workspace: '900GiB', defaultRam: 14800 },
+  { label: '884.1GiB', value: 35, workspace: '1884GiB', defaultRam: 29600 },
 ];
 
 export const plotSizeOptions = plotSizes.map((item) => ({


### PR DESCRIPTION
Fix the problem that the style of adding the button to save the plots file path selection is wrong when using Chinese

Since the style error only occurs in the two files, I used the inline style

After fix [https://imgtu.com/i/gzLKVx](url)
Before fix [https://imgtu.com/i/gzLrRg](url)