### PR TITLE
Fixed issue where if 2 of the same words were generated 

### DIFF
--- a/src/components/wallet/WalletAdd.tsx
+++ b/src/components/wallet/WalletAdd.tsx
@@ -74,7 +74,7 @@ export default function WalletAdd() {
             <Grid container spacing={2}>
               {words.map((word: string, index: number) => (
                 <MnemonicField
-                  key={word}
+                  key={index}
                   word={word}
                   id={`id_${index + 1}`}
                   index={index + 1}


### PR DESCRIPTION
If 2 of the same were generated then it would give an error and display the wrong words or possibly more.
This affects all keys that were generated through the gui