### PR TITLE
Tests to cover toBech32m functionality

### DIFF
--- a/packages/api/src/tests/utils/calculateRoyalties.test.ts
+++ b/packages/api/src/tests/utils/calculateRoyalties.test.ts
@@ -49,6 +49,17 @@ describe('calculateRoyalties', () => {
       );
       expect(royaltyAsset.royaltyPercentage).toBe(350);
     });
+    it('converts mainnet NFTInfo to a RoyaltyCalculationRoyaltyAsset object, mainnet as default', () => {
+      const royaltyAsset: RoyaltyCalculationRoyaltyAsset =
+        royaltyAssetFromNFTInfo(exampleNFT);
+      expect(royaltyAsset.asset).toBe(
+        'nft1g9xfeujpq402dhxrms5wqvh73rr02remvwvycr9s4cxzzlkg324s3nu8vj'
+      );
+      expect(royaltyAsset.royaltyAddress).toBe(
+        'xch17mp20xhhy7l6m20u37nw4ft338r2tt2yquenu4earcyzjwqh6kksc8dyjc'
+      );
+      expect(royaltyAsset.royaltyPercentage).toBe(350);
+    });
     it('converts testnet NFTInfo to a RoyaltyCalculationRoyaltyAsset object', () => {
       const royaltyAsset: RoyaltyCalculationRoyaltyAsset =
         royaltyAssetFromNFTInfo(exampleNFT, true);

--- a/packages/api/src/utils/toBech32m.test.ts
+++ b/packages/api/src/utils/toBech32m.test.ts
@@ -1,0 +1,68 @@
+import toBech32m, { fromBech32m, decodeBech32m } from './toBech32m';
+
+describe('toBech32m', () => {
+  describe('toBech32m', () => {
+    it('should convert a hex string to a bech32m string', () => {
+      const hexString = '0x6a656666697a6b65776c';
+      const bech32mString = toBech32m(hexString, 'xch');
+
+      expect(bech32mString).toBe('xch1dfjkvenf0f4k2amv2y5f9j');
+    });
+    it('should not require the hex string begin with 0x', () => {
+      const hexString = '6a656666697a6b65776c';
+      const bech32mString = toBech32m(hexString, 'xch');
+
+      expect(bech32mString).toBe('xch1dfjkvenf0f4k2amv2y5f9j');
+    });
+    it('should check if the input begins with the prefix', () => {
+      const hexString = 'xch1dfjkvenf0f4k2amv2y5f9j';
+      const bech32mString = toBech32m(hexString, 'xch');
+
+      expect(bech32mString).toBe('xch1dfjkvenf0f4k2amv2y5f9j');
+    });
+    it('should encode a 0-length string', () => {
+      const hexString = '';
+      const bech32mString = toBech32m(hexString, 'xch');
+
+      expect(bech32mString).toBe('xch1jlgazv');
+    });
+    it('should fail if non-hex characters are present', () => {
+      const hexString = 'not a hex string';
+      expect(() => toBech32m(hexString, 'xch')).toThrow();
+    });
+  });
+
+  describe('fromBech32m', () => {
+    it('should convert a bech32m string to a hex string', () => {
+      const bech32mString = 'xch1dfjkvenf0f4k2amv2y5f9j';
+      const hexString = fromBech32m(bech32mString);
+
+      expect(hexString).toBe('6a656666697a6b65776c');
+    });
+    it('should throw if the bech32m string is invalid', () => {
+      const bech32mString = 'not a valid bech32m string';
+      expect(() => fromBech32m(bech32mString)).toThrow();
+    });
+  });
+
+  describe('decodeBech32m', () => {
+    it('should return the prefix and data as a string', () => {
+      const bech32mString = 'xch1dfjkvenf0f4k2amv2y5f9j';
+      const { prefix, data } = decodeBech32m(bech32mString);
+
+      expect(prefix).toBe('xch');
+      expect(data).toBe('jeffizkewl');
+    });
+    it('should return the prefix and data as a hex string', () => {
+      const bech32mString = 'xch1dfjkvenf0f4k2amv2y5f9j';
+      const { prefix, data } = decodeBech32m(bech32mString, 'hex');
+
+      expect(prefix).toBe('xch');
+      expect(data).toBe('6a656666697a6b65776c');
+    });
+    it('should throw if the bech32m string is invalid', () => {
+      const bech32mString = 'not a valid bech32m string';
+      expect(() => decodeBech32m(bech32mString)).toThrow();
+    });
+  });
+});

--- a/packages/api/src/utils/toBech32m.ts
+++ b/packages/api/src/utils/toBech32m.ts
@@ -14,7 +14,14 @@ export default function toBech32m(value: string, prefix: string): string {
   }
 
   const pureHash = removePrefix(value, '0x');
-  const words = bech32m.toWords(Buffer.from(pureHash, 'hex'));
+  const hexBytes = Buffer.from(pureHash, 'hex');
+
+  if (pureHash.length / 2 !== hexBytes.length) {
+    throw new Error('Invalid hex string');
+  }
+
+  const words = bech32m.toWords(hexBytes);
+
   return bech32m.encode(prefix, words);
 }
 
@@ -23,9 +30,12 @@ export function fromBech32m(value: string): string {
   return Buffer.from(bech32m.fromWords(data.words)).toString('hex');
 }
 
-export function decodeBech32m(value: string): string {
+export function decodeBech32m(
+  value: string,
+  outputEncoding: BufferEncoding = 'utf8'
+): { prefix: string; data: string } {
   const { words, prefix } = bech32m.decode(value);
-  const data = Buffer.from(bech32m.fromWords(words)).toString('hex');
+  const data = Buffer.from(bech32m.fromWords(words)).toString(outputEncoding);
 
   return { prefix, data };
 }


### PR DESCRIPTION
toBech32m will now throw if the input hex string is invalid (non-hex chars)
decodeBech32m now converts the decoded data to a utf8 string by default (not currently used)

100% test coverage of code reached by calculateRoyalties
