### PR TITLE
Better handling of mempool full errors

### DIFF
--- a/packages/wallets/src/components/WalletSend.tsx
+++ b/packages/wallets/src/components/WalletSend.tsx
@@ -6,7 +6,6 @@ import {
   useFarmBlockMutation,
 } from '@chia/api-react';
 import {
-  AlertDialog,
   Amount,
   ButtonLoading,
   Fee,

--- a/packages/wallets/src/components/WalletSend.tsx
+++ b/packages/wallets/src/components/WalletSend.tsx
@@ -26,6 +26,7 @@ import {
   Grid,
 } from '@material-ui/core';
 import useWallet from '../hooks/useWallet';
+import CreateWalletSendTransactionResultDialog from './WalletSendTransactionResultDialog';
 
 type SendCardProps = {
   walletId: number;
@@ -116,13 +117,12 @@ export default function WalletSend(props: SendCardProps) {
     }).unwrap();
 
     const result = getTransactionResult(response.transaction);
-    if (result.success) {
-        openDialog(
-          <AlertDialog title={<Trans>Success</Trans>}>
-            {result.message ?? <Trans>Transaction has successfully been sent to a full node and included in the mempool.</Trans>}
-          </AlertDialog>,
-        );
-    } else {
+    const resultDialog = CreateWalletSendTransactionResultDialog({success: result.success, message: result.message});
+
+    if (resultDialog) {
+      await openDialog(resultDialog);
+    }
+    else {
       throw new Error(result.message ?? 'Something went wrong');
     }
 

--- a/packages/wallets/src/components/WalletSendTransactionResultDialog.tsx
+++ b/packages/wallets/src/components/WalletSendTransactionResultDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import {
   AlertDialog,
   Flex,

--- a/packages/wallets/src/components/WalletSendTransactionResultDialog.tsx
+++ b/packages/wallets/src/components/WalletSendTransactionResultDialog.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Trans, t } from '@lingui/macro';
+import {
+  AlertDialog,
+  Flex,
+} from '@chia/core';
+
+type WalletSendTransactionResultDialogProps = {
+  success: boolean;
+  message: string;
+};
+
+function WalletSendTransactionResultDialogTitle(success: boolean, message: string): React.ReactElement | undefined {
+  if (success) {
+    return <Trans>Success</Trans>;
+  }
+  else {
+    if (message === "INVALID_FEE_TOO_CLOSE_TO_ZERO" || message === "INVALID_FEE_LOW_FEE") {
+      return <Trans>Mempool Full</Trans>;
+    }
+  }
+  return undefined;
+}
+
+function WalletSendTransactionResultDialogContent(success: boolean, message: string): React.ReactElement | string | undefined {
+  if (success) {
+    return message ?? <Trans>Transaction has successfully been sent to a full node and included in the mempool.</Trans>
+  }
+  else {
+    if (message === "INVALID_FEE_TOO_CLOSE_TO_ZERO" || message === "INVALID_FEE_LOW_FEE") {
+      return (
+        <Flex flexDirection="column" gap={3}>
+          <Flex>
+            <Trans>
+              The transaction could not be immediately included in the mempool because the specified fee is
+              too low. The transaction will be retried periodically, and may be included in the mempool once
+              fees are lower, or if space becomes available.
+            </Trans>
+          </Flex>
+          <Flex>
+            <Trans>
+              If you would like to speed up the transaction, please delete unconfirmed transactions and retry
+              with a higher fee.
+            </Trans>
+          </Flex>
+        </Flex>
+      );
+    }
+  }
+  return undefined;
+}
+
+export default function CreateWalletSendTransactionResultDialog(props: WalletSendTransactionResultDialogProps): React.ReactElement | undefined {
+  const { success, message, ...rest } = props;
+  const title = WalletSendTransactionResultDialogTitle(success, message);
+  const content = WalletSendTransactionResultDialogContent(success, message);
+
+  if (title && content) {
+    return (
+      <AlertDialog title={title} {...rest}>
+        {content}
+      </AlertDialog>
+    );
+  }
+  return undefined;
+}

--- a/packages/wallets/src/components/cat/WalletCATSend.tsx
+++ b/packages/wallets/src/components/cat/WalletCATSend.tsx
@@ -29,6 +29,7 @@ import { useForm, useWatch } from 'react-hook-form';
 import { Button, Grid } from '@material-ui/core';
 import useWallet from '../../hooks/useWallet';
 import useWalletState from '../../hooks/useWalletState';
+import CreateWalletSendTransactionResultDialog from '../WalletSendTransactionResultDialog';
 
 type Props = {
   walletId: number;
@@ -158,13 +159,12 @@ export default function WalletCATSend(props: Props) {
     const response = await spendCAT(queryData).unwrap();
 
     const result = getTransactionResult(response.transaction);
-    if (result.success) {
-        openDialog(
-          <AlertDialog title={<Trans>Success</Trans>}>
-            {result.message ?? <Trans>Transaction has successfully been sent to a full node and included in the mempool.</Trans>}
-          </AlertDialog>,
-        );
-    } else {
+    const resultDialog = CreateWalletSendTransactionResultDialog({success: result.success, message: result.message});
+
+    if (resultDialog) {
+      await openDialog(resultDialog);
+    }
+    else {
       throw new Error(result.message ?? 'Something went wrong');
     }
 

--- a/packages/wallets/src/components/cat/WalletCATSend.tsx
+++ b/packages/wallets/src/components/cat/WalletCATSend.tsx
@@ -4,7 +4,6 @@ import {
   AdvancedOptions,
   Fee,
   Form,
-  AlertDialog,
   Flex,
   Card,
   ButtonLoading,


### PR DESCRIPTION
Added WalletSendTransactionResultDialog as a home for confirmations/errors when sending a txn.

Added more detailed messages when sending a txn fails due to the mempool being full (fee too low).