### PR TITLE
Move playwright to optionalDependencies

### DIFF
--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -226,7 +226,6 @@
     "html-webpack-plugin": "5.5.0",
     "jest": "29.0.3",
     "lodash-webpack-plugin": "0.11.6",
-    "playwright": "^1.25.0",
     "react-refresh": "0.11.0",
     "source-map-loader": "^3.0.1",
     "style-loader": "3.3.1",
@@ -238,6 +237,9 @@
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.8.1",
     "xmldom": "github:xmldom/xmldom#0.8.0"
+  },
+  "optionalDependencies": {
+    "playwright": "^1.25.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This PR moves the playwright dependency into "optionalDependencies" to prevent CI failures on platforms that don't support playwright.


CI was failing on Ubuntu 18.04 with the following error:

```
npm ERR! Error: ERROR: Playwright does not support firefox on ubuntu18.04-arm64
npm ERR!     at Registry._downloadExecutable (/__w/chia-blockchain/chia-blockchain/chia-blockchain-gui/packages/gui/node_modules/playwright-core/lib/server/registry/index.js:671:57)
npm ERR!     at Object._install (/__w/chia-blockchain/chia-blockchain/chia-blockchain-gui/packages/gui/node_modules/playwright-core/lib/server/registry/index.js:465:28)
npm ERR!     at Registry.install (/__w/chia-blockchain/chia-blockchain/chia-blockchain-gui/packages/gui/node_modules/playwright-core/lib/server/registry/index.js:656:26)
npm ERR!     at async installBrowsersForNpmInstall (/__w/chia-blockchain/chia-blockchain/chia-blockchain-gui/packages/gui/node_modules/playwright-core/lib/server/registry/index.js:850:3)
```

Test builds were produced from this PR: https://github.com/Chia-Network/chia-blockchain/pull/13441