### PR TITLE
Invalidate txns+count when using "Delete Unconfirmed Transactions"

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -4,7 +4,7 @@ import onCacheEntryAddedInvalidate from '../utils/onCacheEntryAddedInvalidate';
 import normalizePoolState from '../utils/normalizePoolState';
 import api, { baseQuery } from '../api';
 
-const apiWithTag = api.enhanceEndpoints({addTagTypes: ['Keys', 'Wallets', 'WalletBalance', 'Address', 'Transactions', 'WalletConnections', 'LoggedInFingerprint', 'PoolWalletStatus', 'NFTs', 'OfferTradeRecord', 'OfferCounts']});
+const apiWithTag = api.enhanceEndpoints({addTagTypes: ['Keys', 'Wallets', 'WalletBalance', 'Address', 'Transactions', 'TransactionCount', 'WalletConnections', 'LoggedInFingerprint', 'PoolWalletStatus', 'NFTs', 'OfferTradeRecord', 'OfferCounts']});
 
 type OfferCounts = {
   total: number;
@@ -222,7 +222,7 @@ export const walletApi = apiWithTag.injectEndpoints({
       invalidatesTags: [{ type: 'Wallets', id: 'LIST' }],
     }),
 
-    deleteUnconfirmedTransactions: build.mutation<any, { 
+    deleteUnconfirmedTransactions: build.mutation<any, {
       walletId: number;
     }>({
       query: ({ walletId }) => ({
@@ -230,8 +230,12 @@ export const walletApi = apiWithTag.injectEndpoints({
         service: Wallet,
         args: [walletId],
       }),
+      invalidatesTags: [
+        { type: 'Transactions', id: 'LIST' },
+        'TransactionCount',
+      ],
     }),
-  
+
     getWalletBalance: build.query<{
       confirmedWalletBalance: number;
       maxSendAmount: number;
@@ -630,6 +634,7 @@ export const walletApi = apiWithTag.injectEndpoints({
         args: [walletId],
       }),
       transformResponse: (response: any) => response?.count,
+      providesTags: ['TransactionCount'],
       onCacheEntryAdded: onCacheEntryAddedInvalidate(baseQuery, [{
         command: 'onCoinAdded',
         service: Wallet,

--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -230,9 +230,9 @@ export const walletApi = apiWithTag.injectEndpoints({
         service: Wallet,
         args: [walletId],
       }),
-      invalidatesTags: [
+      invalidatesTags: (_result, _error, { walletId }) => [
         { type: 'Transactions', id: 'LIST' },
-        'TransactionCount',
+        { type: 'TransactionCount', id: walletId },
       ],
     }),
 
@@ -634,7 +634,9 @@ export const walletApi = apiWithTag.injectEndpoints({
         args: [walletId],
       }),
       transformResponse: (response: any) => response?.count,
-      providesTags: ['TransactionCount'],
+      providesTags: (result, _error, { walletId }) => result
+        ? [{ type: 'TransactionCount', id: walletId }]
+        : [],
       onCacheEntryAdded: onCacheEntryAddedInvalidate(baseQuery, [{
         command: 'onCoinAdded',
         service: Wallet,


### PR DESCRIPTION
When using the "Delete Unconfirmed Transactions" action, pending transactions will continue to appear in the transaction list.

This fix will cause the useDeleteUnconfirmedTransactionsMutation hook to invalidate the Transactions cache, as well as the (newly added) TransactionCount cache.

Issue #648 