### PR TITLE
syncing electron to 20.3.1

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -6235,9 +6235,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-20.1.4.tgz",
-      "integrity": "sha512-7ov5kgSQi2JewV5SrVfjGasUvyScjuJrrDCW0rYxtP2SMe3JjoP4rsOOnh3ps2P/Nrdlbv+0ygiK0zp4ARCZ+A==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-20.3.1.tgz",
+      "integrity": "sha512-mgFAa79Zj8oCegsluPAo6O1yXd7mVMZ0JZC2Rak9HQUAQ7x9xuQY7yop/+nMbi+bOMWwe5JrtOcvjotBArxioA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -17891,9 +17891,9 @@
       "dev": true
     },
     "electron": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-20.1.4.tgz",
-      "integrity": "sha512-7ov5kgSQi2JewV5SrVfjGasUvyScjuJrrDCW0rYxtP2SMe3JjoP4rsOOnh3ps2P/Nrdlbv+0ygiK0zp4ARCZ+A==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-20.3.1.tgz",
+      "integrity": "sha512-mgFAa79Zj8oCegsluPAo6O1yXd7mVMZ0JZC2Rak9HQUAQ7x9xuQY7yop/+nMbi+bOMWwe5JrtOcvjotBArxioA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",

--- a/packages/gui/package-lock.json
+++ b/packages/gui/package-lock.json
@@ -94,7 +94,7 @@
         "copy-webpack-plugin": "10.2.0",
         "cross-env": "7.0.3",
         "css-loader": "6.5.1",
-        "electron": "20.1.4",
+        "electron": "20.3.1",
         "electron-playwright-helpers": "^1.2.0",
         "electron-winstaller": "5.0.0",
         "html-loader": "3.1.0",
@@ -7988,9 +7988,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-20.1.4.tgz",
-      "integrity": "sha512-7ov5kgSQi2JewV5SrVfjGasUvyScjuJrrDCW0rYxtP2SMe3JjoP4rsOOnh3ps2P/Nrdlbv+0ygiK0zp4ARCZ+A==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-20.3.1.tgz",
+      "integrity": "sha512-mgFAa79Zj8oCegsluPAo6O1yXd7mVMZ0JZC2Rak9HQUAQ7x9xuQY7yop/+nMbi+bOMWwe5JrtOcvjotBArxioA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -23571,9 +23571,9 @@
       "dev": true
     },
     "electron": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-20.1.4.tgz",
-      "integrity": "sha512-7ov5kgSQi2JewV5SrVfjGasUvyScjuJrrDCW0rYxtP2SMe3JjoP4rsOOnh3ps2P/Nrdlbv+0ygiK0zp4ARCZ+A==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-20.3.1.tgz",
+      "integrity": "sha512-mgFAa79Zj8oCegsluPAo6O1yXd7mVMZ0JZC2Rak9HQUAQ7x9xuQY7yop/+nMbi+bOMWwe5JrtOcvjotBArxioA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -220,7 +220,7 @@
     "copy-webpack-plugin": "10.2.0",
     "cross-env": "7.0.3",
     "css-loader": "6.5.1",
-    "electron": "20.1.4",
+    "electron": "20.3.1",
     "electron-playwright-helpers": "^1.2.0",
     "electron-winstaller": "5.0.0",
     "html-loader": "3.1.0",


### PR DESCRIPTION
This resolves failing chia-blockchain CI:

>  npm ERR! Invalid: lock file's electron@20.1 .4 does not satisfy electron@20.3.1