### PR TITLE
canExpandDetails is now applied in handleClick() instead of disabling

### DIFF
--- a/packages/gui/src/components/nfts/NFTCard.tsx
+++ b/packages/gui/src/components/nfts/NFTCard.tsx
@@ -1,21 +1,8 @@
 import React from 'react';
 import { Trans } from '@lingui/macro';
 import { useNavigate } from 'react-router-dom';
-import {
-  Box,
-  Card,
-  CardActionArea,
-  CardContent,
-  Typography,
-} from '@mui/material';
-import {
-  IconButton,
-  CopyToClipboard,
-  Flex,
-  Loading,
-  Tooltip,
-  Truncate,
-} from '@chia/core';
+import { Card, CardActionArea, CardContent, Typography } from '@mui/material';
+import { IconButton, Flex, Loading } from '@chia/core';
 import { MoreVert } from '@mui/icons-material';
 import styled from 'styled-components';
 import NFTPreview from './NFTPreview';
@@ -24,12 +11,6 @@ import useNFTMetadata from '../../hooks/useNFTMetadata';
 import NFTContextualActions, {
   NFTContextualActionTypes,
 } from './NFTContextualActions';
-
-const StyledCardFooter = styled(CardContent)`
-  padding-top: ${({ theme }) => theme.spacing(1)};
-  padding-bottom: ${({ theme }) => theme.spacing(1)} !important;
-  background-color: ${({ theme }) => theme.palette.action.hover};
-`;
 
 const StyledCardContent = styled(CardContent)`
   //padding-top: ${({ theme }) => theme.spacing(1)};
@@ -45,15 +26,20 @@ export type NFTCardProps = {
 };
 
 export default function NFTCard(props: NFTCardProps) {
-  const { nft, canExpandDetails = true, availableActions = NFTContextualActionTypes.None } = props;
-  const nftId = nft.$nftId;
+  const {
+    nft,
+    canExpandDetails = true,
+    availableActions = NFTContextualActionTypes.None,
+  } = props;
 
   const navigate = useNavigate();
 
   const { metadata, isLoading } = useNFTMetadata(nft);
 
   function handleClick() {
-    navigate(`/dashboard/nfts/${nft.$nftId}`);
+    if (canExpandDetails) {
+      navigate(`/dashboard/nfts/${nft.$nftId}`);
+    }
   }
 
   return (
@@ -65,7 +51,7 @@ export default function NFTCard(props: NFTCardProps) {
           </CardContent>
         ) : (
           <>
-            <CardActionArea onClick={handleClick} disabled={!canExpandDetails}>
+            <CardActionArea onClick={handleClick}>
               <NFTPreview nft={nft} fit="cover" />
             </CardActionArea>
             <CardActionArea onClick={() => canExpandDetails && handleClick()}>


### PR DESCRIPTION
the CardActionArea. This allows NFT previews in the offer editor/viewer
to support loading large images / retrying failed loads.