### PR TITLE
Fixed issue with non-ASCII characters in NFT metadata.

### DIFF
--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -204,7 +204,9 @@ if (!handleSquirrelEvent()) {
         let error: Error | undefined;
         let statusCode: number | undefined;
         let statusMessage: string | undefined;
-        let data: string;
+        let contentType: string | undefined;
+        let encoding = 'binary';
+        let data: string | undefined;
 
         const buffers: Buffer[] = [];
         let totalLength = 0;
@@ -214,6 +216,24 @@ if (!handleSquirrelEvent()) {
             request.on('response', (response: IncomingMessage) => {
               statusCode = response.statusCode;
               statusMessage = response.statusMessage;
+
+              const rawContentType = response.headers['content-type'];
+              if (rawContentType) {
+                if (Array.isArray(rawContentType)) {
+                  contentType = rawContentType[0];
+                }
+                else {
+                  contentType = rawContentType;
+                }
+
+                if (contentType) {
+                  // extract charset from contentType
+                  const charsetMatch = contentType.match(/charset=([^;]+)/);
+                  if (charsetMatch) {
+                    encoding = charsetMatch[1];
+                  }
+                }
+              }
 
               response.on('data', (chunk) => {
                 buffers.push(chunk);
@@ -227,7 +247,7 @@ if (!handleSquirrelEvent()) {
               });
 
               response.on('end', () => {
-                resolve(Buffer.concat(buffers).toString('latin1'));
+                resolve(Buffer.concat(buffers).toString(encoding as BufferEncoding));
               });
 
               response.on('error', (e: string) => {
@@ -249,7 +269,7 @@ if (!handleSquirrelEvent()) {
           error = e;
         }
 
-        return { error, statusCode, statusMessage, data };
+        return { error, statusCode, statusMessage, encoding, data };
       });
 
       ipcMain.handle('showMessageBox', async (_event, options) => {

--- a/packages/gui/src/hooks/useNFTMetadata.ts
+++ b/packages/gui/src/hooks/useNFTMetadata.ts
@@ -29,7 +29,7 @@ export default function useNFTMetadata(nft: NFTInfo) {
         throw new Error('Invalid URI');
       }
 
-      const content = await getRemoteFileContent(uri, MAX_FILE_SIZE);
+      const { data: content } = await getRemoteFileContent(uri, MAX_FILE_SIZE);
       const metadata = JSON.parse(content);
 
       setMetadata(metadata);

--- a/packages/gui/src/hooks/useVerifyURIHash.ts
+++ b/packages/gui/src/hooks/useVerifyURIHash.ts
@@ -8,7 +8,10 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
 const cache = new Map<string, boolean>();
 
-export default function useVerifyURIHash(uri: string, hash: string): {
+export default function useVerifyURIHash(
+  uri: string,
+  hash: string,
+): {
   isValid: boolean;
   isLoading: boolean;
   error?: Error;
@@ -34,8 +37,11 @@ export default function useVerifyURIHash(uri: string, hash: string): {
         }
 
         if (uri) {
-          const content = await getRemoteFileContent(uri, MAX_FILE_SIZE);
-          const isHashValid = isContentHashValid(content, hash);
+          const { data: content, encoding } = await getRemoteFileContent(
+            uri,
+            MAX_FILE_SIZE,
+          );
+          const isHashValid = isContentHashValid(content, hash, encoding);
           if (!isHashValid) {
             throw new Error(`Hash mismatch`);
           }

--- a/packages/gui/src/util/computeHash.ts
+++ b/packages/gui/src/util/computeHash.ts
@@ -1,5 +1,12 @@
 import crypto from 'crypto';
 
-export default function computeHash(content: string, hash = 'sha256'): string {
-  return crypto.createHash(hash).update(content, 'binary').digest('hex');
+export default function computeHash(
+  content: string,
+  options: { hash?: string; encoding?: string },
+): string {
+  const { hash, encoding } = options;
+  return crypto
+    .createHash(hash ?? 'sha256')
+    .update(content, (encoding ?? 'binary') as crypto.Encoding)
+    .digest('hex');
 }

--- a/packages/gui/src/util/getRemoteFileContent.ts
+++ b/packages/gui/src/util/getRemoteFileContent.ts
@@ -1,11 +1,17 @@
-export default async function getRemoteFileContent(url: string, maxSize?: number): Promise<string> {
+export default async function getRemoteFileContent(
+  url: string,
+  maxSize?: number,
+): Promise<{ data: string; encoding: string }> {
   const ipcRenderer = (window as any).ipcRenderer;
   const requestOptions = {
     url,
     maxSize,
   };
 
-  const { data, statusCode, error } = await ipcRenderer?.invoke('fetchBinaryContent', requestOptions);
+  const { data, statusCode, encoding, error } = await ipcRenderer?.invoke(
+    'fetchBinaryContent',
+    requestOptions,
+  );
 
   if (error) {
     throw error;
@@ -15,5 +21,5 @@ export default async function getRemoteFileContent(url: string, maxSize?: number
     throw new Error(error.message || `Failed to fetch content from ${url}`);
   }
 
-  return data;
+  return { data, encoding };
 }

--- a/packages/gui/src/util/isContentHashValid.ts
+++ b/packages/gui/src/util/isContentHashValid.ts
@@ -3,8 +3,9 @@ import computeHash from './computeHash';
 export default function isContentHashValid(
   content: string,
   hash: string,
+  encoding?: string,
 ): boolean {
-  const computedHash = computeHash(content);
+  const computedHash = computeHash(content, { encoding });
   let otherHash = hash.toLowerCase();
   if (otherHash.startsWith('0x')) {
     otherHash = otherHash.substring(2);


### PR DESCRIPTION
Content-Type is now sniffed in fetchBinaryContent, and if charset is
specified, convert the data to a string using the specified encoding.