### PR TITLE
fix missing isWindows import

### DIFF
--- a/src/components/plot/PlotAction.tsx
+++ b/src/components/plot/PlotAction.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../modules/harvesterMessages';
 import type Plot from '../../types/Plot';
 import useOpenDialog from '../../hooks/useOpenDialog';
+import isWindows from '../../util/isWindows';
 
 type Props = {
   plot: Plot;


### PR DESCRIPTION
fixes a bug:
when one or more plot exists, the plots screen is unusable (blank) on linux