### PR TITLE
NFT offer editor support for NFTs with royalties 

### DIFF
--- a/packages/gui/src/components/nfts/NFTCard.tsx
+++ b/packages/gui/src/components/nfts/NFTCard.tsx
@@ -57,7 +57,7 @@ export default function NFTCard(props: NFTCardProps) {
   }
 
   return (
-    <Card>
+    <Card sx={{ borderRadius: '8px' }}>
       {isLoading ? (
         <CardContent>
           <Loading center />
@@ -65,7 +65,7 @@ export default function NFTCard(props: NFTCardProps) {
       ) : (
         <>
           <CardActionArea onClick={handleClick} disabled={!canExpandDetails}>
-            <NFTPreview nft={nft} fit="contain" />
+            <NFTPreview nft={nft} fit="cover" />
           </CardActionArea>
           <CardActionArea onClick={() => canExpandDetails && handleClick()}>
             <StyledCardContent>

--- a/packages/gui/src/components/offers/NFTOfferPreview.tsx
+++ b/packages/gui/src/components/offers/NFTOfferPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Trans } from '@lingui/macro';
 import { useGetNFTInfoQuery } from '@chia/api-react';
-import { Button, Flex, TooltipIcon } from '@chia/core';
+import { Button, Flex, Loading, TooltipIcon } from '@chia/core';
 import { Card, Typography } from '@mui/material';
 import NFTCard from '../nfts/NFTCard';
 import { launcherIdFromNFTId } from '../../util/nfts';
@@ -34,8 +34,78 @@ type NFTOfferPreviewProps = {
 export default function NFTOfferPreview(props: NFTOfferPreviewProps) {
   const { nftId } = props;
   const launcherId = launcherIdFromNFTId(nftId ?? '');
-  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId });
+  const {
+    data: nft,
+    isLoading: isLoadingNFT,
+    error,
+  } = useGetNFTInfoQuery({ coinId: launcherId });
   const viewOnExplorer = useViewNFTOnExplorer();
+
+  const cardContentElem = (function () {
+    if (isLoadingNFT) {
+      return (
+        <Flex
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          flexGrow={1}
+          gap={1}
+          style={{
+            wordBreak: 'break-all',
+          }}
+        >
+          <Loading center>
+            <Trans>Loading NFT Info...</Trans>
+          </Loading>
+        </Flex>
+      );
+    } else if (launcherId && nft) {
+      return (
+        <NFTCard
+          nft={nft}
+          canExpandDetails={false}
+          availableActions={
+            NFTContextualActionTypes.CopyNFTId |
+            NFTContextualActionTypes.ViewOnExplorer |
+            NFTContextualActionTypes.OpenInBrowser |
+            NFTContextualActionTypes.CopyURL
+          }
+        />
+      );
+    } else if (error) {
+      return (
+        <Flex
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          flexGrow={1}
+          gap={1}
+          style={{
+            wordBreak: 'break-all',
+          }}
+        >
+          <Typography variant="body1" color="error">
+            {error.message}
+          </Typography>
+        </Flex>
+      );
+    } else {
+      <Flex
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        flexGrow={1}
+        gap={1}
+        style={{
+          wordBreak: 'break-all',
+        }}
+      >
+        <Typography variant="h6">
+          <Trans>NFT not specified</Trans>
+        </Typography>
+      </Flex>;
+    }
+  })();
 
   return (
     <StyledPreviewContainer
@@ -46,42 +116,13 @@ export default function NFTOfferPreview(props: NFTOfferPreviewProps) {
     >
       <Flex
         flexDirection="column"
-        flexGrow={1}
         gap={1}
         style={{
           padding: '1.5rem',
         }}
       >
         <Typography variant="subtitle1">Preview</Typography>
-        <StyledCard>
-          {launcherId && nft ? (
-            <NFTCard
-              nft={nft}
-              canExpandDetails={false}
-              availableActions={
-                NFTContextualActionTypes.CopyNFTId |
-                NFTContextualActionTypes.ViewOnExplorer |
-                NFTContextualActionTypes.OpenInBrowser |
-                NFTContextualActionTypes.CopyURL
-              }
-            />
-          ) : (
-            <Flex
-              flexDirection="column"
-              alignItems="center"
-              justifyContent="center"
-              flexGrow={1}
-              gap={1}
-              style={{
-                wordBreak: 'break-all',
-              }}
-            >
-              <Typography variant="h6">
-                <Trans>NFT not specified</Trans>
-              </Typography>
-            </Flex>
-          )}
-        </StyledCard>
+        <StyledCard>{cardContentElem}</StyledCard>
       </Flex>
       {nft && (
         <Flex

--- a/packages/gui/src/util/nfts.ts
+++ b/packages/gui/src/util/nfts.ts
@@ -21,5 +21,5 @@ export function launcherIdFromNFTId(nftId: string): string | undefined {
 }
 
 export function convertRoyaltyToPercentage(royalty: number): number {
-  return royalty / 1000;
+  return royalty / 100;
 }

--- a/packages/wallets/src/components/WalletTokenCard.tsx
+++ b/packages/wallets/src/components/WalletTokenCard.tsx
@@ -147,13 +147,15 @@ export default function WalletTokenCard(props: WalletTokenCardProps) {
             </Flex>
           )}
         </Flex>
-        <Box width="60px" textAlign="center">
-          {isLoading ? (
-            <CircularProgress size={32} />
-          ) : (
-            <Switch checked={!hidden} onChange={handleVisibleChange} />
-          )}
-        </Box>
+        {walletType !== WalletType.STANDARD_WALLET && (
+          <Box width="60px" textAlign="center">
+            {isLoading ? (
+              <CircularProgress size={32} />
+            ) : (
+              <Switch checked={!hidden} onChange={handleVisibleChange} />
+            )}
+          </Box>
+        )}
       </Flex>
     </CardListItem>
   );

--- a/packages/wallets/src/components/WalletsManageTokens.tsx
+++ b/packages/wallets/src/components/WalletsManageTokens.tsx
@@ -1,6 +1,7 @@
 import React, { type ReactNode, useState } from 'react';
 import { Trans } from '@lingui/macro';
 import { Box, IconButton, InputBase } from '@mui/material';
+import { WalletType } from '@chia/api';
 import {
   Button,
   useColorModeValue,
@@ -126,7 +127,10 @@ export default function WalletsManageTokens(props: WalletsManageTokensProps) {
   const t = useTrans();
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
-  const { list, hide, show, isLoading } = useWalletsList(search);
+  const { list, hide, show, isLoading } = useWalletsList(search, [
+    WalletType.STANDARD_WALLET,
+    WalletType.CAT,
+  ]);
 
   function handleAddToken(event) {
     event.preventDefault();

--- a/packages/wallets/src/hooks/useWalletsList.ts
+++ b/packages/wallets/src/hooks/useWalletsList.ts
@@ -43,7 +43,10 @@ function getTypeOrder(item: ListItem) {
   }
 }
 
-export default function useWalletsList(search?: string): {
+export default function useWalletsList(
+  search?: string,
+  walletTypes: WalletType[]
+): {
   list?: ListItem[];
   isLoading: boolean;
   hide: (walletId: number) => void;
@@ -188,6 +191,11 @@ export default function useWalletsList(search?: string): {
         name: getCATName(strayCat.assetId),
       })),
     ];
+
+    // Filter by requested wallet types
+    tokens = tokens.filter(token =>
+      walletTypes.includes(token.walletType as WalletType)
+    );
 
     if (search) {
       tokens = tokens.filter(token =>


### PR DESCRIPTION
(RPC integration needed)

Minor tweaks to NFTCard (border radius, object-fitting --> cover (again))
Added a loading indicator to NFTOfferPreview when fetching coin info
WalletsManageTokens filters on specified wallet types now (NFT/DID wallets excluded)
Prevent disabling the Chia wallet from WalletsManageTokens