### PR TITLE
Position the CAT tooltip to the right of the label to avoid overlapping with the tail DB link

### DIFF
--- a/packages/wallets/src/components/WalletTokenCard.tsx
+++ b/packages/wallets/src/components/WalletTokenCard.tsx
@@ -170,20 +170,7 @@ export default function WalletTokenCard(props: WalletTokenCardProps) {
               minWidth={0}
             >
               {!!subTitle && (
-                <Tooltip
-                  title={subTitle}
-                  PopperProps={{
-                    popperOptions: {
-                      modifiers: [
-                        {
-                          name: 'offset',
-                          options: { offset: [0, -12] },
-                        },
-                      ],
-                    },
-                  }}
-                  copyToClipboard
-                >
+                <Tooltip title={subTitle} placement="right" copyToClipboard>
                   <Typography color="textSecondary" variant="caption" noWrap>
                     {subTitle}
                   </Typography>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/339312/189453724-40d6d262-e28b-45c9-8adf-20e7bc612ae2.png)
