### PR TITLE
Show payout address for a PlotNFT in the Pool section

### DIFF
--- a/src/components/plotNFT/PlotNFTCard.tsx
+++ b/src/components/plotNFT/PlotNFTCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Trans } from '@lingui/macro';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import {
   TooltipTypography,
@@ -45,6 +45,7 @@ import PlotNFTGraph from './PlotNFTGraph';
 import PlotNFTGetPoolLoginLinkDialog from './PlotNFTGetPoolLoginLinkDialog';
 // import PlotNFTPayoutInstructionsDialog from './PlotNFTPayoutInstructionsDialog';
 import getPercentPointsSuccessfull from '../../util/getPercentPointsSuccessfull';
+import encodePuzzleHash from '../../util/toBech32m';
 
 const StyledCard = styled(Card)`
   display: flex;
@@ -81,13 +82,19 @@ export default function PlotNFTCard(props: Props) {
     nft: {
       pool_state: {
         p2_singleton_puzzle_hash,
-        pool_config: { launcher_id, pool_url },
+        pool_config: { launcher_id, pool_url, payout_instructions },
         points_found_24h,
         points_acknowledged_24h,
       },
       pool_wallet_status: { wallet_id },
     },
   } = props;
+
+  const networkPrefix = useSelector(
+    (state: RootState) => state.wallet_state.network_info?.network_prefix,
+  );
+
+  const payoutAddress = encodePuzzleHash(payout_instructions, networkPrefix);
 
   const percentPointsSuccessful24 = getPercentPointsSuccessfull(
     points_acknowledged_24h,
@@ -351,6 +358,17 @@ export default function PlotNFTCard(props: Props) {
             <Tooltip title={launcher_id} copyToClipboard>
               <Typography variant="body2" noWrap>
                 {launcher_id}
+              </Typography>
+            </Tooltip>
+          </Flex>
+
+          <Flex flexDirection="column" gap={1}>
+            <Typography variant="body1" color="textSecondary" noWrap>
+              <Trans>Payout Address</Trans>
+            </Typography>
+            <Tooltip title={payoutAddress} copyToClipboard>
+              <Typography variant="body2" noWrap>
+                {payoutAddress}
               </Typography>
             </Tooltip>
           </Flex>

--- a/src/components/plotNFT/PlotNFTCard.tsx
+++ b/src/components/plotNFT/PlotNFTCard.tsx
@@ -94,7 +94,13 @@ export default function PlotNFTCard(props: Props) {
     (state: RootState) => state.wallet_state.network_info?.network_prefix,
   );
 
-  const payoutAddress = encodePuzzleHash(payout_instructions, networkPrefix);
+  var payoutAddress: string;
+
+  try {
+    payoutAddress = encodePuzzleHash(payout_instructions, networkPrefix)
+  } catch {
+    payoutAddress = payout_instructions;
+  }
 
   const percentPointsSuccessful24 = getPercentPointsSuccessfull(
     points_acknowledged_24h,


### PR DESCRIPTION
Adds this:

![image](https://user-images.githubusercontent.com/43043344/125422824-8d9968ba-68ff-40ec-9bf5-0a07ca4035f8.png)


**Why is it required?**
At Flexpool we use Payout Address as the farm identifier, and there is no way to easily gather it in GUI. This PR fixes that.

As a consideration for the future, it would be nice to have an ability to change the payout address without the need of editing `~/.config/chia/mainnet/config/config.yml` file.