### PR TITLE
Fix first launch hang with undefined daemon_rpc_ws when config.yaml hasn't been written yet

### DIFF
--- a/packages/wallet/src/util/config.js
+++ b/packages/wallet/src/util/config.js
@@ -6,7 +6,7 @@ const lodash = require('lodash');
 
 // defaults used in case of error point to the localhost daemon & its certs
 let self_hostname = 'localhost';
-// global.daemon_rpc_ws = `wss://${self_hostname}:55400`;
+global.daemon_rpc_ws = `wss://${self_hostname}:55401`;
 // global.cert_path = 'config/ssl/daemon/private_daemon.crt';
 // global.key_path = 'config/ssl/daemon/private_daemon.key';
 


### PR DESCRIPTION
When launching for the first time (~/.chia/standalone_wallet not present), the GUI hangs due to an exception throw at Client.ts:57 wherein url is undefined.

This change exposes the default value for daemon_rpc_ws when the config isn't available yet.