### PR TITLE
Fix method for identifying the NFT inbox (unassigned)

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -130,6 +130,19 @@ export const walletApi = apiWithTag.injectEndpoints({
                   }
 
                   meta.name = nameData.name;
+                } else if (type === WalletType.NFT) {
+                  // get DID assigned to the NFT Wallet (if any)
+                  const { data: didData, error: didError } = await fetchWithBQ({
+                    command: 'getNftWalletDid',
+                    service: NFT,
+                    args: [wallet.id],
+                  });
+
+                  if (didError) {
+                    throw didError;
+                  }
+
+                  meta.did = didData.didId;
                 }
 
                 return {

--- a/packages/api/src/wallets/NFT.ts
+++ b/packages/api/src/wallets/NFT.ts
@@ -17,6 +17,12 @@ export default class NFTWallet extends Wallet {
     return this.command('nft_get_wallets_with_dids');
   }
 
+  async getNftWalletDid(walletId: number) {
+    return this.command('nft_get_wallet_did', {
+      walletId,
+    });
+  }
+
   async transferNft(
     walletId: number,
     nftCoinId: string,

--- a/packages/gui/src/components/nfts/NFTProfileDropdown.tsx
+++ b/packages/gui/src/components/nfts/NFTProfileDropdown.tsx
@@ -63,16 +63,8 @@ export default function NFTProfileDropdown(props: NFTGallerySidebarProps) {
     if (isLoadingProfiles || isLoadingNFTWallets) {
       return undefined;
     }
-
-    const nftWalletIds = nftWallets.map((nftWallet: Wallet) => nftWallet.id);
-    const profileWalletIds = new Set(
-      profiles.map((profile) => profile.nftWalletId),
-    );
-    const inboxWalletId = nftWalletIds.find(
-      (nftWalletId: number) => !profileWalletIds.has(nftWalletId),
-    );
-    return nftWallets.find((wallet: Wallet) => wallet.id === inboxWalletId);
-  }, [profiles, nftWallets, isLoadingProfiles, isLoadingNFTWallets]);
+    return nftWallets.find((nftWallet: Wallet) => !nftWallet.meta.did);
+  }, [nftWallets, isLoadingProfiles, isLoadingNFTWallets]);
 
   const remainingNFTWallets = useMemo(() => {
     if (isLoadingProfiles || isLoadingNFTWallets || !inbox) {


### PR DESCRIPTION
Without this fix, it's possible that the "Unassigned" NFT wallet for some users will have an associated DID.