### PR TITLE
hooks|types: Drop deprecated `plot-seed` and use `plot_id` instead

### DIFF
--- a/src/hooks/usePlots.ts
+++ b/src/hooks/usePlots.ts
@@ -35,7 +35,7 @@ export default function usePlots(): {
       return plots;
     }
 
-    return uniqBy(plots, (plot) => plot['plot-seed']);
+    return uniqBy(plots, (plot) => plot['plot_id']);
   }, [plots]);
 
   const updatedPlots = useMemo(() => {
@@ -45,7 +45,7 @@ export default function usePlots(): {
 
     return plots.map((plot) => {
       const duplicates = plots.filter(
-        (item) => plot['plot-seed'] === item['plot-seed'] && item !== plot,
+        (item) => plot['plot_id'] === item['plot_id'] && item !== plot,
       );
 
       return {

--- a/src/types/Plot.ts
+++ b/src/types/Plot.ts
@@ -1,10 +1,10 @@
 type Plot = {
+  plot_id: string;
   filename: string;
   file_size: number;
   size: number;
   local_sk: string;
   farmer_public_key: string;
-  'plot-seed': string;
   plot_public_key: string;
   pool_public_key: string;
   pool_contract_puzzle_hash: string;


### PR DESCRIPTION
The key `seed_id` is [deprecated](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/harvester/harvester.py#L87) and not available in the `get_harvester` response. However, its still available in the `get_plots` response that's why it still works with commits before cb580386df901bd94ab08fca76c70b1c766a5018 which introduces the `get_harvesters` change. 