### PR TITLE
Keyring passphrase UX updates

### DIFF
--- a/src/components/app/AppKeyringMigrator.tsx
+++ b/src/components/app/AppKeyringMigrator.tsx
@@ -19,7 +19,7 @@ import {
 import {
   Help as HelpIcon,
 } from '@material-ui/icons';
-import { AlertDialog, ConfirmDialog, Flex } from '@chia/core';
+import { AlertDialog, ConfirmDialog } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
 import { RootState } from '../../modules/rootReducer';
 import { migrate_keyring_action, skipKeyringMigration } from '../../modules/message';

--- a/src/components/app/AppKeyringMigrator.tsx
+++ b/src/components/app/AppKeyringMigrator.tsx
@@ -19,7 +19,7 @@ import {
 import {
   Help as HelpIcon,
 } from '@material-ui/icons';
-import { AlertDialog, ConfirmDialog } from '@chia/core';
+import { AlertDialog, ConfirmDialog, Flex } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
 import { RootState } from '../../modules/rootReducer';
 import { migrate_keyring_action, skipKeyringMigration } from '../../modules/message';
@@ -33,6 +33,7 @@ export default function AppKeyringMigrator(): JSX.Element {
   const migrationInProgress = keyring_state.migration_in_progress;
   let passphraseInput: HTMLInputElement | null = null;
   let confirmationInput: HTMLInputElement | null = null;
+  let passphraseHintInput: HTMLInputElement | null;
   let savePassphraseCheckbox: HTMLInputElement | null = null;
   let cleanupKeyringCheckbox: HTMLInputElement | null = null;
 
@@ -66,6 +67,7 @@ export default function AppKeyringMigrator(): JSX.Element {
   async function handleMigrate(): Promise<void> {
     const passphrase: string = passphraseInput?.value ?? "";
     const confirmation: string = confirmationInput?.value ?? "";
+    const passphraseHint: string = passphraseHintInput?.value ?? "";
     const savePassphrase: boolean = savePassphraseCheckbox?.checked ?? false;
     const cleanup: boolean = cleanupKeyringCheckbox?.checked ?? false;
     const isValid: boolean = await validateDialog(passphrase, confirmation);
@@ -74,6 +76,7 @@ export default function AppKeyringMigrator(): JSX.Element {
       dispatch(
         migrate_keyring_action(
           passphrase,
+          passphraseHint,
           savePassphrase,
           cleanup,
           (error: string) => {
@@ -146,6 +149,18 @@ export default function AppKeyringMigrator(): JSX.Element {
             type="password"
             fullWidth
             />
+          {keyring_state.can_set_passphrase_hint && (
+            <TextField
+              disabled={migrationInProgress}
+              color="secondary"
+              margin="dense"
+              id="passphraseHintInput"
+              label={<Trans>Passphrase Hint (Optional)</Trans>}
+              placeholder={t`Passphrase Hint`}
+              inputRef={(input) => passphraseHintInput = input}
+              fullWidth
+            />
+          )}
           {keyring_state.can_save_passphrase && (
             <Box display="flex" alignItems="center">
               <FormControlLabel

--- a/src/components/app/AppKeyringMigrator.tsx
+++ b/src/components/app/AppKeyringMigrator.tsx
@@ -33,6 +33,7 @@ export default function AppKeyringMigrator(): JSX.Element {
   const migrationInProgress = keyring_state.migration_in_progress;
   let passphraseInput: HTMLInputElement | null = null;
   let confirmationInput: HTMLInputElement | null = null;
+  let savePassphraseCheckbox: HTMLInputElement | null = null;
   let cleanupKeyringCheckbox: HTMLInputElement | null = null;
 
   async function validateDialog(passphrase: string, confirmation: string): Promise<boolean> {
@@ -65,6 +66,7 @@ export default function AppKeyringMigrator(): JSX.Element {
   async function handleMigrate(): Promise<void> {
     const passphrase: string = passphraseInput?.value ?? "";
     const confirmation: string = confirmationInput?.value ?? "";
+    const savePassphrase: boolean = savePassphraseCheckbox?.checked ?? false;
     const cleanup: boolean = cleanupKeyringCheckbox?.checked ?? false;
     const isValid: boolean = await validateDialog(passphrase, confirmation);
 
@@ -72,6 +74,7 @@ export default function AppKeyringMigrator(): JSX.Element {
       dispatch(
         migrate_keyring_action(
           passphrase,
+          savePassphrase,
           cleanup,
           (error: string) => {
             dispatch(
@@ -143,22 +146,42 @@ export default function AppKeyringMigrator(): JSX.Element {
             type="password"
             fullWidth
             />
-          <Box display="flex" alignItems="center">
-            <FormControlLabel
-              control={(
-                <Checkbox 
-                  disabled={migrationInProgress}
-                  name="cleanupKeyringPostMigration"
-                  inputRef={(input) => cleanupKeyringCheckbox = input}
-                />
-              )}
-              label={t`Remove keys from old keyring upon successful migration`}
-              style={{ marginRight: '8px' }}
-            />
-            <Tooltip title={t`After your keys are successfully migrated to the new keyring, you may choose to have your keys removed from the old keyring.`}>
-              <HelpIcon style={{ color: '#c8c8c8', fontSize: 12 }} />
-            </Tooltip>                
-          </Box>
+          {keyring_state.can_save_passphrase && (
+            <Box display="flex" alignItems="center">
+              <FormControlLabel
+                control={(
+                  <Checkbox
+                    disabled={migrationInProgress}
+                    name="cleanupKeyringPostMigration"
+                    inputRef={(input) => savePassphraseCheckbox = input}
+                  />
+                )}
+                label={t`Save passphrase`}
+                style={{ marginRight: '8px' }}
+              />
+              <Tooltip title={t`Your passphrase can be stored in your system's secure credential store. Chia will be able to access your keys without prompting for your passphrase.`}>
+                <HelpIcon style={{ color: '#c8c8c8', fontSize: 12 }} />
+              </Tooltip>
+            </Box>
+          )}
+          {keyring_state.can_remove_legacy_keys && (
+            <Box display="flex" alignItems="center">
+              <FormControlLabel
+                control={(
+                  <Checkbox
+                    disabled={migrationInProgress}
+                    name="cleanupKeyringPostMigration"
+                    inputRef={(input) => cleanupKeyringCheckbox = input}
+                  />
+                )}
+                label={t`Remove keys from old keyring upon successful migration`}
+                style={{ marginRight: '8px' }}
+              />
+              <Tooltip title={t`After your keys are successfully migrated to the new keyring, you may choose to have your keys removed from the old keyring.`}>
+                <HelpIcon style={{ color: '#c8c8c8', fontSize: 12 }} />
+              </Tooltip>
+            </Box>
+          )}
           <DialogActions>
             <Box display="flex" alignItems="center" style={{ marginTop: '8px' }}>
               <Fade in={migrationInProgress}>

--- a/src/components/app/AppPassPrompt.tsx
+++ b/src/components/app/AppPassPrompt.tsx
@@ -10,8 +10,9 @@ import {
   Button,
 } from '@material-ui/core';
 import { Plural, Trans } from '@lingui/macro';
-import { AlertDialog, ConfirmDialog } from '@chia/core';
+import { AlertDialog, ConfirmDialog, Flex } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
+import TooltipIcon from '../core/components/TooltipIcon';
 import { unlock_keyring_action } from '../../modules/message';
 import { RootState } from 'modules/rootReducer';
 import { KeyringState } from 'modules/keyring';
@@ -107,7 +108,10 @@ export async function validateChangePassphraseParams(
 export default function AppPassPrompt(props: Props): JSX.Element | null {
   const dispatch = useDispatch();
   const { reason } = props;
-  const { user_passphrase_set: userPassphraseIsSet } = useSelector((state: RootState) => state.keyring_state);
+  const {
+    user_passphrase_set: userPassphraseIsSet,
+    passphrase_hint: passphraseHint,
+  } = useSelector((state: RootState) => state.keyring_state);
   const [actionInProgress, setActionInProgress] = React.useState(false);
   let passphraseInput: HTMLInputElement | null = null;
 
@@ -223,6 +227,18 @@ export default function AppPassPrompt(props: Props): JSX.Element | null {
               type="password"
               fullWidth
             />
+            {passphraseHint && passphraseHint.length > 0 && (
+              <Flex gap={1} alignItems="center" style={{ marginTop: '8px' }}>
+                <Typography variant="body2" color="textSecondary">
+                  <Trans>Hint</Trans>
+                </Typography>
+                <TooltipIcon>
+                  <Typography variant="inherit">
+                    {passphraseHint}
+                  </Typography>
+                </TooltipIcon>
+              </Flex>
+            )}
           </DialogContent>
           <DialogActions>
             <Button

--- a/src/components/app/AppPassPrompt.tsx
+++ b/src/components/app/AppPassPrompt.tsx
@@ -10,9 +10,8 @@ import {
   Button,
 } from '@material-ui/core';
 import { Plural, Trans } from '@lingui/macro';
-import { AlertDialog, ConfirmDialog, Flex } from '@chia/core';
+import { AlertDialog, ConfirmDialog, Flex, TooltipIcon } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
-import TooltipIcon from '../core/components/TooltipIcon';
 import { unlock_keyring_action } from '../../modules/message';
 import { RootState } from 'modules/rootReducer';
 import { KeyringState } from 'modules/keyring';
@@ -216,29 +215,31 @@ export default function AppPassPrompt(props: Props): JSX.Element | null {
         >
           <DialogTitle id="form-dialog-title">{dialogTitle}</DialogTitle>
           <DialogContent>
-            <TextField
-              autoFocus
-              color="secondary"
-              disabled={actionInProgress}
-              margin="dense"
-              id="passphraseInput"
-              label={<Trans>Passphrase</Trans>}
-              inputRef={(input: HTMLInputElement) => passphraseInput = input}
-              type="password"
-              fullWidth
-            />
-            {passphraseHint && passphraseHint.length > 0 && (
-              <Flex gap={1} alignItems="center" style={{ marginTop: '8px' }}>
-                <Typography variant="body2" color="textSecondary">
-                  <Trans>Hint</Trans>
-                </Typography>
-                <TooltipIcon>
-                  <Typography variant="inherit">
-                    {passphraseHint}
+            <Flex flexDirection="column" gap={1}>
+              <TextField
+                autoFocus
+                color="secondary"
+                disabled={actionInProgress}
+                margin="dense"
+                id="passphraseInput"
+                label={<Trans>Passphrase</Trans>}
+                inputRef={(input: HTMLInputElement) => passphraseInput = input}
+                type="password"
+                fullWidth
+              />
+              {passphraseHint && passphraseHint.length > 0 && (
+                <Flex gap={1} alignItems="center">
+                  <Typography variant="body2" color="textSecondary">
+                    <Trans>Hint</Trans>
                   </Typography>
-                </TooltipIcon>
-              </Flex>
-            )}
+                  <TooltipIcon>
+                    <Typography variant="inherit">
+                      {passphraseHint}
+                    </Typography>
+                  </TooltipIcon>
+                </Flex>
+              )}
+            </Flex>
           </DialogContent>
           <DialogActions>
             <Button

--- a/src/components/settings/ChangePassphrasePrompt.tsx
+++ b/src/components/settings/ChangePassphrasePrompt.tsx
@@ -17,7 +17,7 @@ import {
   Help as HelpIcon,
 } from '@material-ui/icons';
 import { t, Trans } from '@lingui/macro';
-import { AlertDialog } from '@chia/core';
+import { AlertDialog, Flex } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
 import { change_keyring_passphrase_action, remove_keyring_passphrase_action } from '../../modules/message';
 import { validateChangePassphraseParams } from '../app/AppPassPrompt';
@@ -163,7 +163,7 @@ export default function ChangePassphrasePrompt(props: Props) {
       open={true}
       aria-labelledby="form-dialog-title"
       fullWidth={true}
-      maxWidth = {'sm'}
+      maxWidth="sm"
       onKeyDown={handleKeyDown}
     >
       <DialogTitle id="form-dialog-title">Change Passphrase</DialogTitle>
@@ -230,24 +230,24 @@ export default function ChangePassphrasePrompt(props: Props) {
           </Box>
         )}
         <DialogActions>
-          <Button
-            disabled={actionInProgress}
-            onClick={handleCancel}
-            color="secondary"
-            variant="contained"
-            style={{ marginBottom: '8px', marginRight: '8px' }}
-          >
-            <Trans>Cancel</Trans>
-          </Button>
-          <Button
-            disabled={actionInProgress}
-            onClick={handleSubmit}
-            color="primary"
-            variant="contained"
-            style={{ marginBottom: '8px', marginRight: '8px' }}
-          >
-            <Trans>Change Passphrase</Trans>
-          </Button>
+          <Flex gap={2}>
+            <Button
+              disabled={actionInProgress}
+              onClick={handleCancel}
+              color="secondary"
+              variant="contained"
+            >
+              <Trans>Cancel</Trans>
+            </Button>
+            <Button
+              disabled={actionInProgress}
+              onClick={handleSubmit}
+              color="primary"
+              variant="contained"
+            >
+              <Trans>Change Passphrase</Trans>
+            </Button>
+          </Flex>
         </DialogActions>
       </DialogContent>
     </Dialog>

--- a/src/components/settings/ChangePassphrasePrompt.tsx
+++ b/src/components/settings/ChangePassphrasePrompt.tsx
@@ -36,6 +36,7 @@ export default function ChangePassphrasePrompt(props: Props) {
   let currentPassphraseInput: HTMLInputElement | null;
   let passphraseInput: HTMLInputElement | null;
   let confirmationInput: HTMLInputElement | null;
+  let passphraseHintInput: HTMLInputElement | null;
   let savePassphraseCheckbox: HTMLInputElement | null = null;
 
   const [needsFocusAndSelect, setNeedsFocusAndSelect] = React.useState(false);
@@ -77,6 +78,7 @@ export default function ChangePassphrasePrompt(props: Props) {
     const newPassphrase: string = passphraseInput?.value ?? "";
     const confirmation: string = confirmationInput?.value ?? "";
     const savePassphrase: boolean = savePassphraseCheckbox?.checked ?? false;
+    const passphraseHint: string = passphraseHintInput?.value ?? "";
     const isValid = await validateDialog(currentPassphrase, newPassphrase, confirmation);
 
     if (isValid) {
@@ -108,6 +110,7 @@ export default function ChangePassphrasePrompt(props: Props) {
             change_keyring_passphrase_action(
               currentPassphrase,
               newPassphrase,
+              passphraseHint,
               savePassphrase,
               () => { onSuccess() }, // success
               async (error: string) => { // failure
@@ -196,6 +199,18 @@ export default function ChangePassphrasePrompt(props: Props) {
           type="password"
           fullWidth
         />
+        {keyring_state.can_set_passphrase_hint && (
+          <TextField
+            disabled={actionInProgress}
+            color="secondary"
+            margin="dense"
+            id="passphraseHintInput"
+            label={<Trans>Passphrase Hint (Optional)</Trans>}
+            placeholder={t`Passphrase Hint`}
+            inputRef={(input) => passphraseHintInput = input}
+            fullWidth
+          />
+        )}
         {keyring_state.can_save_passphrase && (
           <Box display="flex" alignItems="center">
             <FormControlLabel

--- a/src/components/settings/ChangePassphrasePrompt.tsx
+++ b/src/components/settings/ChangePassphrasePrompt.tsx
@@ -1,15 +1,22 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
+  Box,
   Button,
+  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
-  TextField
+  FormControlLabel,
+  TextField,
+  Tooltip,
 } from '@material-ui/core';
-import { Trans } from '@lingui/macro';
+import {
+  Help as HelpIcon,
+} from '@material-ui/icons';
+import { t, Trans } from '@lingui/macro';
 import { AlertDialog } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
 import { change_keyring_passphrase_action, remove_keyring_passphrase_action } from '../../modules/message';
@@ -29,6 +36,7 @@ export default function ChangePassphrasePrompt(props: Props) {
   let currentPassphraseInput: HTMLInputElement | null;
   let passphraseInput: HTMLInputElement | null;
   let confirmationInput: HTMLInputElement | null;
+  let savePassphraseCheckbox: HTMLInputElement | null = null;
 
   const [needsFocusAndSelect, setNeedsFocusAndSelect] = React.useState(false);
   useEffect(() => {
@@ -68,6 +76,7 @@ export default function ChangePassphrasePrompt(props: Props) {
     const currentPassphrase: string = currentPassphraseInput?.value ?? "";
     const newPassphrase: string = passphraseInput?.value ?? "";
     const confirmation: string = confirmationInput?.value ?? "";
+    const savePassphrase: boolean = savePassphraseCheckbox?.checked ?? false;
     const isValid = await validateDialog(currentPassphrase, newPassphrase, confirmation);
 
     if (isValid) {
@@ -99,6 +108,7 @@ export default function ChangePassphrasePrompt(props: Props) {
             change_keyring_passphrase_action(
               currentPassphrase,
               newPassphrase,
+              savePassphrase,
               () => { onSuccess() }, // success
               async (error: string) => { // failure
                 await dispatch(
@@ -150,7 +160,7 @@ export default function ChangePassphrasePrompt(props: Props) {
       open={true}
       aria-labelledby="form-dialog-title"
       fullWidth={true}
-      maxWidth = {'xs'}
+      maxWidth = {'sm'}
       onKeyDown={handleKeyDown}
     >
       <DialogTitle id="form-dialog-title">Change Passphrase</DialogTitle>
@@ -186,27 +196,45 @@ export default function ChangePassphrasePrompt(props: Props) {
           type="password"
           fullWidth
         />
+        {keyring_state.can_save_passphrase && (
+          <Box display="flex" alignItems="center">
+            <FormControlLabel
+              control={(
+                <Checkbox
+                  disabled={actionInProgress}
+                  name="cleanupKeyringPostMigration"
+                  inputRef={(input) => savePassphraseCheckbox = input}
+                />
+              )}
+              label={t`Save passphrase`}
+              style={{ marginRight: '8px' }}
+            />
+            <Tooltip title={t`Your passphrase can be stored in your system's secure credential store. Chia will be able to access your keys without prompting for your passphrase.`}>
+              <HelpIcon style={{ color: '#c8c8c8', fontSize: 12 }} />
+            </Tooltip>
+          </Box>
+        )}
+        <DialogActions>
+          <Button
+            disabled={actionInProgress}
+            onClick={handleCancel}
+            color="secondary"
+            variant="contained"
+            style={{ marginBottom: '8px', marginRight: '8px' }}
+          >
+            <Trans>Cancel</Trans>
+          </Button>
+          <Button
+            disabled={actionInProgress}
+            onClick={handleSubmit}
+            color="primary"
+            variant="contained"
+            style={{ marginBottom: '8px', marginRight: '8px' }}
+          >
+            <Trans>Change Passphrase</Trans>
+          </Button>
+        </DialogActions>
       </DialogContent>
-      <DialogActions>
-        <Button
-          disabled={actionInProgress}
-          onClick={handleCancel}
-          color="secondary"
-          variant="contained"
-          style={{ marginBottom: '8px', marginRight: '8px' }}
-        >
-          <Trans>Cancel</Trans>
-        </Button>
-        <Button
-          disabled={actionInProgress}
-          onClick={handleSubmit}
-          color="primary"
-          variant="contained"
-          style={{ marginBottom: '8px', marginRight: '8px' }}
-        >
-          <Trans>Change Passphrase</Trans>
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 }

--- a/src/components/settings/RemovePassphrasePrompt.tsx
+++ b/src/components/settings/RemovePassphrasePrompt.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Button,
   Dialog,
@@ -7,11 +7,14 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  TextField
+  TextField,
+  Typography,
 } from '@material-ui/core';
 import { Trans } from '@lingui/macro';
-import { AlertDialog } from '@chia/core';
+import { AlertDialog, Flex } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
+import TooltipIcon from '../core/components/TooltipIcon';
+import { RootState } from 'modules/rootReducer';
 import { remove_keyring_passphrase_action } from '../../modules/message';
 
 type Props = {
@@ -22,6 +25,7 @@ type Props = {
 export default function RemovePassphrasePrompt(props: Props) {
   const dispatch = useDispatch();
   const { onSuccess, onCancel } = props;
+  const { passphrase_hint: passphraseHint } = useSelector((state: RootState) => state.keyring_state);
   const [actionInProgress, setActionInProgress] = React.useState(false);
   let passphraseInput: HTMLInputElement | null;
 
@@ -125,6 +129,18 @@ export default function RemovePassphrasePrompt(props: Props) {
           type="password"
           fullWidth
         />
+        {passphraseHint && passphraseHint.length > 0 && (
+          <Flex gap={1} alignItems="center" style={{ marginTop: '8px' }}>
+            <Typography variant="body2" color="textSecondary">
+              <Trans>Hint</Trans>
+            </Typography>
+            <TooltipIcon>
+              <Typography variant="inherit">
+                {passphraseHint}
+              </Typography>
+            </TooltipIcon>
+          </Flex>
+        )}
       </DialogContent>
       <DialogActions>
         <Button

--- a/src/components/settings/RemovePassphrasePrompt.tsx
+++ b/src/components/settings/RemovePassphrasePrompt.tsx
@@ -11,9 +11,8 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Trans } from '@lingui/macro';
-import { AlertDialog, Flex } from '@chia/core';
+import { AlertDialog, Flex, TooltipIcon } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
-import TooltipIcon from '../core/components/TooltipIcon';
 import { RootState } from 'modules/rootReducer';
 import { remove_keyring_passphrase_action } from '../../modules/message';
 

--- a/src/components/settings/SetPassphrasePrompt.tsx
+++ b/src/components/settings/SetPassphrasePrompt.tsx
@@ -17,7 +17,7 @@ import {
   Help as HelpIcon,
 } from '@material-ui/icons';
 import { t, Trans } from '@lingui/macro';
-import { AlertDialog, Flex } from '@chia/core';
+import { AlertDialog } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
 import { change_keyring_passphrase_action } from '../../modules/message';
 import { validateChangePassphraseParams } from '../app/AppPassPrompt';

--- a/src/components/settings/SetPassphrasePrompt.tsx
+++ b/src/components/settings/SetPassphrasePrompt.tsx
@@ -1,16 +1,23 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
+  Box,
   Button,
+  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
-  TextField
+  FormControlLabel,
+  TextField,
+  Tooltip,
 } from '@material-ui/core';
-import { Trans } from '@lingui/macro';
-import { AlertDialog } from '@chia/core';
+import {
+  Help as HelpIcon,
+} from '@material-ui/icons';
+import { t, Trans } from '@lingui/macro';
+import { AlertDialog, Flex } from '@chia/core';
 import { openDialog } from '../../modules/dialog';
 import { change_keyring_passphrase_action } from '../../modules/message';
 import { validateChangePassphraseParams } from '../app/AppPassPrompt';
@@ -28,6 +35,8 @@ export default function SetPassphrasePrompt(props: Props) {
   const [actionInProgress, setActionInProgress] = React.useState(false);
   let passphraseInput: HTMLInputElement | null;
   let confirmationInput: HTMLInputElement | null;
+  let passphraseHintInput: HTMLInputElement | null;
+  let savePassphraseCheckbox: HTMLInputElement | null = null;
 
   const [needsFocusAndSelect, setNeedsFocusAndSelect] = React.useState(false);
   useEffect(() => {
@@ -61,6 +70,8 @@ export default function SetPassphrasePrompt(props: Props) {
   async function handleSubmit() {
     const passphrase: string = passphraseInput?.value ?? "";
     const confirmation: string = confirmationInput?.value ?? "";
+    const passphraseHint: string = passphraseHintInput?.value ?? "";
+    const savePassphrase: boolean = savePassphraseCheckbox?.checked ?? false;
     const isValid = await validateDialog(passphrase, confirmation);
 
     if (isValid) {
@@ -71,6 +82,8 @@ export default function SetPassphrasePrompt(props: Props) {
           change_keyring_passphrase_action(
             null,
             passphrase,
+            passphraseHint,
+            savePassphrase,
             () => { onSuccess() }, // success
             async (error: string) => { // failure
               await dispatch(
@@ -155,7 +168,37 @@ export default function SetPassphrasePrompt(props: Props) {
           inputRef={(input) => confirmationInput = input}
           type="password"
           fullWidth
+        />
+        {keyring_state.can_set_passphrase_hint && (
+          <TextField
+            disabled={actionInProgress}
+            color="secondary"
+            margin="dense"
+            id="passphraseHintInput"
+            label={<Trans>Passphrase Hint (Optional)</Trans>}
+            placeholder={t`Passphrase Hint`}
+            inputRef={(input) => passphraseHintInput = input}
+            fullWidth
           />
+        )}
+        {keyring_state.can_save_passphrase && (
+          <Box display="flex" alignItems="center">
+            <FormControlLabel
+              control={(
+                <Checkbox
+                  disabled={actionInProgress}
+                  name="cleanupKeyringPostMigration"
+                  inputRef={(input) => savePassphraseCheckbox = input}
+                />
+              )}
+              label={t`Save passphrase`}
+              style={{ marginRight: '8px' }}
+            />
+            <Tooltip title={t`Your passphrase can be stored in your system's secure credential store. Chia will be able to access your keys without prompting for your passphrase.`}>
+              <HelpIcon style={{ color: '#c8c8c8', fontSize: 12 }} />
+            </Tooltip>
+          </Box>
+        )}
       </DialogContent>
       <DialogActions>
         <Button

--- a/src/modules/keyring.ts
+++ b/src/modules/keyring.ts
@@ -4,6 +4,7 @@ export type KeyringState = {
   can_save_passphrase: boolean;
   user_passphrase_set: boolean;
   needs_migration: boolean;
+  can_remove_legacy_keys: boolean;
   migration_in_progress: boolean;
   migration_skipped: boolean;
   allow_empty_passphrase: boolean;
@@ -16,6 +17,7 @@ const initialState: KeyringState = {
   can_save_passphrase: false,
   user_passphrase_set: false,
   needs_migration: false,
+  can_remove_legacy_keys: false,
   migration_in_progress: false,
   migration_skipped: false,
   allow_empty_passphrase: false,
@@ -43,6 +45,7 @@ export default function keyringReducer(
           const { can_save_passphrase } = data;
           const { user_passphrase_is_set } = data;
           const { needs_migration } = data;
+          const { can_remove_legacy_keys } = data;
           const { passphrase_requirements } = data;
           const allow_empty_passphrase = passphrase_requirements?.is_optional || false;
           const min_passphrase_length = passphrase_requirements?.min_length || 10;
@@ -53,6 +56,7 @@ export default function keyringReducer(
             can_save_passphrase: can_save_passphrase,
             user_passphrase_set: user_passphrase_is_set,
             needs_migration: needs_migration,
+            can_remove_legacy_keys: can_remove_legacy_keys,
             allow_empty_passphrase: allow_empty_passphrase,
             min_passphrase_length: min_passphrase_length,
           };

--- a/src/modules/keyring.ts
+++ b/src/modules/keyring.ts
@@ -9,6 +9,8 @@ export type KeyringState = {
   migration_skipped: boolean;
   allow_empty_passphrase: boolean;
   min_passphrase_length: number;
+  can_set_passphrase_hint: boolean;
+  passphrase_hint: string;
 };
 
 const initialState: KeyringState = {
@@ -22,6 +24,8 @@ const initialState: KeyringState = {
   migration_skipped: false,
   allow_empty_passphrase: false,
   min_passphrase_length: 0,
+  can_set_passphrase_hint: false,
+  passphrase_hint: "",
 };
 
 export default function keyringReducer(
@@ -40,13 +44,17 @@ export default function keyringReducer(
       const { command } = message;
       if ((command === 'keyring_status') || (command === 'keyring_status_changed')) {
         if (data.success) {
-          const { is_keyring_locked } = data;
-          const { passphrase_support_enabled } = data;
-          const { can_save_passphrase } = data;
-          const { user_passphrase_is_set } = data;
-          const { needs_migration } = data;
-          const { can_remove_legacy_keys } = data;
-          const { passphrase_requirements } = data;
+          const {
+            is_keyring_locked,
+            passphrase_support_enabled,
+            can_save_passphrase,
+            user_passphrase_is_set,
+            needs_migration,
+            can_remove_legacy_keys,
+            passphrase_requirements,
+            can_set_passphrase_hint,
+            passphrase_hint,
+          } = data;
           const allow_empty_passphrase = passphrase_requirements?.is_optional || false;
           const min_passphrase_length = passphrase_requirements?.min_length || 10;
           return {
@@ -59,6 +67,8 @@ export default function keyringReducer(
             can_remove_legacy_keys: can_remove_legacy_keys,
             allow_empty_passphrase: allow_empty_passphrase,
             min_passphrase_length: min_passphrase_length,
+            can_set_passphrase_hint: can_set_passphrase_hint,
+            passphrase_hint: passphrase_hint,
           };
         }
       } else if (command === 'unlock_keyring') {

--- a/src/modules/message.js
+++ b/src/modules/message.js
@@ -988,15 +988,15 @@ export const unlock_keyring_action = (key, onFailure) => (dispatch) => {
   );
 };
 
-export const migrate_keyring = (passphrase, save_passphrase, cleanup_legacy_keyring) => {
+export const migrate_keyring = (passphrase, passphrase_hint, save_passphrase, cleanup_legacy_keyring) => {
   const action = daemonMessage();
   action.message.command = 'migrate_keyring';
-  action.message.data = { passphrase: passphrase, save_passphrase: save_passphrase, cleanup_legacy_keyring: cleanup_legacy_keyring };
+  action.message.data = { passphrase: passphrase, passphrase_hint: passphrase_hint, save_passphrase: save_passphrase, cleanup_legacy_keyring: cleanup_legacy_keyring };
   return action;
 }
 
-export const migrate_keyring_action = (passphrase, savePassphrase, cleanup_legacy_keyring, onFailure) => (dispatch) => {
-  return async_api(dispatch, migrate_keyring(passphrase, savePassphrase, cleanup_legacy_keyring), false, true).then(
+export const migrate_keyring_action = (passphrase, passphraseHint, savePassphrase, cleanup_legacy_keyring, onFailure) => (dispatch) => {
+  return async_api(dispatch, migrate_keyring(passphrase, passphraseHint, savePassphrase, cleanup_legacy_keyring), false, true).then(
     (response) => {
       if (response.data.success) {
         dispatch(keyringStatus());
@@ -1008,15 +1008,15 @@ export const migrate_keyring_action = (passphrase, savePassphrase, cleanup_legac
   );
 }
 
-export const change_keyring_passphrase = (current_passphrase, new_passphrase, save_passphrase) => {
+export const change_keyring_passphrase = (current_passphrase, new_passphrase, passphrase_hint, save_passphrase) => {
   const action = daemonMessage();
   action.message.command = 'set_keyring_passphrase';
-  action.message.data = { current_passphrase: current_passphrase, new_passphrase: new_passphrase, save_passphrase: save_passphrase };
+  action.message.data = { current_passphrase: current_passphrase, new_passphrase: new_passphrase, passphrase_hint: passphrase_hint, save_passphrase: save_passphrase };
   return action;
 }
 
-export const change_keyring_passphrase_action = (current_passphrase, new_passphrase, savePassphrase, onSuccess, onFailure) => (dispatch) => {
-  return async_api(dispatch, change_keyring_passphrase(current_passphrase, new_passphrase, savePassphrase), false, true).then(
+export const change_keyring_passphrase_action = (current_passphrase, new_passphrase, passphraseHint, savePassphrase, onSuccess, onFailure) => (dispatch) => {
+  return async_api(dispatch, change_keyring_passphrase(current_passphrase, new_passphrase, passphraseHint, savePassphrase), false, true).then(
     (response) => {
       if (response.data.success) {
         dispatch(keyringStatus());

--- a/src/modules/message.js
+++ b/src/modules/message.js
@@ -988,15 +988,15 @@ export const unlock_keyring_action = (key, onFailure) => (dispatch) => {
   );
 };
 
-export const migrate_keyring = (passphrase, cleanup_legacy_keyring) => {
+export const migrate_keyring = (passphrase, save_passphrase, cleanup_legacy_keyring) => {
   const action = daemonMessage();
   action.message.command = 'migrate_keyring';
-  action.message.data = { passphrase: passphrase, cleanup_legacy_keyring: cleanup_legacy_keyring };
+  action.message.data = { passphrase: passphrase, save_passphrase: save_passphrase, cleanup_legacy_keyring: cleanup_legacy_keyring };
   return action;
 }
 
-export const migrate_keyring_action = (passphrase, cleanup_legacy_keyring, onFailure) => (dispatch) => {
-  return async_api(dispatch, migrate_keyring(passphrase, cleanup_legacy_keyring), false, true).then(
+export const migrate_keyring_action = (passphrase, savePassphrase, cleanup_legacy_keyring, onFailure) => (dispatch) => {
+  return async_api(dispatch, migrate_keyring(passphrase, savePassphrase, cleanup_legacy_keyring), false, true).then(
     (response) => {
       if (response.data.success) {
         dispatch(keyringStatus());
@@ -1008,15 +1008,15 @@ export const migrate_keyring_action = (passphrase, cleanup_legacy_keyring, onFai
   );
 }
 
-export const change_keyring_passphrase = (current_passphrase, new_passphrase) => {
+export const change_keyring_passphrase = (current_passphrase, new_passphrase, save_passphrase) => {
   const action = daemonMessage();
   action.message.command = 'set_keyring_passphrase';
-  action.message.data = { current_passphrase: current_passphrase, new_passphrase: new_passphrase };
+  action.message.data = { current_passphrase: current_passphrase, new_passphrase: new_passphrase, save_passphrase: save_passphrase };
   return action;
 }
 
-export const change_keyring_passphrase_action = (current_passphrase, new_passphrase, onSuccess, onFailure) => (dispatch) => {
-  return async_api(dispatch, change_keyring_passphrase(current_passphrase, new_passphrase), false, true).then(
+export const change_keyring_passphrase_action = (current_passphrase, new_passphrase, savePassphrase, onSuccess, onFailure) => (dispatch) => {
+  return async_api(dispatch, change_keyring_passphrase(current_passphrase, new_passphrase, savePassphrase), false, true).then(
     (response) => {
       if (response.data.success) {
         dispatch(keyringStatus());


### PR DESCRIPTION
Trello issue: https://trello.com/c/P4SmvQVs/1373-final-ux-for-passphrase-encryption-feature

This change introduces the following changes:

1) Exposes the "Save Passphrase" functionality on macOS and Windows. The user is allowed to save their keyring passphrase to the macOS Keychain or Windows Credential Store, allowing Chia to access the keyring in an unattended manner. The GUI now provides a checkbox to save the passphrase when setting/changing the passphrase.

2) When setting a passphrase, an optional passphrase hint field is provided. If specified, the hint will be displayed in the passphrase dialogs.

3) During keyring migration, the checkbox to optionally delete keys from the old location has been hidden. Migration from the CLI still allows deletion of the keys from the old location. After 2-3 releases, we'll revisit the task of removing keys from their prior location.