### PR TITLE
Add offerpool.io to offer share dialog, fix share bug

### DIFF
--- a/packages/wallets/src/components/offers/OfferManager.tsx
+++ b/packages/wallets/src/components/offers/OfferManager.tsx
@@ -18,7 +18,7 @@ import {
   TableControlled,
   TooltipIcon,
   useOpenDialog,
-  chiaToMojo, 
+  chiaToMojo,
   mojoToCATLocaleString,
   useShowSaveDialog,
   Tooltip,
@@ -208,9 +208,9 @@ function OfferList(props: OfferListProps) {
   }
 
   function handleRowClick(event: any, row: OfferTradeRecord) {
-    navigate('/dashboard/wallets/offers/view', { 
+    navigate('/dashboard/wallets/offers/view', {
       state: {
-        tradeRecord: row 
+        tradeRecord: row
       },
     });
   }
@@ -525,9 +525,9 @@ export function CreateOffer() {
         element={
           <CreateOfferEditor
             onOfferCreated={(obj: { offerRecord: any, offerData: any }) => {
-              setOfferCreated(true);
               setOfferRecord(obj.offerRecord);
               setOfferData(obj.offerData);
+              setOfferCreated(true);
             }}
           />
         }

--- a/packages/wallets/src/components/offers/OfferShareDialog.tsx
+++ b/packages/wallets/src/components/offers/OfferShareDialog.tsx
@@ -46,6 +46,7 @@ type CommonDialogProps = {
 type OfferShareOfferBinDialogProps = CommonOfferProps & CommonDialogProps;
 type OfferShareHashgreenDialogProps = CommonOfferProps & CommonDialogProps;
 type OfferShareKeybaseDialogProps = CommonOfferProps & CommonDialogProps;
+type OfferShareOfferpoolDialogProps = CommonOfferProps & CommonDialogProps;
 
 async function writeTempOfferFile(offerData: string, filename: string): Promise<string> {
   const ipcRenderer = (window as any).ipcRenderer;
@@ -269,6 +270,36 @@ async function postToKeybase(
     }
   }
   return success;
+}
+
+type PostToOfferpoolResponse = {
+  success: boolean,
+  error_message?: string
+}
+
+// Posts the offer data to offerpool and returns success and an error_message on failure
+async function postToOfferpool(offerData: string): Promise<PostToOfferpoolResponse> {
+  const ipcRenderer = (window as any).ipcRenderer;
+  const requestOptions = {
+    method: 'POST',
+    protocol: 'https:',
+    hostname: 'offerpool.io',
+    port: 443,
+    path: '/api/v1/offers',
+  };
+  const requestHeaders = {
+    'Content-Type': 'application/json',
+  }
+  const requestData = JSON.stringify({offer: offerData});
+  const { err, statusCode, statusMessage, responseBody } = await ipcRenderer.invoke('fetchTextResponse', requestOptions, requestHeaders, requestData);
+
+  if (err || (statusCode !== 200 && statusCode !== 400)) {
+    const error = new Error(`offerpool upload failed: ${err}, statusCode=${statusCode}, statusMessage=${statusMessage}, response=${responseBody}`);
+    throw error;
+  }
+
+  console.log('offerpool upload completed');
+  return JSON.parse(responseBody);
 }
 
 function OfferShareOfferBinDialog(props: OfferShareOfferBinDialogProps) {
@@ -784,6 +815,113 @@ OfferShareKeybaseDialog.defaultProps = {
   onClose: () => {},
 };
 
+function OfferShareOfferpoolDialog(props: OfferShareOfferpoolDialogProps) {
+  const { offerRecord, offerData, onClose, open } = props;
+  const showError = useShowError();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [offerResponse, setOfferResponse] = React.useState<PostToOfferpoolResponse>();
+
+  function handleClose() {
+    onClose(false);
+  }
+
+  async function handleConfirm() {
+    try {
+      setIsSubmitting(true);
+
+      const result = await postToOfferpool(offerData);
+
+      console.log(`offerpool result ${JSON.stringify(result)}`);
+      setOfferResponse(result);
+    }
+    catch (e) {
+      showError(e);
+    }
+    finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (offerResponse) {
+    return (
+      <Dialog
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+        maxWidth="xs"
+        open={open}
+        onClose={handleClose}
+        fullWidth
+      >
+        <DialogTitle>
+          <Trans>Offer Shared</Trans>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Flex flexDirection="column" gap={3}>
+            <Trans>
+              {offerResponse.success
+                ? 'Your offer has been successfully posted to offerpool.'
+                : `Error posting offer: ${offerResponse.error_message}`}
+            </Trans>
+          </Flex>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary" variant="contained">
+            <Trans>Close</Trans>
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      maxWidth="sm"
+      open={open}
+      fullWidth
+    >
+      <DialogTitle id="alert-dialog-title">
+        <Trans>Share on offerpool</Trans>
+      </DialogTitle>
+      <DialogContent dividers>
+        <OfferSummary
+          isMyOffer={true}
+          summary={offerRecord.summary}
+          makerTitle={<Typography variant="subtitle1"><Trans>Your offer:</Trans></Typography>}
+          takerTitle={<Typography variant="subtitle1"><Trans>In exchange for:</Trans></Typography>}
+          rowIndentation={4}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Flex flexGrow={1}></Flex>
+        <Button
+          onClick={handleClose}
+          color="primary"
+          variant="contained"
+          disabled={isSubmitting}
+        >
+          <Trans>Cancel</Trans>
+        </Button>
+        <ButtonLoading
+          onClick={handleConfirm}
+          color="secondary"
+          variant="contained"
+          loading={isSubmitting}
+        >
+          <Trans>Share</Trans>
+        </ButtonLoading>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+OfferShareOfferpoolDialog.defaultProps = {
+  open: false,
+  onClose: () => {},
+};
+
 type OfferShareDialogProps = CommonOfferProps & CommonDialogProps & {
   showSuppressionCheckbox: boolean;
 };
@@ -812,6 +950,12 @@ export default function OfferShareDialog(props: OfferShareDialogProps) {
   async function handleKeybase() {
     await openDialog(
       <OfferShareKeybaseDialog offerRecord={offerRecord} offerData={offerData} />
+    );
+  }
+
+  async function handleOfferpool() {
+    await openDialog(
+      <OfferShareOfferpoolDialog offerRecord={offerRecord} offerData={offerData} />
     );
   }
 
@@ -849,6 +993,15 @@ export default function OfferShareDialog(props: OfferShareDialogProps) {
                 onClick={handleHashgreen}
               >
                 Hashgreen DEX
+              </Button>
+              <Button
+                variant="contained"
+                color="default"
+                onClick={handleOfferpool}
+              >
+                <Flex flexDirection="column">
+                  offerpool
+                </Flex>
               </Button>
               <Button
                 variant="contained"


### PR DESCRIPTION
This PR adds offerpool as an option in the offer share dialog.

Fixes a bug where sharing was broken when the dialog launched after creating an offer because the offer property was not yet set.