### PR TITLE
Fix issue entering a maker fee in the offer editor.

### DIFF
--- a/packages/wallets/src/components/offers/OfferEditor.tsx
+++ b/packages/wallets/src/components/offers/OfferEditor.tsx
@@ -32,7 +32,7 @@ type FormData = {
   selectedTab: number;
   makerRows: OfferEditorRowData[];
   takerRows: OfferEditorRowData[];
-  fee: number;
+  fee: string;
 };
 
 type OfferEditorProps = {
@@ -47,6 +47,7 @@ function OfferEditor(props: OfferEditorProps) {
     selectedTab: 0,
     makerRows: [{ amount: '', assetWalletId: 0, walletType: WalletType.STANDARD_WALLET, spendableBalance: new BigNumber(0) }],
     takerRows: [{ amount: '', assetWalletId: 0, walletType: WalletType.STANDARD_WALLET, spendableBalance: new BigNumber(0) }],
+    fee: '',
   };
   const methods = useForm<FormData>({
     defaultValues,


### PR DESCRIPTION
The <Fee> component doesn't behave well if the bound data has an undefined default value. The form data now expects a string and sets the default value to an empty string.