### PR TITLE
Fix fee layout in NFT components

### DIFF
--- a/packages/gui/src/components/nfts/NFTBurnDialog.tsx
+++ b/packages/gui/src/components/nfts/NFTBurnDialog.tsx
@@ -152,6 +152,7 @@ export default function NFTBurnDialog(props: NFTPreviewDialogProps) {
                 label={<Trans>Fee</Trans>}
                 disabled={isSubmitting}
                 txType="burnNFT"
+                fullWidth
               />
               <DialogActions>
                 <Flex flexDirection="row" gap={2}>

--- a/packages/gui/src/components/nfts/NFTMoveToProfileDialog.tsx
+++ b/packages/gui/src/components/nfts/NFTMoveToProfileDialog.tsx
@@ -439,6 +439,7 @@ export function NFTMoveToProfileAction(props: NFTMoveToProfileActionProps) {
           label={<Trans>Fee</Trans>}
           disabled={isLoading}
           txType="assignDIDToNFT"
+          fullWidth
         />
         <DialogActions>
           <Flex flexDirection="row" gap={3}>

--- a/packages/gui/src/components/nfts/NFTTransferAction.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferAction.tsx
@@ -151,6 +151,7 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
           label={<Trans>Fee</Trans>}
           disabled={isLoading}
           txType="transferNFT"
+          fullWidth
         />
         <DialogActions>
           <Flex flexDirection="row" gap={3}>


### PR DESCRIPTION
Fix EstimatedFee layout in NFT transfer/burn/did-assignment components. Without this fix, the fee component appears scrunched up.

Before:
![image](https://user-images.githubusercontent.com/339312/201551857-8cdfbb03-965e-46c0-bf8f-3ae1dec08262.png)

Fixed:
![image](https://user-images.githubusercontent.com/339312/201551862-4d1eabd5-0517-4c2c-941b-4238688c08cc.png)
