### PR TITLE
autocomplete fix

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.tsx
@@ -77,6 +77,9 @@ export default function Autocomplete(props: Props) {
 
   return (
     <MaterialAutocomplete
+      autoComplete
+      autoHighlight
+      autoSelect
       options={options}
       filterOptions={filterOptions}
       onChange={(_e, newValue) => handleChange(newValue)}


### PR DESCRIPTION
Made it so that on the import from mnemonics page, while a word in the dropdown list is highlighted, pressing tab autofills that word in the text field and the cursor moves to the next text field.