### PR TITLE
One-sided offers should not be possible [Bug] #1082

### DIFF
--- a/packages/gui/src/util/offerBuilderDataToOffer.ts
+++ b/packages/gui/src/util/offerBuilderDataToOffer.ts
@@ -46,8 +46,12 @@ export default async function offerBuilderDataToOffer(
   const hasRequest =
     !!requestedXch.length || !!requestedTokens.length || !!requestedNfts.length;
 
-  if (!hasOffer && !hasRequest) {
-    throw new Error(t`Offer or request must be specified`);
+  if (!hasRequest) {
+    throw new Error(t`Please specify at least one requested asset`);
+  }
+
+  if (!hasOffer) {
+    throw new Error(t`Please specify at least one offered asset`);
   }
 
   await Promise.all(


### PR DESCRIPTION
Fix for One-sided offers should not be possible [Bug] #1082

Use the offer builder to make an offer where only one side has any assets. For example,

1 XCH in exchange for nothing
nothing in exchange for 1 XCH

This shouldn't be allowed