### PR TITLE
Fix NFT inbox detection in NFTMoveToProfileDialog.

### DIFF
--- a/packages/gui/src/components/nfts/NFTMoveToProfileDialog.tsx
+++ b/packages/gui/src/components/nfts/NFTMoveToProfileDialog.tsx
@@ -39,6 +39,7 @@ import {
 } from '@mui/material';
 import { stripHexPrefix } from '../../util/utils';
 import { didFromDIDId, didToDIDId } from '../../util/dids';
+import { getNFTInbox } from './utils';
 import NFTSummary from './NFTSummary';
 import styled from 'styled-components';
 
@@ -210,23 +211,12 @@ export function NFTMoveToProfileAction(props: NFTMoveToProfileActionProps) {
     : undefined;
 
   const inbox: Wallet | undefined = useMemo(() => {
-    if (isLoadingDIDs || isLoadingNFTWallets) {
+    if (isLoadingNFTWallets) {
       return undefined;
     }
 
-    const nftWalletIds: number[] = nftWallets.map(
-      (nftWallet: Wallet) => nftWallet.walletId,
-    );
-    const didWalletIds = new Set(
-      didWallets.map((wallet: Wallet) => wallet.nftWalletId),
-    );
-    const inboxWalletId = nftWalletIds.find(
-      (nftWalletId) => !didWalletIds.has(nftWalletId),
-    );
-    return nftWallets.find(
-      (wallet: Wallet) => wallet.walletId === inboxWalletId,
-    );
-  }, [didWallets, nftWallets, isLoadingDIDs, isLoadingNFTWallets]);
+    return getNFTInbox(nftWallets);
+  }, [nftWallets, isLoadingNFTWallets]);
 
   const currentDID = useMemo(() => {
     if (!didWallets || !currentDIDId) {

--- a/packages/gui/src/components/nfts/NFTProfileDropdown.tsx
+++ b/packages/gui/src/components/nfts/NFTProfileDropdown.tsx
@@ -15,6 +15,7 @@ import {
 import { NFTsSmall as NFTsSmallIcon } from '@chia/icons';
 import { orderBy } from 'lodash';
 import useNachoNFTs from '../../hooks/useNachoNFTs';
+import { getNFTInbox } from './utils';
 
 type Profile = Wallet & {
   nftWalletId: number;
@@ -63,11 +64,12 @@ export default function NFTProfileDropdown(props: NFTGallerySidebarProps) {
   const haveNachoNFTs = !isLoadingNachoNFTs && nachoNFTs?.length > 0;
 
   const inbox: Wallet | undefined = useMemo(() => {
-    if (isLoadingProfiles || isLoadingNFTWallets) {
+    if (isLoadingNFTWallets) {
       return undefined;
     }
-    return nftWallets.find((nftWallet: Wallet) => !nftWallet.meta.did);
-  }, [nftWallets, isLoadingProfiles, isLoadingNFTWallets]);
+
+    return getNFTInbox(nftWallets);
+  }, [nftWallets, isLoadingNFTWallets]);
 
   const remainingNFTWallets = useMemo(() => {
     if (isLoadingProfiles || isLoadingNFTWallets || !inbox) {

--- a/packages/gui/src/components/nfts/utils.test.ts
+++ b/packages/gui/src/components/nfts/utils.test.ts
@@ -1,0 +1,83 @@
+import { WalletType } from '@chia/api';
+import { getNFTInbox } from './utils';
+
+describe('utils', () => {
+  describe('getNFTInbox', () => {
+    it('should return undefined if no wallets are provided', () => {
+      expect(getNFTInbox(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if all of the NFT wallets have an associated DID', () => {
+      const nftWallets = [
+        {
+          id: 3,
+          type: WalletType.NFT,
+          name: 'NFT 1',
+          meta: {
+            did: 'did_1',
+          },
+        },
+        {
+          id: 4,
+          type: WalletType.NFT,
+          name: 'NFT 2',
+          meta: {
+            did: 'did_2',
+          },
+        },
+      ];
+
+      expect(getNFTInbox(nftWallets)).toBeUndefined();
+    });
+
+    it('should return undefined if no NFT wallets are present', () => {
+      const wallets = [
+        {
+          id: 1,
+          type: WalletType.STANDARD_WALLET,
+          name: 'Chia',
+        },
+        {
+          id: 2,
+          type: WalletType.CAT,
+          name: 'Duck Sauce',
+        },
+      ];
+
+      expect(getNFTInbox(wallets)).toBeUndefined();
+    });
+
+    it("should return the inbox when an NFT wallet doesn't have an associated DID", () => {
+      const wallets = [
+        {
+          id: 1,
+          type: WalletType.STANDARD_WALLET,
+          name: 'Chia',
+        },
+        {
+          id: 2,
+          type: WalletType.CAT,
+          name: 'Duck Sauce',
+        },
+        {
+          id: 3,
+          type: WalletType.NFT,
+          name: 'NFT 1',
+          meta: {
+            did: 'did_1',
+          },
+        },
+        {
+          id: 4,
+          type: WalletType.NFT,
+          name: 'NFT 2',
+          meta: {
+            did: '',
+          },
+        },
+      ];
+
+      expect(getNFTInbox(wallets)).toEqual(wallets[3]);
+    });
+  });
+});

--- a/packages/gui/src/components/nfts/utils.ts
+++ b/packages/gui/src/components/nfts/utils.ts
@@ -1,0 +1,17 @@
+import { WalletType } from '@chia/api';
+import type { Wallet } from '@chia/api';
+
+/**
+ * Locate the NFT "inbox" from a list of NFT wallets. The inbox is the NFT wallet
+ * that contains unassigned (no DID set) NFTs. Locating the inbox involves checking
+ * whether the NFT wallet has a DID set. Only one NFT wallet can be used for holding
+ * unassigned NFTs.
+ *
+ * @param wallets Wallets
+ * @returns NFT inbox or undefined if not found
+ */
+export function getNFTInbox(wallets: Wallet[] | undefined): Wallet | undefined {
+  return wallets
+    ?.filter((wallet) => wallet.type === WalletType.NFT)
+    .find((nftWallet: Wallet) => !nftWallet.meta?.did);
+}


### PR DESCRIPTION
Added getNFTInbox() util function with corresponding tests.

NFTMoveToProfileDialog was using an incorrect method for identifying the NFT inbox. The incorrect code contained an unsafe dereference that could lead to an exception (caused by calling undefined.map())

`getNFTInbox` filters on NFT wallets and matches on a wallet where meta.data is falsey.

Addresses #1168 