### PR TITLE
Fix issue wherein the progress spinner would disappear after selecting a key

### DIFF
--- a/src/modules/message.js
+++ b/src/modules/message.js
@@ -76,7 +76,9 @@ export const async_api = (dispatch, action, openSpinner, usePromiseReject) => {
     action.resolve = resolve;
     action.reject = reject;
   }).finally(() => {
-    dispatch(closeProgress());
+    if (openSpinner) {
+      dispatch(closeProgress());
+    }
   });
 
   action.usePromiseReject = usePromiseReject;


### PR DESCRIPTION
PROBLEM
At launch, the SelectKey screen allows the user to select a wallet key to login. Upon selecting a key, a progress spinner appears, blocking further user interaction until the login response is received. Other background activity would cause the progress spinner to disappear, allowing the user to select the key again. Eventually the original login request completes, taking the user to the main dashboard.

FIX
The async_api call takes an openProgress param, which if set to true, will display the progress spinner. The finally block calls closeProgress(), but doesn't check if openProgress was set to true. Since the login command is currently taking a long time, another call to async_api with openProgress set to false would have the effect of closing the progress spinner if it completes before the login command. This fix checks if openProgress is set to true before calling closeProgress.

NOTE
It's possible that another async_api caller can set openProgress to true, and if that command completes before the login command, it will have the same behavior as before. Currently I only observed `get_blocks` being called during login.