### PR TITLE
remove find config by version logic

### DIFF
--- a/src/electron/main.tsx
+++ b/src/electron/main.tsx
@@ -110,7 +110,7 @@ if (!handleSquirrelEvent()) {
   // if any of these checks return false, don't do any other initialization since the app is quitting
   if (ensureSingleInstance() && ensureCorrectEnvironment()) {
     // this needs to happen early in startup so all processes share the same global config
-    chiaConfig.loadConfig(chiaEnvironment.getChiaVersion());
+    chiaConfig.loadConfig('mainnet');
     global.sharedObj = { local_test };
 
     const exitPyProc = (e) => {};

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -10,17 +10,13 @@ global.daemon_rpc_ws = `wss://${self_hostname}:55400`;
 global.cert_path = 'config/ssl/daemon/private_daemon.crt';
 global.key_path = 'config/ssl/daemon/private_daemon.key';
 
-function loadConfig(version) {
+function loadConfig(net) {
   try {
-    // finding the right config file uses this precedence
-    // 1) CHIA_ROOT environment variable
-    // 2) version passed in and determined by the `chia version` call
-
-    // check if CHIA_ROOT is set. it overrides everything else
+    // check if CHIA_ROOT is set. it overrides 'net'
     const config_root_dir =
       'CHIA_ROOT' in process.env
         ? process.env.CHIA_ROOT
-        : path.join(os.homedir(), '.chia', version);
+        : path.join(os.homedir(), '.chia', net);
     const config = yaml.load(
       fs.readFileSync(path.join(config_root_dir, 'config/config.yaml'), 'utf8'),
     );


### PR DESCRIPTION
Remove the logic that still tried to find the config folder based on `chia version`, a holdover from pre-release versions. Now it just looks for 'mainnet' yet still respects `CHIA_ROOT`.