### PR TITLE
UI flow for transferring an NFT to a new owner

### DIFF
--- a/packages/api-react/src/services/index.ts
+++ b/packages/api-react/src/services/index.ts
@@ -132,8 +132,22 @@ export const {
   useAddCATTokenMutation,
   useGetStrayCatsQuery,
 
-  // NFTs
+  // PlotNFTs
   useGetPlotNFTsQuery,
+
+  // DID
+  useCreateNewDIDWalletMutation,
+  useUpdateDIDRecoveryIdsQuery,
+  useGetDIDPubKeyQuery,
+  useGetDIDQuery,
+  useGetDIDRecoveryListQuery,
+  useGetDIDInformationNeededForRecoveryQuery,
+  useGetDIDCurrentCoinInfoQuery,
+
+  // NFTs
+  useGetCurrentNFTsQuery,
+  useTransferNFTMutation,
+  useReceiveNFTMutation,
 } = wallet;
 
 // harvester hooks

--- a/packages/api/src/wallets/NFT.ts
+++ b/packages/api/src/wallets/NFT.ts
@@ -11,17 +11,14 @@ export default class DIDWallet extends Wallet {
     walletId: number,
     nftCoinInfo: any,
     newDid: string,
-    newDidParent: string,
     newDidInnerHash: string,
-    newDidAmount: number,
-    tradePrice: number) {
+    tradePrice: number
+  ) {
     return this.command('nft_transfer_nft', {
       walletId,
       nftCoinInfo,
       newDid,
-      newDidParent,
       newDidInnerHash,
-      newDidAmount,
       tradePrice,
     });
   }

--- a/packages/api/src/wallets/index.ts
+++ b/packages/api/src/wallets/index.ts
@@ -1,4 +1,5 @@
 export { default as CAT } from './CAT';
 export { default as DID } from './DID';
+export { default as NFT } from './NFT';
 export { default as Pool } from './Pool';
 export { default as RL } from './RL';

--- a/packages/gui/src/components/nfts/NFTTransferAction.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferAction.tsx
@@ -1,0 +1,196 @@
+import React, { useState } from 'react';
+import { Trans } from '@lingui/macro';
+import {
+  Button,
+  ButtonLoading,
+  ConfirmDialog,
+  Fee,
+  Form,
+  Flex,
+  TextField,
+  useOpenDialog,
+} from '@chia/core';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+import { useForm } from 'react-hook-form';
+
+type NFTTransferFormData = {
+  destinationDID: string;
+  fee: string;
+};
+
+type NFTTransferActionProps = {
+  nftAssetId: string;
+  destinationDID?: string;
+  onComplete?: (success: boolean) => void;
+};
+
+export default function NFTTransferAction(props: NFTTransferActionProps) {
+  const { nftAssetId, destinationDID, onComplete } = props;
+  const [isLoading, setIsLoading] = useState(false);
+  const openDialog = useOpenDialog();
+  const methods = useForm<NFTTransferFormData>({
+    shouldUnregister: false,
+    defaultValues: {
+      destinationDID: destinationDID || '',
+      fee: '',
+    },
+  });
+
+  async function handleClose() {
+    console.log('handleClose called in NFTs');
+    if (onComplete) {
+      onComplete(false);
+    }
+  }
+
+  async function handleSubmit(formData: NFTTransferFormData) {
+    const { destinationDID } = formData;
+    let isValid = true;
+    let confirmation = false;
+    console.log('handleSubmit called in NFTTransferAction');
+    console.log(formData);
+
+    if (isValid) {
+      confirmation = await openDialog(
+        <ConfirmDialog
+          title={<Trans>Confirm NFT Transfer</Trans>}
+          confirmTitle={<Trans>Transfer</Trans>}
+          confirmColor="secondary"
+          cancelTitle={<Trans>Cancel</Trans>}
+        >
+          <Trans>
+            Once you initiate this transfer, you will not be able to cancel the
+            transaction. Are you sure you want to transfer the NFT?
+          </Trans>
+        </ConfirmDialog>
+      );
+    }
+
+    if (confirmation) {
+      setIsLoading(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
+      setIsLoading(false);
+
+      if (onComplete) {
+        onComplete(true);
+      }
+    }
+  }
+
+  return (
+    <Form methods={methods} onSubmit={handleSubmit}>
+      <Flex flexDirection="column" gap={3}>
+        <Trans>NFT Asset ID:</Trans>
+        <Typography variant="body1">{nftAssetId}</Typography>
+        <TextField
+          name="destinationDID"
+          variant="filled"
+          color="secondary"
+          fullWidth
+          label={<Trans>Send to Address / Puzzle hash</Trans>}
+          disabled={isLoading}
+          required
+        />
+        <Fee
+          id="filled-secondary"
+          variant="filled"
+          name="fee"
+          color="secondary"
+          label={<Trans>Fee</Trans>}
+          disabled={isLoading}
+        />
+        <DialogActions>
+          <Flex flexDirection="row" gap={3}>
+            <Button
+              onClick={handleClose}
+              color="secondary"
+              variant="outlined"
+              autoFocus
+            >
+              <Trans>Close</Trans>
+            </Button>
+            <ButtonLoading
+              type="submit"
+              autoFocus
+              color="primary"
+              variant="contained"
+              loading={isLoading}
+            >
+              <Trans>Transfer</Trans>
+            </ButtonLoading>
+          </Flex>
+        </DialogActions>
+      </Flex>
+    </Form>
+  );
+}
+
+type NFTTransferDialogProps = {
+  open: boolean;
+  onClose: (value: any) => void;
+  onComplete?: (success: boolean) => void;
+  nftAssetId: string;
+  destinationDID?: string;
+};
+
+export function NFTTransferDialog(props: NFTTransferDialogProps) {
+  const { open, onClose, onComplete, nftAssetId, destinationDID, ...rest } =
+    props;
+
+  function handleClose() {
+    console.log('handleClose called in NFTTransferDialog');
+    onClose(false);
+  }
+
+  function handleCompletion(success: boolean) {
+    console.log('handleCompletion called in NFTTransferDialog');
+    onClose(success);
+    if (onComplete) {
+      onComplete(success);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="nft-transfer-dialog-title"
+      aria-describedby="nft-transfer-dialog-description"
+      maxWidth="sm"
+      fullWidth
+      {...rest}
+    >
+      <DialogTitle id="nft-transfer-dialog-title">
+        <Trans>Transfer NFT</Trans>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="nft-transfer-dialog-description">
+          <Trans>
+            Would you like to transfer the specified NFT to a new owner? It is
+            recommended that you include a fee to ensure that the transaction is
+            completed in a timely manner.
+          </Trans>
+        </DialogContentText>
+        <NFTTransferAction
+          nftAssetId={nftAssetId}
+          destinationDID={destinationDID}
+          onComplete={handleCompletion}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+NFTTransferDialog.defaultProps = {
+  open: false,
+  onClose: () => {},
+};

--- a/packages/gui/src/components/nfts/NFTTransferAction.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferAction.tsx
@@ -1,57 +1,166 @@
-import React, { useState } from 'react';
-import { Trans } from '@lingui/macro';
+import React, { useMemo, useState } from 'react';
+import { Plural, Trans } from '@lingui/macro';
 import {
   Button,
   ButtonLoading,
   ConfirmDialog,
   Fee,
   Form,
+  FormatLargeNumber,
   Flex,
   TextField,
+  chiaToMojo,
+  useCurrencyCode,
   useOpenDialog,
 } from '@chia/core';
 import {
+  Box,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Divider,
   Typography,
 } from '@mui/material';
 import { useForm } from 'react-hook-form';
 
+// Temporary: Used by getFakeNFTName
+import seedrandom from 'seedrandom';
+import {
+  uniqueNamesGenerator,
+  adjectives,
+  colors,
+  animals,
+} from 'unique-names-generator';
+
+/* ========================================================================== */
+/*                              NFTTransferResult                             */
+/* ========================================================================== */
+
+export type NFTTransferResult = {
+  success: boolean;
+  transferInfo?: {
+    nftAssetId: string;
+    destinationDID: string;
+    destinationInnerPH: string;
+    fee: string;
+  };
+  error?: string;
+};
+
+/* ========================================================================== */
+/*                      NFT Transfer Confirmation Dialog                      */
+/* ========================================================================== */
+
+type NFTTransferConfirmationDialogProps = NFTTransferFormData & {
+  open: boolean; // For use in openDialog()
+};
+
+function NFTTransferConfirmationDialog(
+  props: NFTTransferConfirmationDialogProps,
+) {
+  const { destinationDID, destinationInnerPH, fee, ...rest } = props;
+  const feeInMojos = chiaToMojo(fee || 0);
+  const currencyCode = useCurrencyCode();
+
+  return (
+    <ConfirmDialog
+      title={<Trans>Confirm NFT Transfer</Trans>}
+      confirmTitle={<Trans>Transfer</Trans>}
+      confirmColor="secondary"
+      cancelTitle={<Trans>Cancel</Trans>}
+      {...rest}
+    >
+      <Flex flexDirection="column" gap={3}>
+        <Typography variant="body1">
+          <Trans>
+            Once you initiate this transfer, you will not be able to cancel the
+            transaction. Are you sure you want to transfer the NFT?
+          </Trans>
+        </Typography>
+        <Divider />
+        <Flex flexDirection="column" gap={1}>
+          <Flex flexDirection="row" gap={1}>
+            <Typography variant="body1">
+              <Trans>Destination:</Trans>
+            </Typography>
+            <Typography variant="body1">{destinationDID}</Typography>
+          </Flex>
+          <Flex flexDirection="row" gap={1}>
+            <Typography variant="body1">
+              <Trans>Destination Inner Puzzle Hash:</Trans>
+            </Typography>
+            <Typography variant="body1">{destinationInnerPH}</Typography>
+          </Flex>
+          <Flex flexDirection="row" gap={1}>
+            <Typography variant="body1">Fee:</Typography>
+            <Typography variant="body1">
+              {fee || '0'} {currencyCode}
+            </Typography>
+            {feeInMojos > 0 && (
+              <>
+                (
+                <FormatLargeNumber value={feeInMojos} />
+                <Box>
+                  <Plural
+                    value={feeInMojos.toNumber()}
+                    one="mojo"
+                    other="mojos"
+                  />
+                </Box>
+                )
+              </>
+            )}
+          </Flex>
+        </Flex>
+      </Flex>
+    </ConfirmDialog>
+  );
+}
+
+NFTTransferConfirmationDialog.defaultProps = {
+  open: false,
+};
+
+/* ========================================================================== */
+/*                         NFT Transfer Action (Form)                         */
+/* ========================================================================== */
+
 type NFTTransferFormData = {
   destinationDID: string;
+  destinationInnerPH: string;
   fee: string;
 };
 
 type NFTTransferActionProps = {
   nftAssetId: string;
   destinationDID?: string;
-  onComplete?: (success: boolean) => void;
+  destinationInnerPH?: string;
+  onComplete?: (result?: NFTTransferResult) => void;
 };
 
 export default function NFTTransferAction(props: NFTTransferActionProps) {
-  const { nftAssetId, destinationDID, onComplete } = props;
+  const { nftAssetId, destinationDID, destinationInnerPH, onComplete } = props;
   const [isLoading, setIsLoading] = useState(false);
   const openDialog = useOpenDialog();
   const methods = useForm<NFTTransferFormData>({
     shouldUnregister: false,
     defaultValues: {
       destinationDID: destinationDID || '',
+      destinationInnerPH: destinationInnerPH || '',
       fee: '',
     },
   });
 
   async function handleClose() {
-    console.log('handleClose called in NFTs');
     if (onComplete) {
-      onComplete(false);
+      onComplete(); // No result provided if the user cancels out of the dialog
     }
   }
 
   async function handleSubmit(formData: NFTTransferFormData) {
-    const { destinationDID } = formData;
+    const { destinationDID, destinationInnerPH, fee } = formData;
     let isValid = true;
     let confirmation = false;
     console.log('handleSubmit called in NFTTransferAction');
@@ -59,29 +168,37 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
 
     if (isValid) {
       confirmation = await openDialog(
-        <ConfirmDialog
-          title={<Trans>Confirm NFT Transfer</Trans>}
-          confirmTitle={<Trans>Transfer</Trans>}
-          confirmColor="secondary"
-          cancelTitle={<Trans>Cancel</Trans>}
-        >
-          <Trans>
-            Once you initiate this transfer, you will not be able to cancel the
-            transaction. Are you sure you want to transfer the NFT?
-          </Trans>
-        </ConfirmDialog>
+        <NFTTransferConfirmationDialog
+          destinationDID={destinationDID}
+          destinationInnerPH={destinationInnerPH}
+          fee={fee}
+        />,
       );
     }
 
     if (confirmation) {
       setIsLoading(true);
 
-      await new Promise((resolve) => setTimeout(resolve, 5000));
+      // TODO: Swap this out with a real NFT transfer call
+      const success: boolean = await new Promise(
+        (resolve) => setTimeout(() => resolve(true), 5000), // simulate success
+        // setTimeout(() => resolve(false), 5000),  // simulate failure
+      );
+      const errorMessage = 'Placeholder: Generic failure message';
 
       setIsLoading(false);
 
       if (onComplete) {
-        onComplete(true);
+        onComplete({
+          success,
+          transferInfo: {
+            nftAssetId,
+            destinationDID,
+            destinationInnerPH,
+            fee,
+          },
+          error: success ? undefined : errorMessage,
+        });
       }
     }
   }
@@ -89,14 +206,27 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
   return (
     <Form methods={methods} onSubmit={handleSubmit}>
       <Flex flexDirection="column" gap={3}>
-        <Trans>NFT Asset ID:</Trans>
-        <Typography variant="body1">{nftAssetId}</Typography>
+        <Flex flexDirection="row" gap={1}>
+          <Typography variant="body1">
+            <Trans>Asset ID:</Trans>
+          </Typography>
+          <Typography variant="body1">{nftAssetId}</Typography>
+        </Flex>
         <TextField
           name="destinationDID"
           variant="filled"
           color="secondary"
           fullWidth
-          label={<Trans>Send to Address / Puzzle hash</Trans>}
+          label={<Trans>Send to Address</Trans>}
+          disabled={isLoading}
+          required
+        />
+        <TextField
+          name="destinationInnerPH"
+          variant="filled"
+          color="secondary"
+          fullWidth
+          label={<Trans>Destination DID Inner Puzzle Hash</Trans>}
           disabled={isLoading}
           required
         />
@@ -134,10 +264,14 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
   );
 }
 
+/* ========================================================================== */
+/*                             NFT Transfer Dialog                            */
+/* ========================================================================== */
+
 type NFTTransferDialogProps = {
   open: boolean;
   onClose: (value: any) => void;
-  onComplete?: (success: boolean) => void;
+  onComplete?: (result?: NFTTransferResult) => void;
   nftAssetId: string;
   destinationDID?: string;
 };
@@ -146,16 +280,20 @@ export function NFTTransferDialog(props: NFTTransferDialogProps) {
   const { open, onClose, onComplete, nftAssetId, destinationDID, ...rest } =
     props;
 
+  const nftFakeName = useMemo(() => {
+    return getFakeNFTName(nftAssetId);
+  }, [nftAssetId]);
+
   function handleClose() {
     console.log('handleClose called in NFTTransferDialog');
     onClose(false);
   }
 
-  function handleCompletion(success: boolean) {
+  function handleCompletion(result?: NFTTransferResult) {
     console.log('handleCompletion called in NFTTransferDialog');
-    onClose(success);
+    onClose(true);
     if (onComplete) {
-      onComplete(success);
+      onComplete(result);
     }
   }
 
@@ -170,21 +308,28 @@ export function NFTTransferDialog(props: NFTTransferDialogProps) {
       {...rest}
     >
       <DialogTitle id="nft-transfer-dialog-title">
-        <Trans>Transfer NFT</Trans>
+        <Flex flexDirection="row" gap={1}>
+          <Typography variant="h6">
+            <Trans>Transfer NFT: </Trans>
+          </Typography>
+          <Typography variant="h6">{nftFakeName}</Typography>
+        </Flex>
       </DialogTitle>
       <DialogContent>
-        <DialogContentText id="nft-transfer-dialog-description">
-          <Trans>
-            Would you like to transfer the specified NFT to a new owner? It is
-            recommended that you include a fee to ensure that the transaction is
-            completed in a timely manner.
-          </Trans>
-        </DialogContentText>
-        <NFTTransferAction
-          nftAssetId={nftAssetId}
-          destinationDID={destinationDID}
-          onComplete={handleCompletion}
-        />
+        <Flex flexDirection="column" gap={3}>
+          <DialogContentText id="nft-transfer-dialog-description">
+            <Trans>
+              Would you like to transfer the specified NFT to a new owner? It is
+              recommended that you include a fee to ensure that the transaction
+              is completed in a timely manner.
+            </Trans>
+          </DialogContentText>
+          <NFTTransferAction
+            nftAssetId={nftAssetId}
+            destinationDID={destinationDID}
+            onComplete={handleCompletion}
+          />
+        </Flex>
       </DialogContent>
     </Dialog>
   );
@@ -194,3 +339,38 @@ NFTTransferDialog.defaultProps = {
   open: false,
   onClose: () => {},
 };
+
+/* ========================================================================== */
+/*                              Utility Functions                             */
+/* ========================================================================== */
+
+const uniqueNames: {
+  [key: string]: string;
+} = {};
+
+function getFakeNFTName(seed: string, iteration = 0): string {
+  const computedName = Object.keys(uniqueNames).find(
+    (key) => uniqueNames[key] === seed,
+  );
+  if (computedName) {
+    return computedName;
+  }
+
+  const generator = seedrandom(iteration ? `${seed}-${iteration}` : seed);
+
+  const uniqueName = uniqueNamesGenerator({
+    dictionaries: [colors, animals, adjectives],
+    length: 2,
+    seed: generator.int32(),
+    separator: ' ',
+    style: 'capital',
+  });
+
+  if (uniqueNames[uniqueName] && uniqueNames[uniqueName] !== seed) {
+    return getFakeNFTName(seed, iteration + 1);
+  }
+
+  uniqueNames[uniqueName] = seed;
+
+  return uniqueName;
+}

--- a/packages/gui/src/components/nfts/NFTTransferAction.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferAction.tsx
@@ -97,16 +97,60 @@ function NFTTransferConfirmationDialog(
         <Divider />
         <Flex flexDirection="column" gap={1}>
           <Flex flexDirection="row" gap={1}>
-            <Typography variant="body1">
-              <Trans>Destination:</Trans>
-            </Typography>
-            <Typography variant="body1">{destinationDID}</Typography>
+            <Flex flexShrink={0}>
+              <Typography variant="body1">
+                <Trans>Destination:</Trans>
+              </Typography>
+            </Flex>
+            <Flex
+              flexDirection="row"
+              alignItems="center"
+              gap={1}
+              sx={{ overflow: 'hidden' }}
+            >
+              <Typography noWrap variant="body1">
+                {destinationDID}
+              </Typography>
+              <TooltipIcon interactive>
+                <Flex flexDirection="column" gap={1}>
+                  <StyledTitle>
+                    <Trans>Destination</Trans>
+                  </StyledTitle>
+                  <StyledValue>
+                    <Typography variant="caption">{destinationDID}</Typography>
+                  </StyledValue>
+                </Flex>
+              </TooltipIcon>
+            </Flex>
           </Flex>
           <Flex flexDirection="row" gap={1}>
-            <Typography variant="body1">
-              <Trans>Destination Inner Puzzle Hash:</Trans>
-            </Typography>
-            <Typography variant="body1">{destinationInnerPH}</Typography>
+            <Flex flexShrink={0}>
+              <Typography variant="body1">
+                <Trans>Destination Inner Puzzle Hash:</Trans>
+              </Typography>
+            </Flex>
+            <Flex
+              flexDirection="row"
+              alignItems="center"
+              gap={1}
+              sx={{ overflow: 'hidden' }}
+            >
+              <Typography noWrap variant="body1">
+                {destinationInnerPH}
+              </Typography>
+              <TooltipIcon interactive>
+                <Flex flexDirection="column" gap={1}>
+                  <StyledTitle>
+                    <Trans>Destination Inner Puzzle Hash</Trans>
+                  </StyledTitle>
+                  <StyledValue>
+                    <Typography variant="caption">
+                      {destinationInnerPH}
+                    </Typography>
+                  </StyledValue>
+                </Flex>
+              </TooltipIcon>
+            </Flex>
           </Flex>
           <Flex flexDirection="row" gap={1}>
             <Typography variant="body1">Fee:</Typography>

--- a/packages/gui/src/components/nfts/NFTTransferAction.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferAction.tsx
@@ -58,7 +58,6 @@ export type NFTTransferResult = {
   transferInfo?: {
     nftAssetId: string;
     destinationDID: string;
-    destinationInnerPH: string;
     fee: string;
   };
   error?: string;
@@ -75,7 +74,7 @@ type NFTTransferConfirmationDialogProps = NFTTransferFormData & {
 function NFTTransferConfirmationDialog(
   props: NFTTransferConfirmationDialogProps,
 ) {
-  const { destinationDID, destinationInnerPH, fee, ...rest } = props;
+  const { destinationDID, fee, ...rest } = props;
   const feeInMojos = chiaToMojo(fee || 0);
   const currencyCode = useCurrencyCode();
 
@@ -124,35 +123,6 @@ function NFTTransferConfirmationDialog(
             </Flex>
           </Flex>
           <Flex flexDirection="row" gap={1}>
-            <Flex flexShrink={0}>
-              <Typography variant="body1">
-                <Trans>Destination Inner Puzzle Hash:</Trans>
-              </Typography>
-            </Flex>
-            <Flex
-              flexDirection="row"
-              alignItems="center"
-              gap={1}
-              sx={{ overflow: 'hidden' }}
-            >
-              <Typography noWrap variant="body1">
-                {destinationInnerPH}
-              </Typography>
-              <TooltipIcon interactive>
-                <Flex flexDirection="column" gap={1}>
-                  <StyledTitle>
-                    <Trans>Destination Inner Puzzle Hash</Trans>
-                  </StyledTitle>
-                  <StyledValue>
-                    <Typography variant="caption">
-                      {destinationInnerPH}
-                    </Typography>
-                  </StyledValue>
-                </Flex>
-              </TooltipIcon>
-            </Flex>
-          </Flex>
-          <Flex flexDirection="row" gap={1}>
             <Typography variant="body1">Fee:</Typography>
             <Typography variant="body1">
               {fee || '0'} {currencyCode}
@@ -188,7 +158,6 @@ NFTTransferConfirmationDialog.defaultProps = {
 
 type NFTTransferFormData = {
   destinationDID: string;
-  destinationInnerPH: string;
   fee: string;
 };
 
@@ -196,25 +165,17 @@ type NFTTransferActionProps = {
   nftAssetId: string;
   nftName: string;
   destinationDID?: string;
-  destinationInnerPH?: string;
   onComplete?: (result?: NFTTransferResult) => void;
 };
 
 export default function NFTTransferAction(props: NFTTransferActionProps) {
-  const {
-    nftAssetId,
-    nftName,
-    destinationDID,
-    destinationInnerPH,
-    onComplete,
-  } = props;
+  const { nftAssetId, nftName, destinationDID, onComplete } = props;
   const [isLoading, setIsLoading] = useState(false);
   const openDialog = useOpenDialog();
   const methods = useForm<NFTTransferFormData>({
     shouldUnregister: false,
     defaultValues: {
       destinationDID: destinationDID || '',
-      destinationInnerPH: destinationInnerPH || '',
       fee: '',
     },
   });
@@ -226,17 +187,14 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
   }
 
   async function handleSubmit(formData: NFTTransferFormData) {
-    const { destinationDID, destinationInnerPH, fee } = formData;
+    const { destinationDID, fee } = formData;
     let isValid = true;
     let confirmation = false;
-    console.log('handleSubmit called in NFTTransferAction');
-    console.log(formData);
 
     if (isValid) {
       confirmation = await openDialog(
         <NFTTransferConfirmationDialog
           destinationDID={destinationDID}
-          destinationInnerPH={destinationInnerPH}
           fee={fee}
         />,
       );
@@ -260,7 +218,6 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
           transferInfo: {
             nftAssetId,
             destinationDID,
-            destinationInnerPH,
             fee,
           },
           error: success ? undefined : errorMessage,
@@ -337,15 +294,6 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
           disabled={isLoading}
           required
         />
-        <TextField
-          name="destinationInnerPH"
-          variant="filled"
-          color="secondary"
-          fullWidth
-          label={<Trans>Destination DID Inner Puzzle Hash</Trans>}
-          disabled={isLoading}
-          required
-        />
         <Fee
           id="filled-secondary"
           variant="filled"
@@ -401,12 +349,10 @@ export function NFTTransferDialog(props: NFTTransferDialogProps) {
   }, [nftAssetId]);
 
   function handleClose() {
-    console.log('handleClose called in NFTTransferDialog');
     onClose(false);
   }
 
   function handleCompletion(result?: NFTTransferResult) {
-    console.log('handleCompletion called in NFTTransferDialog');
     onClose(true);
     if (onComplete) {
       onComplete(result);

--- a/packages/gui/src/components/nfts/NFTTransferAction.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferAction.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Plural, Trans } from '@lingui/macro';
+import styled from 'styled-components';
 import {
   Button,
   ButtonLoading,
@@ -9,6 +10,7 @@ import {
   FormatLargeNumber,
   Flex,
   TextField,
+  TooltipIcon,
   chiaToMojo,
   useCurrencyCode,
   useOpenDialog,
@@ -33,6 +35,19 @@ import {
   colors,
   animals,
 } from 'unique-names-generator';
+
+/* ========================================================================== */
+/*                                   Styles                                   */
+/* ========================================================================== */
+
+const StyledTitle = styled(Box)`
+  font-size: 0.625rem;
+  color: rgba(255, 255, 255, 0.7);
+`;
+
+const StyledValue = styled(Box)`
+  word-break: break-all;
+`;
 
 /* ========================================================================== */
 /*                              NFTTransferResult                             */
@@ -135,13 +150,20 @@ type NFTTransferFormData = {
 
 type NFTTransferActionProps = {
   nftAssetId: string;
+  nftName: string;
   destinationDID?: string;
   destinationInnerPH?: string;
   onComplete?: (result?: NFTTransferResult) => void;
 };
 
 export default function NFTTransferAction(props: NFTTransferActionProps) {
-  const { nftAssetId, destinationDID, destinationInnerPH, onComplete } = props;
+  const {
+    nftAssetId,
+    nftName,
+    destinationDID,
+    destinationInnerPH,
+    onComplete,
+  } = props;
   const [isLoading, setIsLoading] = useState(false);
   const openDialog = useOpenDialog();
   const methods = useForm<NFTTransferFormData>({
@@ -206,11 +228,61 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
   return (
     <Form methods={methods} onSubmit={handleSubmit}>
       <Flex flexDirection="column" gap={3}>
-        <Flex flexDirection="row" gap={1}>
-          <Typography variant="body1">
-            <Trans>Asset ID:</Trans>
-          </Typography>
-          <Typography variant="body1">{nftAssetId}</Typography>
+        <Flex flexDirection="column" gap={1}>
+          <Flex flexDirection="row" gap={1}>
+            <Flex flexShrink={0}>
+              <Typography variant="body1">
+                <Trans>NFT Name:</Trans>
+              </Typography>
+            </Flex>
+            <Flex
+              flexDirection="row"
+              alignItems="center"
+              gap={1}
+              sx={{ overflow: 'hidden' }}
+            >
+              <Typography noWrap variant="body1">
+                {nftName}
+              </Typography>
+              <TooltipIcon interactive>
+                <Flex flexDirection="column" gap={1}>
+                  <StyledTitle>
+                    <Trans>NFT Name</Trans>
+                  </StyledTitle>
+                  <StyledValue>
+                    <Typography variant="caption">{nftName}</Typography>
+                  </StyledValue>
+                </Flex>
+              </TooltipIcon>
+            </Flex>
+          </Flex>
+          <Flex flexDirection="row" gap={1}>
+            <Flex flexShrink={0}>
+              <Typography variant="body1">
+                <Trans>Asset ID:</Trans>
+              </Typography>
+            </Flex>
+            <Flex
+              flexDirection="row"
+              alignItems="center"
+              gap={1}
+              sx={{ overflow: 'hidden' }}
+            >
+              <Typography noWrap variant="body1">
+                {nftAssetId}
+              </Typography>
+              <TooltipIcon interactive>
+                <Flex flexDirection="column" gap={1}>
+                  <StyledTitle>
+                    <Trans>NFT Asset ID</Trans>
+                  </StyledTitle>
+                  <StyledValue>
+                    <Typography variant="caption">{nftAssetId}</Typography>
+                  </StyledValue>
+                </Flex>
+              </TooltipIcon>
+            </Flex>
+          </Flex>
         </Flex>
         <TextField
           name="destinationDID"
@@ -310,9 +382,8 @@ export function NFTTransferDialog(props: NFTTransferDialogProps) {
       <DialogTitle id="nft-transfer-dialog-title">
         <Flex flexDirection="row" gap={1}>
           <Typography variant="h6">
-            <Trans>Transfer NFT: </Trans>
+            <Trans>Transfer NFT</Trans>
           </Typography>
-          <Typography variant="h6">{nftFakeName}</Typography>
         </Flex>
       </DialogTitle>
       <DialogContent>
@@ -326,6 +397,7 @@ export function NFTTransferDialog(props: NFTTransferDialogProps) {
           </DialogContentText>
           <NFTTransferAction
             nftAssetId={nftAssetId}
+            nftName={nftFakeName}
             destinationDID={destinationDID}
             onComplete={handleCompletion}
           />

--- a/packages/gui/src/components/nfts/NFTTransferDemo.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferDemo.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Trans } from '@lingui/macro';
+import { Flex, Form, TextField, useOpenDialog } from '@chia/core';
+import { Button, Grid } from '@mui/material';
+import { useForm } from 'react-hook-form';
+import { NFTTransferDialog } from './NFTTransferAction';
+
+type NFTTransferDemoFormData = {
+  nftAssetId: string;
+  destinationDID?: string;
+};
+
+export default function NFTTransferDemo() {
+  const openDialog = useOpenDialog();
+  const methods = useForm<NFTTransferDemoFormData>({
+    shouldUnregister: false,
+    defaultValues: {
+      nftAssetId: '',
+      destinationDID: '',
+    },
+  });
+
+  async function handleClose() {
+    console.log('handleClose called in NFTs');
+  }
+
+  // async function handleTransferNFT() {
+  //   const result = await openDialog(<NFTTransferDialog />);
+
+  //   console.log('handleTransferNFT result:');
+  //   console.log(result);
+  // }
+
+  async function handleInitiateTransfer(formData: NFTTransferDemoFormData) {
+    const { nftAssetId, destinationDID } = formData;
+    console.log('handleInitiateTransfer called in NFTs');
+    console.log(formData);
+
+    const result = await openDialog(
+      <NFTTransferDialog
+        nftAssetId={nftAssetId}
+        destinationDID={destinationDID}
+      />
+    );
+
+    console.log('handleInitiateTransfer result:');
+    console.log(result);
+  }
+
+  return (
+    <Form methods={methods} onSubmit={handleInitiateTransfer}>
+      <Grid container>
+        <Grid lg={3} item>
+          <Flex flexDirection="column" gap={3}>
+            <Button type="submit" variant="contained" color="primary">
+              <Trans>Transfer NFT</Trans>
+            </Button>
+            <TextField
+              name="nftAssetId"
+              variant="outlined"
+              label="NFT Coin Info"
+              required
+            />
+            <TextField
+              name="destinationDID"
+              variant="outlined"
+              label="Destination DID Address (optional)"
+            />
+          </Flex>
+        </Grid>
+      </Grid>
+    </Form>
+  );
+}

--- a/packages/gui/src/components/nfts/NFTTransferDemo.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferDemo.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Trans } from '@lingui/macro';
-import { Flex, Form, TextField, useOpenDialog } from '@chia/core';
+import { AlertDialog, Flex, Form, TextField, useOpenDialog } from '@chia/core';
 import { Button, Grid } from '@mui/material';
 import { useForm } from 'react-hook-form';
-import { NFTTransferDialog } from './NFTTransferAction';
+import { NFTTransferDialog, NFTTransferResult } from './NFTTransferAction';
 
 type NFTTransferDemoFormData = {
   nftAssetId: string;
@@ -20,16 +20,30 @@ export default function NFTTransferDemo() {
     },
   });
 
-  async function handleClose() {
-    console.log('handleClose called in NFTs');
+  function handleComplete(result?: NFTTransferResult) {
+    console.log('handleComplete called in NFTTransferDemo');
+    console.log(result);
+
+    if (result) {
+      if (result.success) {
+        openDialog(
+          <AlertDialog title={<Trans>NFT Transfer Complete</Trans>}>
+            <Trans>
+              The NFT transfer transaction has been successfully submitted to
+              the blockchain.
+            </Trans>
+          </AlertDialog>,
+        );
+      } else {
+        const error = result.error || 'Unknown error';
+        openDialog(
+          <AlertDialog title={<Trans>NFT Transfer Failed</Trans>}>
+            <Trans>The NFT transfer failed: {error}</Trans>
+          </AlertDialog>,
+        );
+      }
+    }
   }
-
-  // async function handleTransferNFT() {
-  //   const result = await openDialog(<NFTTransferDialog />);
-
-  //   console.log('handleTransferNFT result:');
-  //   console.log(result);
-  // }
 
   async function handleInitiateTransfer(formData: NFTTransferDemoFormData) {
     const { nftAssetId, destinationDID } = formData;
@@ -40,11 +54,9 @@ export default function NFTTransferDemo() {
       <NFTTransferDialog
         nftAssetId={nftAssetId}
         destinationDID={destinationDID}
-      />
+        onComplete={handleComplete}
+      />,
     );
-
-    console.log('handleInitiateTransfer result:');
-    console.log(result);
   }
 
   return (

--- a/packages/gui/src/components/nfts/NFTTransferDemo.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferDemo.tsx
@@ -21,9 +21,6 @@ export default function NFTTransferDemo() {
   });
 
   function handleComplete(result?: NFTTransferResult) {
-    console.log('handleComplete called in NFTTransferDemo');
-    console.log(result);
-
     if (result) {
       if (result.success) {
         openDialog(
@@ -47,10 +44,8 @@ export default function NFTTransferDemo() {
 
   async function handleInitiateTransfer(formData: NFTTransferDemoFormData) {
     const { nftAssetId, destinationDID } = formData;
-    console.log('handleInitiateTransfer called in NFTs');
-    console.log(formData);
 
-    const result = await openDialog(
+    await openDialog(
       <NFTTransferDialog
         nftAssetId={nftAssetId}
         destinationDID={destinationDID}

--- a/packages/gui/src/components/nfts/NFTTransferDemo.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferDemo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Trans } from '@lingui/macro';
 import { AlertDialog, Flex, Form, TextField, useOpenDialog } from '@chia/core';
-import { Button, Grid } from '@mui/material';
+import { Button } from '@mui/material';
 import { useForm } from 'react-hook-form';
 import { NFTTransferDialog, NFTTransferResult } from './NFTTransferAction';
 
@@ -60,27 +60,31 @@ export default function NFTTransferDemo() {
   }
 
   return (
-    <Form methods={methods} onSubmit={handleInitiateTransfer}>
-      <Grid container>
-        <Grid lg={3} item>
+    <Flex flexDirection="row" flexGrow={1} gap={3} style={{ padding: '1rem' }}>
+      <Flex flexDirection="column" flexGrow={1} gap={3}>
+        <Form methods={methods} onSubmit={handleInitiateTransfer}>
           <Flex flexDirection="column" gap={3}>
-            <Button type="submit" variant="contained" color="primary">
-              <Trans>Transfer NFT</Trans>
-            </Button>
             <TextField
               name="nftAssetId"
               variant="outlined"
               label="NFT Coin Info"
               required
+              fullWidth
             />
             <TextField
               name="destinationDID"
               variant="outlined"
               label="Destination DID Address (optional)"
+              fullWidth
             />
+            <Flex justifyContent="flex-end">
+              <Button type="submit" variant="contained" color="primary">
+                <Trans>Transfer NFT</Trans>
+              </Button>
+            </Flex>
           </Flex>
-        </Grid>
-      </Grid>
-    </Form>
+        </Form>
+      </Flex>
+    </Flex>
   );
 }

--- a/packages/gui/src/components/nfts/NFTTransferDemo.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferDemo.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import { NFTTransferDialog, NFTTransferResult } from './NFTTransferAction';
 
 type NFTTransferDemoFormData = {
+  walletId: number;
   nftAssetId: string;
   destinationDID?: string;
 };
@@ -15,6 +16,7 @@ export default function NFTTransferDemo() {
   const methods = useForm<NFTTransferDemoFormData>({
     shouldUnregister: false,
     defaultValues: {
+      walletId: 0,
       nftAssetId: '',
       destinationDID: '',
     },
@@ -43,10 +45,11 @@ export default function NFTTransferDemo() {
   }
 
   async function handleInitiateTransfer(formData: NFTTransferDemoFormData) {
-    const { nftAssetId, destinationDID } = formData;
+    const { walletId, nftAssetId, destinationDID } = formData;
 
     await openDialog(
       <NFTTransferDialog
+        walletId={walletId}
         nftAssetId={nftAssetId}
         destinationDID={destinationDID}
         onComplete={handleComplete}
@@ -59,6 +62,13 @@ export default function NFTTransferDemo() {
       <Flex flexDirection="column" flexGrow={1} gap={3}>
         <Form methods={methods} onSubmit={handleInitiateTransfer}>
           <Flex flexDirection="column" gap={3}>
+            <TextField
+              name="walletId"
+              variant="outlined"
+              label="Wallet ID"
+              required
+              fullWidth
+            />
             <TextField
               name="nftAssetId"
               variant="outlined"

--- a/packages/gui/src/components/nfts/NFTs.tsx
+++ b/packages/gui/src/components/nfts/NFTs.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import NFTTransferDemo from './NFTTransferDemo';
 
 export default function NFTs() {
   return (
     <div>
       NFTs
+      <NFTTransferDemo />
     </div>
   );
 }

--- a/packages/gui/src/components/nfts/NFTs.tsx
+++ b/packages/gui/src/components/nfts/NFTs.tsx
@@ -1,11 +1,81 @@
 import React from 'react';
+import { Trans } from '@lingui/macro';
+import { Flex, DropdownActions, useOpenDialog } from '@chia/core';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  ListItemIcon,
+  MenuItem,
+  Typography,
+} from '@mui/material';
+import { ArrowForward as TransferIcon } from '@mui/icons-material';
 import NFTTransferDemo from './NFTTransferDemo';
 
 export default function NFTs() {
+  const actions = undefined;
+  const openDialog = useOpenDialog();
+
+  function handleTransferNFT() {
+    const open = true;
+    console.log('handleTransferNFT called in NFTs');
+
+    openDialog(
+      <Dialog
+        open={open}
+        aria-labelledby="nft-transfer-dialog-title"
+        aria-describedby="nft-transfer-dialog-description"
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle id="nft-transfer-dialog-title">
+          <Typography variant="h6">
+            <Trans>NFT Transfer Demo</Trans>
+          </Typography>
+        </DialogTitle>
+        <DialogContent>
+          <Flex justifyContent="center">
+            <NFTTransferDemo />
+          </Flex>
+        </DialogContent>
+      </Dialog>,
+    );
+  }
+
   return (
     <div>
       NFTs
-      <NFTTransferDemo />
+      <Flex
+        flexDirection="row"
+        flexGrow={1}
+        justifyContent="flex-end"
+        gap={3}
+        style={{ padding: '1rem' }}
+      >
+        <Flex gap={1} alignItems="center">
+          <DropdownActions label={<Trans>Actions</Trans>}>
+            {({ onClose }) => (
+              <>
+                <MenuItem
+                  onClick={() => {
+                    onClose();
+                    handleTransferNFT();
+                  }}
+                >
+                  <ListItemIcon>
+                    <TransferIcon />
+                  </ListItemIcon>
+                  <Typography variant="inherit" noWrap>
+                    <Trans>Transfer NFT</Trans>
+                  </Typography>
+                </MenuItem>
+              </>
+            )}
+          </DropdownActions>
+        </Flex>
+      </Flex>
     </div>
   );
 }

--- a/packages/gui/src/components/nfts/NFTs.tsx
+++ b/packages/gui/src/components/nfts/NFTs.tsx
@@ -3,9 +3,7 @@ import { Trans } from '@lingui/macro';
 import { Flex, DropdownActions, useOpenDialog } from '@chia/core';
 import {
   Dialog,
-  DialogActions,
   DialogContent,
-  DialogContentText,
   DialogTitle,
   ListItemIcon,
   MenuItem,
@@ -15,12 +13,10 @@ import { ArrowForward as TransferIcon } from '@mui/icons-material';
 import NFTTransferDemo from './NFTTransferDemo';
 
 export default function NFTs() {
-  const actions = undefined;
   const openDialog = useOpenDialog();
 
   function handleTransferNFT() {
     const open = true;
-    console.log('handleTransferNFT called in NFTs');
 
     openDialog(
       <Dialog


### PR DESCRIPTION
This still needs to be integrated with the gallery view, but for the time being, a "demo" dialog is presented to collect the NFT asset ID and wallet ID. The demo dialog then launches into the NFT transfer UI, calling nft_transfer_nft in the wallet backend. Updates will be needed once the nft_transfer_nft RPC has been finalized.