### PR TITLE
Set webpack hash algorithm

### DIFF
--- a/webpack.electron.babel.ts
+++ b/webpack.electron.babel.ts
@@ -29,10 +29,11 @@ export default {
   output: {
     path: path.resolve(__dirname, './build/electron'),
     filename: '[name].js',
+    hashFunction: "sha256",
   },
   plugins: [
     new CopyPlugin({
-      patterns: [{ 
+      patterns: [{
         from: path.resolve(__dirname, './src/electron/preload.js'),
         to: path.resolve(__dirname, './build/electron'),
       }],

--- a/webpack.react.babel.ts
+++ b/webpack.react.babel.ts
@@ -70,6 +70,7 @@ export default {
     path: path.resolve(__dirname, './build/renderer'),
     filename: 'js/[name].js',
     publicPath: './',
+    hashFunction: "sha256",
   },
   resolve: {
     extensions: ['.wasm', '.mjs', '.ts', '.tsx', '.js', '.jsx', '.json'],


### PR DESCRIPTION
Sets the webpack hash algorithm to SHA256 to avoid issues with node 17 and ERR_OSSL_EVP_UNSUPPORTED errors from openssl