### PR TITLE
Show royalty amounts and totals when viewing an offer

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -1968,6 +1968,11 @@ export const walletApi = apiWithTag.injectEndpoints({
         args: [request],
       }),
       providesTags: ['NFTRoyalties'],
+      transformResponse: (response) => {
+        // Move royalties to a 'royalties' key to avoid co-mingling with success/error keys
+        const { success, ...royalties } = response;
+        return { royalties: { ...royalties }, success };
+      },
     }),
 
     getNFTsByNFTIDs: build.query<any, { nftIds: string[] }>({

--- a/packages/api/src/@types/CalculateRoyaltiesResponse.ts
+++ b/packages/api/src/@types/CalculateRoyaltiesResponse.ts
@@ -2,7 +2,9 @@ import Response from './Response';
 import RoyaltyCalculationFungibleAssetPayout from './RoyaltyCalculationFungibleAssetPayout';
 
 type CalculateRoyaltiesResponse = Response & {
-  [key: string]: RoyaltyCalculationFungibleAssetPayout[];
+  royalties: {
+    [key: string]: RoyaltyCalculationFungibleAssetPayout[];
+  };
 };
 
 export default CalculateRoyaltiesResponse;

--- a/packages/api/src/wallets/NFT.ts
+++ b/packages/api/src/wallets/NFT.ts
@@ -1,8 +1,5 @@
 import Wallet from '../services/Wallet';
-import {
-  CalculateRoyaltiesRequest,
-  CalculateRoyaltiesResponse,
-} from '../@types';
+import { CalculateRoyaltiesRequest } from '../@types';
 
 export default class NFTWallet extends Wallet {
   async getNfts(walletId: number) {

--- a/packages/api/src/wallets/NFT.ts
+++ b/packages/api/src/wallets/NFT.ts
@@ -77,7 +77,7 @@ export default class NFTWallet extends Wallet {
 
   async calculateRoyalties(
     req: CalculateRoyaltiesRequest
-  ): Promise<CalculateRoyaltiesResponse> {
+  ): Promise<Record<string, any>> {
     return this.command('nft_calculate_royalties', req);
   }
 }

--- a/packages/gui/src/components/offers2/OfferBuilder.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilder.tsx
@@ -10,6 +10,7 @@ import { Grid } from '@mui/material';
 import OfferBuilderProvider from './OfferBuilderProvider';
 import OfferBuilderTradeColumn from './OfferBuilderTradeColumn';
 import type OfferBuilderData from '../../@types/OfferBuilderData';
+import OfferState from '../offers/OfferState';
 
 export const emptyDefaultValues = {
   offered: {
@@ -31,6 +32,7 @@ export type OfferBuilderProps = {
   readOnly?: boolean;
   viewer?: boolean;
   imported?: boolean;
+  state?: OfferState;
   onSubmit: (values: OfferBuilderData) => Promise<void>;
   defaultValues?: OfferBuilderData;
 };
@@ -42,6 +44,7 @@ function OfferBuilder(props: OfferBuilderProps, ref: any) {
     viewer = false,
     imported = false,
     defaultValues = emptyDefaultValues,
+    state,
     onSubmit,
   } = props;
 
@@ -96,6 +99,7 @@ function OfferBuilder(props: OfferBuilderProps, ref: any) {
       <OfferBuilderProvider
         isMyOffer={isMyOffer}
         imported={imported}
+        state={state}
         readOnly={readOnly}
       >
         <Grid spacing={3} rowSpacing={4} container>

--- a/packages/gui/src/components/offers2/OfferBuilderContext.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderContext.tsx
@@ -1,9 +1,12 @@
 import { createContext } from 'react';
 import type { CalculateRoyaltiesResponse } from '@chia/api';
+import OfferState from '../offers/OfferState';
 
 export interface OfferBuilderContextData {
   readOnly: boolean;
   imported: boolean;
+  isMyOffer: boolean;
+  state?: OfferState;
   offeredUnknownCATs?: string[];
   requestedUnknownCATs?: string[];
   usedAssetIds: string[];

--- a/packages/gui/src/components/offers2/OfferBuilderFeeSection.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderFeeSection.tsx
@@ -21,7 +21,7 @@ export default function OfferBuilderFeeSection(
 ) {
   const { name, offering, viewer } = props;
   const { wallet, loading } = useStandardWallet();
-  const { imported } = useOfferBuilderContext();
+  const { imported, state } = useOfferBuilderContext();
   const { unit = '' } = useWallet(wallet?.id);
 
   const hideBalance = !offering;
@@ -42,6 +42,9 @@ export default function OfferBuilderFeeSection(
     remove(index);
   }
 
+  const canAdd =
+    (!fields.length && state === undefined) || // If in builder mode, or in viewer mode when offer hasn't been accepted
+    (viewer && imported && !offering); // If in viewer mode when offer has not been accepted and showing the requesting side
   const disableReadOnly = offering && viewer && imported;
 
   return (
@@ -51,7 +54,7 @@ export default function OfferBuilderFeeSection(
       subtitle={
         <Trans>Optional network fee to expedite acceptance of your offer</Trans>
       }
-      onAdd={!fields.length && !viewer ? handleAdd : undefined}
+      onAdd={canAdd ? handleAdd : undefined}
       expanded={!!fields.length}
       disableReadOnly={disableReadOnly}
     >

--- a/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Trans } from '@lingui/macro';
 import { Flex, Loading } from '@chia/core';
 import { useGetNFTInfoQuery } from '@chia/api-react';
@@ -29,7 +29,7 @@ function PreviewCard(props) {
   );
 }
 
-export type OfferBuilderNFTProps = {
+export type OfferBuilderNFTProps = ReactNode & {
   name: string;
   onRemove?: () => void;
   provenance?: boolean;

--- a/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
@@ -1,11 +1,12 @@
 import React, { ReactNode } from 'react';
 import { Trans } from '@lingui/macro';
-import { Flex, Loading } from '@chia/core';
+import { Flex, Loading, Tooltip } from '@chia/core';
 import { useGetNFTInfoQuery } from '@chia/api-react';
 import { useWatch } from 'react-hook-form';
 import { Grid, Typography, Card } from '@mui/material';
 import NFTCard from '../nfts/NFTCard';
 import { launcherIdFromNFTId } from '../../util/nfts';
+import useNFTMinterDID from '../../hooks/useNFTMinterDID';
 import { NFTContextualActionTypes } from '../nfts/NFTContextualActions';
 import OfferBuilderValue from './OfferBuilderValue';
 import OfferBuilderNFTProvenance from './OfferBuilderNFTProvenance';
@@ -43,6 +44,7 @@ export default function OfferBuilderNFT(props: OfferBuilderNFTProps) {
   const value = useWatch({
     name: fieldName,
   });
+  const { didId: minterDID, didName: minterDIDName } = useNFTMinterDID(value);
 
   const launcherId = launcherIdFromNFTId(value ?? '');
 
@@ -58,12 +60,26 @@ export default function OfferBuilderNFT(props: OfferBuilderNFTProps) {
 
   return (
     <Flex flexDirection="column" gap={2}>
-      <OfferBuilderValue
-        name={fieldName}
-        type="text"
-        label={<Trans>NFT ID</Trans>}
-        onRemove={onRemove}
-      />
+      <Flex flexDirection="column" gap={1}>
+        <OfferBuilderValue
+          name={fieldName}
+          type="text"
+          label={<Trans>NFT ID</Trans>}
+          onRemove={onRemove}
+        />
+        {(minterDID || minterDIDName) && (
+          <Flex flexDirection="column" gap={1}>
+            <Typography variant="body1" color="textSecondary">
+              <Trans>Minter</Trans>
+            </Typography>
+            <Tooltip title={minterDID} copyToClipboard>
+              <Typography variant="body2" color="textPrimary" noWrap>
+                {minterDIDName ?? minterDID}
+              </Typography>
+            </Tooltip>
+          </Flex>
+        )}
+      </Flex>
 
       {value && (
         <Flex flexDirection="column" gap={2}>

--- a/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { Trans } from '@lingui/macro';
 import { Flex, Loading, Tooltip } from '@chia/core';
 import { useGetNFTInfoQuery } from '@chia/api-react';
@@ -30,7 +30,7 @@ function PreviewCard(props) {
   );
 }
 
-export type OfferBuilderNFTProps = ReactNode & {
+export type OfferBuilderNFTProps = {
   name: string;
   onRemove?: () => void;
   provenance?: boolean;

--- a/packages/gui/src/components/offers2/OfferBuilderProvider.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderProvider.tsx
@@ -14,12 +14,14 @@ import {
 import { catToMojo, chiaToMojo } from '@chia/core';
 import OfferBuilderContext from './OfferBuilderContext';
 import getUnknownCATs from '../../util/getUnknownCATs';
+import OfferState from '../offers/OfferState';
 
 export type OfferBuilderProviderProps = {
   children: ReactNode;
   readOnly?: boolean;
   isMyOffer?: boolean;
   imported?: boolean;
+  state?: OfferState;
 };
 
 export default function OfferBuilderProvider(props: OfferBuilderProviderProps) {
@@ -28,12 +30,13 @@ export default function OfferBuilderProvider(props: OfferBuilderProviderProps) {
     readOnly = false,
     isMyOffer = false,
     imported = false,
+    state,
   } = props;
   let royaltyNFTsSelector = undefined;
   let fungibleXCHSelector = undefined;
   let fungibleTokenSelector = undefined;
 
-  if (readOnly && isMyOffer) {
+  if (readOnly) {
     royaltyNFTsSelector = 'requested.nfts';
     fungibleXCHSelector = 'offered.xch';
     fungibleTokenSelector = 'offered.tokens';
@@ -111,11 +114,13 @@ export default function OfferBuilderProvider(props: OfferBuilderProviderProps) {
 
   const skipRoyalitiesCalculation =
     request.royaltyAssets.length === 0 || request.fungibleAssets.length === 0;
-  const { data: updatedRoyalties, isLoading: isCalculatingRoyalties } =
+  const { data: royaltiesData, isLoading: isCalculatingRoyalties } =
     useCalculateRoyaltiesForNFTsQuery(request, {
       skip: skipRoyalitiesCalculation,
     });
-  const royalties = skipRoyalitiesCalculation ? undefined : updatedRoyalties;
+  const royalties = skipRoyalitiesCalculation
+    ? undefined
+    : royaltiesData?.royalties;
 
   const usedAssetIds = useMemo(() => {
     const used: string[] = [];
@@ -138,6 +143,8 @@ export default function OfferBuilderProvider(props: OfferBuilderProviderProps) {
     () => ({
       readOnly,
       imported,
+      isMyOffer,
+      state,
       offeredUnknownCATs,
       requestedUnknownCATs,
       usedAssetIds,
@@ -147,6 +154,8 @@ export default function OfferBuilderProvider(props: OfferBuilderProviderProps) {
     [
       readOnly,
       imported,
+      isMyOffer,
+      state,
       offeredUnknownCATs,
       requestedUnknownCATs,
       usedAssetIds,

--- a/packages/gui/src/components/offers2/OfferBuilderRoyaltyPayouts.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderRoyaltyPayouts.tsx
@@ -1,0 +1,76 @@
+import React, { ReactNode } from 'react';
+import { Trans } from '@lingui/macro';
+import { RoyaltyCalculationFungibleAssetPayout } from '@chia/api';
+import { CopyToClipboard, Flex } from '@chia/core';
+import { Box, Divider } from '@mui/material';
+import styled from 'styled-components';
+
+const StyledTitle = styled(Box)`
+  font-size: 0.625rem;
+  color: rgba(255, 255, 255, 0.7);
+`;
+
+const StyledValue = styled(Box)`
+  word-break: break-all;
+`;
+
+type NFTId = string;
+
+export type OfferBuilderRoyaltyPayoutsProps = ReactNode & {
+  totalAmount: string;
+  originalAmount: string;
+  royaltyPayments: Record<NFTId, RoyaltyCalculationFungibleAssetPayout>[];
+};
+
+export default function OfferBuilderRoyaltyPayouts(
+  props: OfferBuilderRoyaltyPayoutsProps,
+) {
+  const { totalAmount, originalAmount, royaltyPayments } = props;
+
+  return (
+    <Flex flexDirection="column" gap={1}>
+      <Flex flexDirection="column" gap={0}>
+        <StyledTitle>
+          <Trans>Total amount including royalties</Trans>
+        </StyledTitle>
+        <StyledValue>{totalAmount}</StyledValue>
+      </Flex>
+      <Flex flexDirection="column" gap={0}>
+        <StyledTitle>
+          <Trans>Amount before adding royalties</Trans>
+        </StyledTitle>
+        <StyledValue>{originalAmount}</StyledValue>
+      </Flex>
+      {royaltyPayments.length > 0 && <Divider />}
+      {royaltyPayments.map(({ nftId, payment }, i) => (
+        <Flex key={i} flexDirection="column" gap={1}>
+          <Flex flexDirection="row" alignItems="center" gap={1}>
+            <Flex flexDirection="column" gap={0}>
+              <StyledTitle>
+                <Trans>Asset</Trans>
+              </StyledTitle>
+              <StyledValue>{nftId}</StyledValue>
+            </Flex>
+            <CopyToClipboard value={nftId} fontSize="small" invertColor />
+          </Flex>
+          <Flex flexDirection="column" gap={0}>
+            <StyledTitle>Royalty Amount</StyledTitle>
+            <StyledValue>{payment.displayAmount}</StyledValue>
+          </Flex>
+          <Flex flexDirection="row" alignItems="center" gap={1}>
+            <Flex flexDirection="column" gap={0}>
+              <StyledTitle>Royalty Recipient</StyledTitle>
+              <StyledValue>{payment.address}</StyledValue>
+            </Flex>
+            <CopyToClipboard
+              value={payment.address}
+              fontSize="small"
+              invertColor
+            />
+          </Flex>
+          {i < royaltyPayments.length - 1 && <Divider />}
+        </Flex>
+      ))}
+    </Flex>
+  );
+}

--- a/packages/gui/src/components/offers2/OfferBuilderRoyaltyPayouts.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderRoyaltyPayouts.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { Trans } from '@lingui/macro';
 import { RoyaltyCalculationFungibleAssetPayout } from '@chia/api';
 import { CopyToClipboard, Flex } from '@chia/core';
@@ -16,7 +16,7 @@ const StyledValue = styled(Box)`
 
 type NFTId = string;
 
-export type OfferBuilderRoyaltyPayoutsProps = ReactNode & {
+export type OfferBuilderRoyaltyPayoutsProps = {
   totalAmount: string;
   originalAmount: string;
   royaltyPayments: Record<NFTId, RoyaltyCalculationFungibleAssetPayout>[];

--- a/packages/gui/src/components/offers2/OfferBuilderToken.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderToken.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
+import BigNumber from 'bignumber.js';
 import { Trans } from '@lingui/macro';
 import { Grid } from '@mui/material';
 import type { Wallet } from '@chia/api';
@@ -7,15 +8,24 @@ import { useWatch } from 'react-hook-form';
 import OfferBuilderValue from './OfferBuilderValue';
 import OfferBuilderWalletAmount from './OfferBuilderWalletAmount';
 
-export type OfferBuilderTokenProps = {
+export type OfferBuilderTokenProps = ReactNode & {
   name: string;
   onRemove?: () => void;
   usedAssets?: string[];
   hideBalance?: boolean;
+  amountWithRoyalties?: string;
+  royaltyPayments?: Record<string, any>[];
 };
 
 export default function OfferBuilderToken(props: OfferBuilderTokenProps) {
-  const { name, onRemove, usedAssets, hideBalance } = props;
+  const {
+    name,
+    onRemove,
+    usedAssets,
+    hideBalance,
+    amountWithRoyalties,
+    royaltyPayments,
+  } = props;
 
   const assetIdFieldName = `${name}.assetId`;
   const assetId = useWatch({
@@ -34,9 +44,10 @@ export default function OfferBuilderToken(props: OfferBuilderTokenProps) {
         <OfferBuilderWalletAmount
           name={`${name}.amount`}
           walletId={wallet?.id}
-          label={<Trans>Amount</Trans>}
           showAmountInMojos={false}
           hideBalance={hideBalance}
+          amountWithRoyalties={amountWithRoyalties}
+          royaltyPayments={royaltyPayments}
         />
       </Grid>
       <Grid xs={12} md={7} item>

--- a/packages/gui/src/components/offers2/OfferBuilderToken.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderToken.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from 'react';
-import BigNumber from 'bignumber.js';
 import { Trans } from '@lingui/macro';
 import { Grid } from '@mui/material';
 import type { Wallet } from '@chia/api';

--- a/packages/gui/src/components/offers2/OfferBuilderToken.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderToken.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { Trans } from '@lingui/macro';
 import { Grid } from '@mui/material';
 import type { Wallet } from '@chia/api';
@@ -7,7 +7,7 @@ import { useWatch } from 'react-hook-form';
 import OfferBuilderValue from './OfferBuilderValue';
 import OfferBuilderWalletAmount from './OfferBuilderWalletAmount';
 
-export type OfferBuilderTokenProps = ReactNode & {
+export type OfferBuilderTokenProps = {
   name: string;
   onRemove?: () => void;
   usedAssets?: string[];

--- a/packages/gui/src/components/offers2/OfferBuilderTokensSection.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderTokensSection.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { Trans } from '@lingui/macro';
 import { Tokens } from '@chia/icons';
-import { Flex } from '@chia/core';
+import { Flex, Loading, catToMojo, mojoToCATLocaleString } from '@chia/core';
 import { WalletType } from '@chia/api';
 import type { Wallet } from '@chia/api';
 import { useGetWalletsQuery } from '@chia/api-react';
@@ -9,6 +9,7 @@ import { useFieldArray, useWatch } from 'react-hook-form';
 import OfferBuilderSection from './OfferBuilderSection';
 import OfferBuilderToken from './OfferBuilderToken';
 import useOfferBuilderContext from '../../hooks/useOfferBuilderContext';
+import BigNumber from 'bignumber.js';
 
 export type OfferBuilderTokensSectionProps = {
   name: string;
@@ -21,14 +22,70 @@ export default function OfferBuilderTokensSection(
 ) {
   const { name, offering, muted } = props;
 
-  const { data: wallets } = useGetWalletsQuery();
+  const { data: wallets, isLoading: isLoadingWallets } = useGetWalletsQuery();
   const { fields, append, remove } = useFieldArray({
     name,
   });
-
   const tokens = useWatch({
     name,
   });
+  const {
+    readOnly,
+    royalties: allRoyalties,
+    isCalculatingRoyalties,
+  } = useOfferBuilderContext();
+  const loading = isLoadingWallets || isCalculatingRoyalties;
+
+  const [amountWithRoyalties, royaltiesByAssetId] = useMemo(() => {
+    if (!readOnly || !allRoyalties) {
+      return [];
+    }
+
+    const tokenAmountsWithRoyalties: Record<string, BigNumber> = {};
+    const royaltiesByAssetId: Record<string, any> = {};
+    const assetIds = fields.map((field) => field.assetId);
+
+    fields.forEach((field) => {
+      tokenAmountsWithRoyalties[field.assetId] = catToMojo(field.amount ?? 0);
+    });
+
+    assetIds.map((assetId) => {
+      Object.entries(allRoyalties).forEach(([nftId, royaltyPayments]) => {
+        const royaltyPayment = royaltyPayments?.find(
+          (payment) => payment.asset === assetId,
+        );
+
+        if (royaltyPayment) {
+          if (!royaltiesByAssetId[assetId]) {
+            royaltiesByAssetId[assetId] = [];
+          }
+
+          const baseTotal: BigNumber =
+            tokenAmountsWithRoyalties[royaltyPayment.asset];
+          const totalAmount = baseTotal.plus(royaltyPayment.amount);
+
+          tokenAmountsWithRoyalties[royaltyPayment.asset] = totalAmount;
+
+          royaltiesByAssetId[assetId].push({
+            nftId,
+            payment: {
+              asset: royaltyPayment.asset,
+              amount: royaltyPayment.amount,
+              address: royaltyPayment.address,
+              displayAmount: mojoToCATLocaleString(royaltyPayment.amount),
+            },
+          });
+        }
+      });
+    });
+
+    const amountsWithRoyalties: Record<string, string> = {};
+    Object.entries(tokenAmountsWithRoyalties).forEach(([assetId, amount]) => {
+      amountsWithRoyalties[assetId] = mojoToCATLocaleString(amount);
+    });
+
+    return [amountsWithRoyalties, royaltiesByAssetId];
+  }, [fields, readOnly, allRoyalties]);
 
   function handleAdd() {
     append({
@@ -70,17 +127,23 @@ export default function OfferBuilderTokensSection(
       expanded={!!fields.length}
       muted={muted}
     >
-      <Flex gap={4} flexDirection="column">
-        {fields.map((field, index) => (
-          <OfferBuilderToken
-            key={field.id}
-            // usedAssets={usedAssets}
-            name={`${name}.${index}`}
-            onRemove={() => handleRemove(index)}
-            hideBalance={!offering}
-          />
-        ))}
-      </Flex>
+      {loading ? (
+        <Loading />
+      ) : (
+        <Flex gap={4} flexDirection="column">
+          {fields.map((field, index) => (
+            <OfferBuilderToken
+              key={field.id}
+              // usedAssets={usedAssets}
+              name={`${name}.${index}`}
+              onRemove={() => handleRemove(index)}
+              hideBalance={!offering}
+              amountWithRoyalties={amountWithRoyalties?.[field.assetId]}
+              royaltyPayments={royaltiesByAssetId?.[field.assetId]}
+            />
+          ))}
+        </Flex>
+      )}
     </OfferBuilderSection>
   );
 }

--- a/packages/gui/src/components/offers2/OfferBuilderValue.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderValue.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { useWatch } from 'react-hook-form';
 import { Trans } from '@lingui/macro';
 import {
@@ -20,7 +20,7 @@ import useOfferBuilderContext from '../../hooks/useOfferBuilderContext';
 import OfferBuilderTokenSelector from './OfferBuilderTokenSelector';
 import OfferBuilderRoyaltyPayouts from './OfferBuilderRoyaltyPayouts';
 
-export type OfferBuilderValueProps = ReactNode & {
+export type OfferBuilderValueProps = {
   name: string;
   label: ReactNode;
   caption?: ReactNode;

--- a/packages/gui/src/components/offers2/OfferBuilderValue.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderValue.tsx
@@ -3,6 +3,7 @@ import { useWatch } from 'react-hook-form';
 import { Trans } from '@lingui/macro';
 import {
   Amount,
+  CopyToClipboard,
   Fee,
   Flex,
   FormatLargeNumber,
@@ -17,8 +18,9 @@ import { Box, Typography, IconButton } from '@mui/material';
 import { Remove } from '@mui/icons-material';
 import useOfferBuilderContext from '../../hooks/useOfferBuilderContext';
 import OfferBuilderTokenSelector from './OfferBuilderTokenSelector';
+import OfferBuilderRoyaltyPayouts from './OfferBuilderRoyaltyPayouts';
 
-export type OfferBuilderValueProps = {
+export type OfferBuilderValueProps = ReactNode & {
   name: string;
   label: ReactNode;
   caption?: ReactNode;
@@ -30,6 +32,8 @@ export type OfferBuilderValueProps = {
   usedAssets?: string[];
   disableReadOnly?: boolean;
   warnUnknownCAT?: boolean;
+  amountWithRoyalties?: string;
+  royaltyPayments?: Record<string, any>[];
 };
 
 export default function OfferBuilderValue(props: OfferBuilderValueProps) {
@@ -45,6 +49,8 @@ export default function OfferBuilderValue(props: OfferBuilderValueProps) {
     usedAssets,
     disableReadOnly = false,
     warnUnknownCAT = false,
+    amountWithRoyalties,
+    royaltyPayments,
   } = props;
   const {
     readOnly: builderReadOnly,
@@ -54,9 +60,10 @@ export default function OfferBuilderValue(props: OfferBuilderValueProps) {
   const value = useWatch({
     name,
   });
-
   const readOnly = disableReadOnly ? false : builderReadOnly;
-  const displayValue = !value ? (
+  const displayValue = amountWithRoyalties ? (
+    amountWithRoyalties
+  ) : !value ? (
     <Trans>Not Available</Trans>
   ) : ['amount', 'fee', 'token'].includes(type) && Number.isFinite(value) ? (
     <FormatLargeNumber value={value} />
@@ -75,19 +82,35 @@ export default function OfferBuilderValue(props: OfferBuilderValueProps) {
           </Typography>
           <Tooltip
             title={
-              <Flex flexDirection="column" gap={1}>
-                {displayValue}
-                {type === 'token' ? (
-                  <Link
-                    href={`https://www.taildatabase.com/tail/${value.toLowerCase()}`}
-                    target="_blank"
-                  >
-                    <Trans>Search on Tail Database</Trans>
-                  </Link>
-                ) : null}
-              </Flex>
+              royaltyPayments && amountWithRoyalties ? (
+                <OfferBuilderRoyaltyPayouts
+                  totalAmount={amountWithRoyalties}
+                  originalAmount={value}
+                  royaltyPayments={royaltyPayments}
+                />
+              ) : (
+                <Flex flexDirection="column" gap={1}>
+                  <Flex flexDirection="row" alignItems="center" gap={1}>
+                    <Flex flexDirection="column" gap={1} maxWidth={200}>
+                      {displayValue}
+                      {type === 'token' ? (
+                        <Link
+                          href={`https://www.taildatabase.com/tail/${value.toLowerCase()}`}
+                          target="_blank"
+                        >
+                          <Trans>Search on Tail Database</Trans>
+                        </Link>
+                      ) : null}
+                    </Flex>
+                    <CopyToClipboard
+                      value={displayValue}
+                      fontSize="small"
+                      invertColor
+                    />
+                  </Flex>
+                </Flex>
+              )
             }
-            copyToClipboard
           >
             <Typography variant="h6" noWrap>
               {type === 'token' ? (

--- a/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
@@ -107,7 +107,7 @@ export default function OfferBuilderViewer(props: OfferBuilderViewerProps) {
   const missingRequestedCATs = requestedUnknownCATs?.length ?? 0 > 0;
 
   const canAccept = !!offerData;
-  const disableAccept = missingOfferedCATs;
+  const disableAccept = missingOfferedCATs || showInvalid;
 
   const isLoading = isLoadingWallets || !offerBuilderData;
 
@@ -205,6 +205,7 @@ export default function OfferBuilderViewer(props: OfferBuilderViewerProps) {
             ref={offerBuilderRef}
             isMyOffer={isMyOffer}
             imported={imported}
+            state={state}
             readOnly
             viewer
           />

--- a/packages/gui/src/components/offers2/OfferBuilderWalletAmount.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderWalletAmount.tsx
@@ -4,13 +4,15 @@ import { useWallet } from '@chia/wallets';
 import OfferBuilderValue from './OfferBuilderValue';
 import OfferBuilderWalletBalance from './OfferBuilderWalletBalance';
 
-export type OfferBuilderWalletAmountProps = {
+export type OfferBuilderWalletAmountProps = ReactNode & {
   name: string;
   walletId: number;
   label?: ReactNode;
   onRemove?: () => void;
   showAmountInMojos?: boolean;
   hideBalance?: boolean;
+  amountWithRoyalties?: string;
+  royaltyPayments?: Record<string, any>[];
 };
 
 export default function OfferBuilderWalletAmount(
@@ -22,7 +24,9 @@ export default function OfferBuilderWalletAmount(
     onRemove,
     showAmountInMojos,
     hideBalance = false,
-    label = <Trans>Amount</Trans>,
+    label,
+    amountWithRoyalties,
+    royaltyPayments,
   } = props;
 
   const { unit = '' } = useWallet(walletId);
@@ -30,7 +34,14 @@ export default function OfferBuilderWalletAmount(
   return (
     <OfferBuilderValue
       name={name}
-      label={label}
+      label={
+        label ??
+        (amountWithRoyalties ? (
+          <Trans>Total Amount</Trans>
+        ) : (
+          <Trans>Amount</Trans>
+        ))
+      }
       type="amount"
       symbol={unit}
       showAmountInMojos={showAmountInMojos}
@@ -39,6 +50,8 @@ export default function OfferBuilderWalletAmount(
         !hideBalance && <OfferBuilderWalletBalance walletId={walletId} />
       }
       onRemove={onRemove}
+      amountWithRoyalties={amountWithRoyalties}
+      royaltyPayments={royaltyPayments}
     />
   );
 }

--- a/packages/gui/src/components/offers2/OfferBuilderWalletAmount.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderWalletAmount.tsx
@@ -1,10 +1,10 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { Trans } from '@lingui/macro';
 import { useWallet } from '@chia/wallets';
 import OfferBuilderValue from './OfferBuilderValue';
 import OfferBuilderWalletBalance from './OfferBuilderWalletBalance';
 
-export type OfferBuilderWalletAmountProps = ReactNode & {
+export type OfferBuilderWalletAmountProps = {
   name: string;
   walletId: number;
   label?: ReactNode;


### PR DESCRIPTION
Show the breakdown of royalties for each CAT/XCH amount in the offer
Fixed fee section expansion when viewing an offer
Fixed tooltip copy-to-clipboard functionality in offer builder values
Show NFT minter name/DID