### PR TITLE
Fixed wallet balance graph bugs #1068

### DIFF
--- a/packages/wallets/src/components/card/WalletCardTotalBalance.tsx
+++ b/packages/wallets/src/components/card/WalletCardTotalBalance.tsx
@@ -91,7 +91,12 @@ export default function WalletCardTotalBalance(props: Props) {
     >
       <Flex flexGrow={1} />
       <StyledGraphContainer>
-        <WalletGraph walletId={walletId} height={80} />
+        <WalletGraph
+          walletId={walletId}
+          walletType={wallet.type}
+          unit={unit.length > 0 ? unit.toUpperCase() : wallet.name}
+          height={80}
+        />
       </StyledGraphContainer>
     </CardSimple>
   );


### PR DESCRIPTION
* The graph units were assumed to be XCH. The wallet type and name are now passed in to handle CATs.
* Fixed the graph appearance when only a single transaction was present.

Should also address: #1065