### PR TITLE
Use fee estimator when viewing an offer

### DIFF
--- a/packages/gui/src/components/offers2/OfferBuilderValue.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderValue.tsx
@@ -1,6 +1,7 @@
 import {
   Amount,
   CopyToClipboard,
+  EstimatedFee,
   Fee,
   Flex,
   FormatLargeNumber,
@@ -140,7 +141,18 @@ export default function OfferBuilderValue(props: OfferBuilderValueProps) {
                 fullWidth
               />
             ) : type === 'fee' ? (
-              <Fee variant="filled" color="secondary" label={label} name={name} required fullWidth />
+              builderReadOnly ? (
+                <EstimatedFee
+                  txType="acceptOffer"
+                  variant="filled"
+                  color="secondary"
+                  label={label}
+                  name={name}
+                  fullWidth
+                />
+              ) : (
+                <Fee variant="filled" color="secondary" label={label} name={name} fullWidth />
+              )
             ) : type === 'text' ? (
               <TextField variant="filled" color="secondary" label={label} name={name} required fullWidth />
             ) : type === 'token' ? (


### PR DESCRIPTION
The fee estimator will appear when viewing an offer.  The classic fee component is used when creating an offer.

![image](https://user-images.githubusercontent.com/339312/202059804-5a84181b-8e4f-472f-922a-381944f2b977.png)
