### PR TITLE
Fix incorrect display of assets when viewing offers created by self

### DIFF
--- a/packages/gui/src/components/offers/NFTOfferViewer.tsx
+++ b/packages/gui/src/components/offers/NFTOfferViewer.tsx
@@ -313,7 +313,7 @@ export function NFTOfferSummary(props: NFTOfferSummaryProps) {
   const makerSummary: React.ReactElement = (
     <NFTOfferSummaryRow
       title={makerTitle}
-      summaryKey="offered"
+      summaryKey={isMyOffer ? 'requested' : 'offered'}
       summary={summary}
       unknownAssets={isMyOffer ? undefined : takerUnknownAssets}
       rowIndentation={rowIndentation}
@@ -324,7 +324,7 @@ export function NFTOfferSummary(props: NFTOfferSummaryProps) {
   const takerSummary: React.ReactElement = (
     <NFTOfferSummaryRow
       title={takerTitle}
-      summaryKey="requested"
+      summaryKey={isMyOffer ? 'offered' : 'requested'}
       summary={summary}
       unknownAssets={isMyOffer ? undefined : makerUnknownAssets}
       rowIndentation={rowIndentation}


### PR DESCRIPTION
When a user views an NFT offer that they created from the "Offers you created" list, the offered/requested assets are reversed. This fixes the issue by flipping the offered/requested assets in the above scenario.

Doesn't impact "imported" NFT offers (viewing from a blob/file).
Doesn't impact token offers as those use a separate component.