### PR TITLE
Tighten up sensitive_content checking

### DIFF
--- a/packages/gui/src/hooks/useNFTMetadata.ts
+++ b/packages/gui/src/hooks/useNFTMetadata.ts
@@ -6,7 +6,12 @@ import { useLocalStorage } from '@chia/api-react';
 export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
 
 function normalizedSensitiveContent(value: any): boolean {
-  return typeof value === 'boolean' ? value : value === 'true';
+  if (typeof value === 'boolean') {
+    return value;
+  } else if (Array.isArray(value) && value.length > 0) {
+    return true;
+  }
+  return value === 'true';
 }
 
 export default function useNFTsMetadata(nfts: NFTInfo[], isMultiple = false) {

--- a/packages/gui/src/hooks/useNFTMetadata.ts
+++ b/packages/gui/src/hooks/useNFTMetadata.ts
@@ -5,6 +5,10 @@ import { useLocalStorage } from '@chia/api-react';
 
 export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
 
+function normalizedSensitiveContent(value: any): boolean {
+  return typeof value === 'boolean' ? value : value === 'true';
+}
+
 export default function useNFTsMetadata(nfts: NFTInfo[], isMultiple = false) {
   const nft = nfts[0];
   const nftId = nft?.$nftId;
@@ -23,17 +27,20 @@ export default function useNFTsMetadata(nfts: NFTInfo[], isMultiple = false) {
     {},
   );
 
-  function setSensitiveContent(metadataString: string) {
-    let object;
+  function setSensitiveContent(nftId: string, metadata: Record<string, any>) {
     try {
-      object = JSON.parse(metadataString);
+      const sensitiveContentValue = normalizedSensitiveContent(
+        metadata.sensitive_content,
+      );
 
-      if (object.sensitive_content) {
+      if (sensitiveContentValue) {
         setSensitiveContentObject(
-          Object.assign({}, sensitiveContentObject, { [nft.$nftId]: true }),
+          Object.assign({}, sensitiveContentObject, { [nftId]: true }),
         );
       }
-    } catch (e) {}
+    } catch (e) {
+      // Do nothing
+    }
   }
 
   async function getMetadataContents({ dataHash, nftId, uri }): Promise<{
@@ -46,10 +53,18 @@ export default function useNFTsMetadata(nfts: NFTInfo[], isMultiple = false) {
       let metadata;
       const cachedMetadata = localStorage.getItem(`metadata-cache-${nftId}`);
       try {
-        obj = JSON.parse(cachedMetadata);
-        metadata = JSON.parse(obj.json);
-      } catch (e) {}
-      if (isMultiple && metadata && !metadata.sensitive_content) {
+        if (cachedMetadata) {
+          obj = JSON.parse(cachedMetadata);
+          metadata = JSON.parse(obj.json);
+        }
+      } catch (e) {
+        // Do nothing
+      }
+      if (
+        isMultiple &&
+        metadata &&
+        !normalizedSensitiveContent(metadata.sensitive_content)
+      ) {
         allowedNFTs.push(nftId);
       }
     } else {
@@ -111,8 +126,11 @@ export default function useNFTsMetadata(nfts: NFTInfo[], isMultiple = false) {
         });
       }
       setMetadata(metadata);
-      setSensitiveContent(metadata);
-      if (isMultiple && !metadata.sensitive_content) {
+      setSensitiveContent(nftId, metadata);
+      if (
+        isMultiple &&
+        !normalizedSensitiveContent(metadata.sensitive_content)
+      ) {
         allowedNFTs.push(nftId);
       }
     } catch (error: any) {


### PR DESCRIPTION
Fixed issue where benign NFTs could be flagged as sensitive_content

Metadata with `"sensitive_content" : "false"` was being flagged as sensitive content. We now check for a boolean value of true, or a string of 'true'.

Additionally, the `setSensitiveContent()` nested function was incorrectly assuming that the passed in data was a string, instead of an already parsed JSON object. The captured values inside of the nested function were also not necessarily the expected values, so `setSensitiveContent()` now takes the `nftId` as a function param.