### PR TITLE
Properly truncate the NFT title if it's too long to display

### DIFF
--- a/packages/gui/src/components/nfts/NFTCard.tsx
+++ b/packages/gui/src/components/nfts/NFTCard.tsx
@@ -57,7 +57,15 @@ export default function NFTCard(props: NFTCardProps) {
             <CardActionArea onClick={() => canExpandDetails && handleClick()}>
               <StyledCardContent>
                 <Flex justifyContent="space-between" alignItems="center">
-                  <Flex gap={1} alignItems="center">
+                  <Flex
+                    gap={1}
+                    alignItems="center"
+                    sx={{
+                      overflow: 'hidden',
+                      wordBreak: 'break-all',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
                     <Typography noWrap>
                       {metadata?.name ?? <Trans>Title Not Available</Trans>}
                     </Typography>

--- a/packages/gui/src/components/nfts/NFTCard.tsx
+++ b/packages/gui/src/components/nfts/NFTCard.tsx
@@ -57,15 +57,7 @@ export default function NFTCard(props: NFTCardProps) {
             <CardActionArea onClick={() => canExpandDetails && handleClick()}>
               <StyledCardContent>
                 <Flex justifyContent="space-between" alignItems="center">
-                  <Flex
-                    gap={1}
-                    alignItems="center"
-                    sx={{
-                      overflow: 'hidden',
-                      wordBreak: 'break-all',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
+                  <Flex gap={1} alignItems="center" minWidth={0}>
                     <Typography noWrap>
                       {metadata?.name ?? <Trans>Title Not Available</Trans>}
                     </Typography>

--- a/packages/gui/src/components/offers/NFTOfferPreview.tsx
+++ b/packages/gui/src/components/offers/NFTOfferPreview.tsx
@@ -8,7 +8,7 @@ import {
   TooltipIcon,
   useColorModeValue,
 } from '@chia/core';
-import { Card, Typography } from '@mui/material';
+import { Card, Grid, Typography } from '@mui/material';
 import NFTCard from '../nfts/NFTCard';
 import { launcherIdFromNFTId } from '../../util/nfts';
 import { NFTContextualActionTypes } from '../nfts/NFTContextualActions';
@@ -77,16 +77,18 @@ export default function NFTOfferPreview(props: NFTOfferPreviewProps) {
       );
     } else if (launcherId && nft) {
       return (
-        <NFTCard
-          nft={nft}
-          canExpandDetails={false}
-          availableActions={
-            NFTContextualActionTypes.CopyNFTId |
-            NFTContextualActionTypes.ViewOnExplorer |
-            NFTContextualActionTypes.OpenInBrowser |
-            NFTContextualActionTypes.CopyURL
-          }
-        />
+        <Grid xs={12} item>
+          <NFTCard
+            nft={nft}
+            canExpandDetails={false}
+            availableActions={
+              NFTContextualActionTypes.CopyNFTId |
+              NFTContextualActionTypes.ViewOnExplorer |
+              NFTContextualActionTypes.OpenInBrowser |
+              NFTContextualActionTypes.CopyURL
+            }
+          />
+        </Grid>
       );
     } else if (launcherId && error) {
       return (


### PR DESCRIPTION
With the fix:

NFT Gallery:
![image](https://user-images.githubusercontent.com/339312/183313132-fb3aad58-75a9-4593-89fe-efe43f1ffa91.png)

NFT Offer:
![image](https://user-images.githubusercontent.com/339312/183313151-53afaee6-997c-400c-bcf6-9c1540ba8808.png)
