### PR TITLE
Enable webpack fs caching to speed up launching via 'npm run dev:fast'

### DIFF
--- a/packages/gui/webpack.react.babel.ts
+++ b/packages/gui/webpack.react.babel.ts
@@ -58,6 +58,12 @@ export default {
   entry: path.join(CONTEXT, '/src/index'),
   target: 'electron-renderer',
   stats: 'errors-only',
+  cache: {
+    type: 'filesystem',
+    buildDependencies: {
+      config: [__filename],
+    },
+  },
   devServer: DEV
     ? {
         client: {


### PR DESCRIPTION
Relaunching takes ~12 seconds now compared to ~1:30 previously. I haven't noticed any increased build times as a result of this change.