### PR TITLE
Show the image hash mismatch status for large files (#899)

### DIFF
--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -61,13 +61,17 @@ export default function NFTPreview(props: NFTPreviewProps) {
   } = props;
 
   const [loaded, setLoaded] = useState(false);
-  const { isValid, isLoading, error } = useNFTHash(nft);
   const hasFile = dataUris?.length > 0;
   const file = dataUris?.[0];
   const [ignoreError, setIgnoreError] = usePersistState<boolean>(
     false,
     `nft-preview-ignore-error-${nft.$nftId}-${file}`,
   );
+  const [ignoreSizeLimit, setIgnoreSizeLimit] = usePersistState<boolean>(
+    false,
+    `nft-preview-ignore-size-limit-${nft.$nftId}-${file}`,
+  );
+  const { isValid, isLoading, error } = useNFTHash(nft, ignoreSizeLimit);
 
   useEffect(() => {
     setLoaded(false);
@@ -88,7 +92,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
       return [t`Image Hash Mismatch`, true];
     }
     return [undefined, false];
-  }, [nft, isValid, error]);
+  }, [nft, isValid, error, ignoreError]);
 
   const srcDoc = useMemo(() => {
     if (!file) {
@@ -167,6 +171,10 @@ export default function NFTPreview(props: NFTPreviewProps) {
     event.stopPropagation();
 
     setIgnoreError(true);
+
+    if (error?.message === 'Response too large') {
+      setIgnoreSizeLimit(true);
+    }
   }
 
   return (

--- a/packages/gui/src/hooks/useHiddenNFTs.ts
+++ b/packages/gui/src/hooks/useHiddenNFTs.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { type NFTInfo } from '@chia/api';
+import type { NFTInfo } from '@chia/api';
 import { useHiddenList } from '@chia/core';
 
 export default function useHiddenNFTs() {

--- a/packages/gui/src/hooks/useNFTHash.ts
+++ b/packages/gui/src/hooks/useNFTHash.ts
@@ -1,9 +1,9 @@
 import type NFTInfo from '@chia/api';
 import useVerifyURIHash from './useVerifyURIHash';
 
-export default function useNFTHash(nft: NFTInfo) {
+export default function useNFTHash(nft: NFTInfo, ignoreSizeLimit = false) {
   const { dataHash, dataUris } = nft;
   const uri = dataUris?.[0];
 
-  return useVerifyURIHash(uri, dataHash);
+  return useVerifyURIHash(uri, dataHash, ignoreSizeLimit);
 }

--- a/packages/gui/src/hooks/useVerifyURIHash.ts
+++ b/packages/gui/src/hooks/useVerifyURIHash.ts
@@ -11,6 +11,7 @@ const cache = new Map<string, boolean>();
 export default function useVerifyURIHash(
   uri: string,
   hash: string,
+  ignoreSizeLimit = false,
 ): {
   isValid: boolean;
   isLoading: boolean;
@@ -39,7 +40,7 @@ export default function useVerifyURIHash(
         if (uri) {
           const { data: content, encoding } = await getRemoteFileContent(
             uri,
-            MAX_FILE_SIZE,
+            ignoreSizeLimit ? undefined : MAX_FILE_SIZE,
           );
           const isHashValid = isContentHashValid(content, hash, encoding);
           if (!isHashValid) {
@@ -65,7 +66,7 @@ export default function useVerifyURIHash(
 
   useEffect(() => {
     validateHash(uri, hash);
-  }, [uri, hash]);
+  }, [uri, hash, ignoreSizeLimit]);
 
   return { isValid, isLoading, error };
 }


### PR DESCRIPTION
* Show the image hash mismatch status for large files

* More specific fix. Prior change wasn't matching on hash mismatches.

* Linter fix