### PR TITLE
Fix bb2 workspace label

### DIFF
--- a/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
@@ -11,7 +11,7 @@ import {
   MenuItem,
   FormHelperText,
 } from '@mui/material';
-import { plotSizeOptions } from '../../../constants/plotSizes';
+import { getPlotSizeOptions } from '../../../constants/plotSizes';
 import Plotter from '../../../types/Plotter';
 
 const MIN_MAINNET_K_SIZE = 32;
@@ -35,10 +35,18 @@ export default function PlotAddChooseSize(props: Props) {
   const overrideK = watch('overrideK');
   const isKLow = plotSize < MIN_MAINNET_K_SIZE;
 
-  const [allowedPlotSizes, setAllowedPlotSizes] = useState(plotSizeOptions.filter((option) => plotter.options.kSizes.includes(option.value)));
+  const [allowedPlotSizes, setAllowedPlotSizes] = useState(
+    getPlotSizeOptions(plotterName).filter(option =>
+      plotter.options.kSizes.includes(option.value)
+    )
+  );
 
   useEffect(() => {
-    setAllowedPlotSizes(plotSizeOptions.filter((option) => plotter.options.kSizes.includes(option.value)));
+    setAllowedPlotSizes(
+      getPlotSizeOptions(plotterName).filter(option =>
+        plotter.options.kSizes.includes(option.value)
+      )
+    );
   }, [plotterName]);
 
   async function getConfirmation() {
@@ -87,7 +95,7 @@ export default function PlotAddChooseSize(props: Props) {
       </Typography>
 
       <Grid container>
-        <Grid xs={12} sm={10} md={8} lg={6} item>
+        <Grid xs={12} sm={10} md={8} lg={8} item>
           <FormControl variant="filled" fullWidth>
             <InputLabel required focused>
               <Trans>Plot Size</Trans>

--- a/packages/gui/src/components/plot/add/PlotAddForm.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddForm.tsx
@@ -15,10 +15,11 @@ import PlotAddSelectTemporaryDirectory from './PlotAddSelectTemporaryDirectory';
 import PlotAddSelectFinalDirectory from './PlotAddSelectFinalDirectory';
 import PlotAddNFT from './PlotAddNFT';
 import PlotAddConfig from '../../../types/PlotAdd';
-import plotSizes from '../../../constants/plotSizes';
+import { plottingInfo } from '../../../constants/plotSizes';
 import PlotNFTState from '../../../constants/PlotNFTState';
 import PlotterName from '../../../constants/PlotterName';
 import useUnconfirmedPlotNFTs from '../../../hooks/useUnconfirmedPlotNFTs';
+import { PlotterDefaults, PlotterOptions } from '../../../types/Plotter';
 
 type FormData = PlotAddConfig & {
   p2SingletonPuzzleHash?: string;
@@ -28,7 +29,17 @@ type FormData = PlotAddConfig & {
 
 type Props = {
   fingerprint: number;
-  plotters: Object;
+  plotters: Record<PlotterName, {
+    displayName: string;
+    version: string;
+    options: PlotterOptions;
+    defaults: PlotterDefaults;
+    installInfo: {
+      installed: boolean;
+      canInstall: boolean;
+      bladebitMemoryWarning?: string,
+    },
+  }>;
   currencyCode: string;
 };
 
@@ -66,7 +77,7 @@ export default function PlotAddForm(props: Props) {
     const plotterDefaults =
       plotters[plotterName]?.defaults ?? defaultPlotter.defaults;
     const plotSize = plotterDefaults.plotSize;
-    const maxRam = plotSizes.find(
+    const maxRam = plottingInfo[plotterName].find(
       (element) => element.value === plotSize,
     )?.defaultRam;
     const defaults = {
@@ -87,7 +98,7 @@ export default function PlotAddForm(props: Props) {
   const plotSize = watch('plotSize');
 
   useEffect(() => {
-    const plotSizeConfig = plotSizes.find((item) => item.value === plotSize);
+    const plotSizeConfig = plottingInfo[plotterName].find((item) => item.value === plotSize);
     if (plotSizeConfig) {
       setValue('maxRam', plotSizeConfig.defaultRam);
     }

--- a/packages/gui/src/components/plot/queue/PlotQueueSize.tsx
+++ b/packages/gui/src/components/plot/queue/PlotQueueSize.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import plotSizes from '../../../constants/plotSizes';
+import { getPlotSize } from '../../../constants/plotSizes';
 import type PlotQueueItem from '../../../types/PlotQueueItem';
 
 type Props = {
@@ -10,10 +10,10 @@ export default function PlotQueueSize(props: Props) {
   const {
     queueItem: { size },
   } = props;
-  const item = plotSizes.find((item) => item.value === size);
+  const item = getPlotSize(size as 25|32|33|34|35);
   if (!item) {
     return null;
   }
 
-  return <>{`K-${size}, ${item.label}`}</>;
+  return <>{`K-${size}, ${item}`}</>;
 }

--- a/packages/gui/src/constants/plotSizes.ts
+++ b/packages/gui/src/constants/plotSizes.ts
@@ -1,3 +1,5 @@
+import PlotterName from "./PlotterName";
+
 type PlotSize = {
   label: string;
   value: number;
@@ -5,25 +7,44 @@ type PlotSize = {
   defaultRam: number;
 };
 
-export const defaultPlotSize: PlotSize = {
-  label: '101.4GiB',
-  value: 32,
-  workspace: '239GiB',
-  defaultRam: 3390,
+export function getPlotSize(kSize: 25|32|33|34|35){
+  return {
+    25: '600MiB',
+    32: '101.4GiB',
+    33: '208.8GiB',
+    34: '429.8GiB',
+    35: '884.1GiB',
+  }[kSize] || "Size Unknown";
+}
+
+export const plottingInfo: Record<PlotterName, PlotSize[]> = {
+  [PlotterName.CHIAPOS]: [
+    { value: 25, label: getPlotSize(25), workspace: '1.8GiB', defaultRam: 512 },
+    { value: 32, label: getPlotSize(32), workspace: '239GiB', defaultRam: 3390 },
+    { value: 33, label: getPlotSize(33), workspace: '521GiB', defaultRam: 7400 },
+    // workspace are guesses using 55.35% - rounded up - past here
+    { value: 34, label: getPlotSize(34), workspace: '1041GiB', defaultRam: 14800 },
+    { value: 35, label: getPlotSize(35), workspace: '2175GiB', defaultRam: 29600 },
+  ],
+  [PlotterName.MADMAX]: [
+    { value: 25, label: getPlotSize(25), workspace: '1.8GiB', defaultRam: 512 },
+    { value: 32, label: getPlotSize(32), workspace: '239GiB', defaultRam: 3390 },
+    { value: 33, label: getPlotSize(33), workspace: '521GiB', defaultRam: 7400 },
+    // workspace are guesses using 55.35% - rounded up - past here
+    { value: 34, label: getPlotSize(34), workspace: '1041GiB', defaultRam: 14800 },
+    { value: 35, label: getPlotSize(35), workspace: '2175GiB', defaultRam: 29600 },
+  ],
+  [PlotterName.BLADEBIT]: [
+    { value: 32, label: getPlotSize(32), workspace: '416GiB', defaultRam: 3390 },
+  ],
+  [PlotterName.BLADEBIT2]: [
+    { value: 32, label: getPlotSize(32), workspace: '480GiB', defaultRam: 3390 },
+  ],
 };
 
-const plotSizes: PlotSize[] = [
-  { label: '600MiB', value: 25, workspace: '1.8GiB', defaultRam: 512 },
-  defaultPlotSize,
-  { label: '208.8GiB', value: 33, workspace: '521GiB', defaultRam: 7400 },
-  // workspace are guesses using 55.35% - rounded up - past here
-  { label: '429.8GiB', value: 34, workspace: '1041GiB', defaultRam: 14800 },
-  { label: '884.1GiB', value: 35, workspace: '2175GiB', defaultRam: 29600 },
-];
-
-export const plotSizeOptions = plotSizes.map((item) => ({
-  value: item.value,
-  label: `${item.label} (k=${item.value}, temporary space: ${item.workspace})`,
-}));
-
-export default plotSizes;
+export function getPlotSizeOptions(plotterName: PlotterName){
+  return plottingInfo[plotterName].map((item) => ({
+    value: item.value,
+    label: `${item.label} (k=${item.value}, temporary space: ${item.workspace})`,
+  }));
+}


### PR DESCRIPTION
## Original problem
Workspace label for bladebit2 was wrong (It showed 239GiB but actually around 480GiB is required)

## Challenge and solution
- Workspace sizes could not be set for each plotter. The workspace size values were shared among all the plotters.
- So I tried to separate plotting info for each plotter

## Note
This PR must be merged to `1.6.1`