### PR TITLE
Added checkbox for keeping service running background after GUI closes

### DIFF
--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -478,16 +478,26 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
     // if (!guessPackaged()) {
     //   mainWindow.webContents.openDevTools();
     // }
-    mainWindow.on('close', (e) => {
+    mainWindow.on('close', async (e) => {
       // if the daemon isn't local we aren't going to try to start/stop it
       if (decidedToClose || !manageDaemonLifetime(NET)) {
         return;
       }
+      if (!mainWindow) {
+        throw new Error('`mainWindow` is empty');
+      }
       e.preventDefault();
+
       if (!isClosing) {
         isClosing = true;
+        let keepBackgroundRunning: boolean | undefined;
+        const p = readPrefs();
+        if (typeof p.keepBackgroundRunning === 'boolean') {
+          keepBackgroundRunning = p.keepBackgroundRunning;
+        }
+
         if (promptOnQuit) {
-          const choice = dialog.showMessageBoxSync({
+          const choice = await dialog.showMessageBox({
             type: 'question',
             buttons: [i18n._(/* i18n */ { id: 'No' }), i18n._(/* i18n */ { id: 'Yes' })],
             title: i18n._(/* i18n */ { id: 'Confirm' }),
@@ -496,22 +506,36 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
                 id: 'Are you sure you want to quit?',
               }
             ),
+            checkboxChecked: keepBackgroundRunning ?? false,
+            checkboxLabel: i18n._(/* i18n */ { id: 'Keep service running background' }),
           });
-          if (choice === 0) {
+          if (keepBackgroundRunning !== choice.checkboxChecked) {
+            savePrefs({ ...p, keepBackgroundRunning: choice.checkboxChecked });
+          }
+          if (choice.response === 0) {
             isClosing = false;
             return;
           }
+          keepBackgroundRunning = choice.checkboxChecked;
         }
         isClosing = false;
         decidedToClose = true;
-        mainWindow.webContents.send('exit-daemon');
+
         // save the window state and unmange so we don't restore the mini exiting state
         mainWindowState.saveState(mainWindow);
-        mainWindowState.unmanage(mainWindow);
+        mainWindowState.unmanage();
+
+        if (keepBackgroundRunning) {
+          mainWindow.close();
+          openedWindows.forEach((win) => win.close());
+          return;
+        }
+
+        mainWindow.webContents.send('exit-daemon');
         mainWindow.setBounds({ height: 500, width: 500 });
         mainWindow.center();
         ipcMain.on('daemon-exited', () => {
-          mainWindow.close();
+          mainWindow?.close();
 
           openedWindows.forEach((win) => win.close());
         });

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -507,7 +507,7 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
               }
             ),
             checkboxChecked: keepBackgroundRunning ?? false,
-            checkboxLabel: i18n._(/* i18n */ { id: 'Keep service running background' }),
+            checkboxLabel: i18n._(/* i18n */ { id: 'Keep service running in the background' }),
           });
           if (keepBackgroundRunning !== choice.checkboxChecked) {
             savePrefs({ ...p, keepBackgroundRunning: choice.checkboxChecked });


### PR DESCRIPTION
# Change summary
- Added a checkbox to toggle on/off whether to keep services running background
- Save checkbox value to prefs.yaml
- Restore checkbox value from prefs.yaml

# Alert
Users may easily forget that they have Chia services running in the background, even when they're trying to update the app. Perhaps it would be beneficial to notify people to ensure they shut down the Chia-blockchain app.
