### PR TITLE
Fix metadata decoding/parsing when content-type is missing

### DIFF
--- a/packages/gui/src/hooks/useNFTMetadata.ts
+++ b/packages/gui/src/hooks/useNFTMetadata.ts
@@ -29,8 +29,20 @@ export default function useNFTMetadata(nft: NFTInfo) {
         throw new Error('Invalid URI');
       }
 
-      const { data: content } = await getRemoteFileContent(uri, MAX_FILE_SIZE);
-      const metadata = JSON.parse(content);
+      const { data: content, encoding } = await getRemoteFileContent(
+        uri,
+        MAX_FILE_SIZE,
+      );
+
+      let metadata = undefined;
+      if (['utf8', 'utf-8'].includes(encoding.toLowerCase())) {
+        metadata = JSON.parse(content);
+      } else {
+        // Special case where we don't know the encoding type -- assume UTF-8
+        metadata = JSON.parse(
+          Buffer.from(content, encoding as BufferEncoding).toString('utf8'),
+        );
+      }
 
       setMetadata(metadata);
     } catch (error: any) {


### PR DESCRIPTION
Electron's net.request has a long-standing bug wherein the IncomingMessage response object will not have a content-type header if the server originally responded with a redirect. The content-type header also appears to be missing in some cases for unknown reasons. This change works around the issue by reinterpreting the bytes as UTF-8 if the header is missing.