### PR TITLE
Fix crash when viewing an NFT with malformed attributes

### DIFF
--- a/packages/gui/src/components/nfts/NFTProperties.tsx
+++ b/packages/gui/src/components/nfts/NFTProperties.tsx
@@ -87,7 +87,10 @@ export default function NFTProperties(props: NFTPropertiesProps) {
   const { attributes } = props;
 
   const valueAttributes = useMemo(() => {
-    return attributes?.filter((attribute) => !isRankingAttribute(attribute));
+    if (Array.isArray(attributes)) {
+      return attributes.filter((attribute) => !isRankingAttribute(attribute));
+    }
+    return [];
   }, [attributes]);
 
   if (!valueAttributes?.length) {

--- a/packages/gui/src/components/nfts/NFTRankings.tsx
+++ b/packages/gui/src/components/nfts/NFTRankings.tsx
@@ -67,7 +67,10 @@ export default function NFTRankings(props: NFTRankingsProps) {
   const { attributes } = props;
 
   const rankingsAttributes = useMemo(() => {
-    return attributes?.filter(isRankingAttribute);
+    if (Array.isArray(attributes)) {
+      return attributes.filter(isRankingAttribute);
+    }
+    return [];
   }, [attributes]);
 
   if (!rankingsAttributes?.length) {


### PR DESCRIPTION
Fixes issue #1019

In the bug report, the NFT has `attributes` to set `{trait_type: 'un1qu3EXE', value: 'm32k13 7233'}` instead of being an array of objects.