### PR TITLE
added splitting NFT description on newlines.

### DIFF
--- a/packages/gui/src/components/nfts/detail/NFTDetail.tsx
+++ b/packages/gui/src/components/nfts/detail/NFTDetail.tsx
@@ -73,8 +73,8 @@ export default function NFTDetail() {
                   <Trans>Description</Trans>
                 </Typography>
 
-                <Typography>
-                  {metadata?.description?.split('\n').map((line,i) => <p key={i}>{line}</p>) ?? <Trans>Not Available</Trans>}
+                <Typography sx={{ whiteSpace : 'pre-line'}}>
+                  {metadata?.description ?? <Trans>Not Available</Trans>}
                 </Typography>
               </Flex>
               {metadata?.collection?.name && (

--- a/packages/gui/src/components/nfts/detail/NFTDetail.tsx
+++ b/packages/gui/src/components/nfts/detail/NFTDetail.tsx
@@ -74,7 +74,7 @@ export default function NFTDetail() {
                 </Typography>
 
                 <Typography>
-                  {metadata?.description ?? <Trans>Not Available</Trans>}
+                  {metadata?.description?.split('\n').map((line,i) => <p key={i}>{line}</p>) ?? <Trans>Not Available</Trans>}
                 </Typography>
               </Flex>
               {metadata?.collection?.name && (

--- a/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
+++ b/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
@@ -98,7 +98,7 @@ export default function NFTDetail() {
                   </Typography>
 
                   <Typography overflow="hidden">
-                    {metadata?.description ?? <Trans>Not Available</Trans>}
+                    {metadata?.description?.split('\n').map((line,i) => <p key={i}>{line}</p>) ?? <Trans>Not Available</Trans>}
                   </Typography>
                 </Flex>
                 {metadata?.collection?.name && (

--- a/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
+++ b/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
@@ -97,8 +97,8 @@ export default function NFTDetail() {
                     <Trans>Description</Trans>
                   </Typography>
 
-                  <Typography overflow="hidden">
-                    {metadata?.description?.split('\n').map((line,i) => <p key={i}>{line}</p>) ?? <Trans>Not Available</Trans>}
+                  <Typography sx={{ whiteSpace : 'pre-line'}} overflow="hidden">
+                    {metadata?.description ?? <Trans>Not Available</Trans>}
                   </Typography>
                 </Flex>
                 {metadata?.collection?.name && (


### PR DESCRIPTION
As an NFT creator, I found it necessary for my collection, and thought it advantageous for others, to preserve some formatting in the NFT description. Newlines are a simple, bare minimum, and easy to implement.

I'm not certain whether or not this is the best way to do this, as I rarely work with react/jsx. Feel free to keep the good and toss the bad, or roll your own.