### PR TITLE
Minor README.md tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ This monorepo consists of the following packages:
 | **icons**     | Chia specific icons                                                                                        |
 | **wallets**   | Common React components and hooks. Do not use this in you project. Will be merged to **core** package soon |
 
-Feel free to install any of these packages as dependencies for your next Chia project.
-
 ## Development
 
 1. This repo (chia-blockchain-gui) must be under chia-blockchain repo. Please follow the [installation steps for the chia-blockchain](https://github.com/Chia-Network/chia-blockchain/wiki/INSTALL#install-from-source). Make sure to install from source code (git clone...).

--- a/packages/api-react/README.md
+++ b/packages/api-react/README.md
@@ -4,8 +4,8 @@
 
 ![GitHub contributors](https://img.shields.io/github/contributors/Chia-Network/chia-blockchain-gui?logo=GitHub)
 
-This library provides react hooks on the top of @chia/api and uses [RTK Query](https://redux-toolkit.js.org/rtk-query/overview) under do hood.
-It is designed to simplify common cases for loading data in a web application, eliminating the need to hand-write data fetching & caching logic yourself. Providing much more benefits:
+This library provides react hooks on the top of @chia/api and uses [RTK Query](https://redux-toolkit.js.org/rtk-query/overview) under the hood.
+It is designed to simplify common cases for loading data in a web application, eliminating the need to hand-write data fetching & caching logic yourself. Benefits include:
 
 - Automatically refresh queries when data changed (using events from Chia Blockchain).
 - Tracking loading state in order to show UI spinners.
@@ -32,7 +32,7 @@ export default function PublicKeys() {
   }
 
   if (error) {
-    return <Alert severiry="error">{error.message}</Alert>;
+    return <Alert severity="error">{error.message}</Alert>;
   }
 
   return (
@@ -65,7 +65,7 @@ export default function Application() {
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <Provider store={store}>
-        <PublickKeys />
+        <PublicKeys />
       </Provider>
     </Suspense>
   );

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -4,7 +4,7 @@
 
 ![GitHub contributors](https://img.shields.io/github/contributors/Chia-Network/chia-blockchain-gui?logo=GitHub)
 
-This library provides support for TypeScript/JavaScript [Chia](https://www.chia.net) apps to access the [Chia Blockchain RPC](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces), by making it easier to perform the following actions:
+This library provides support for TypeScript/JavaScript [Chia](https://www.chia.net) apps to access the [Chia Blockchain RPC](https://docs.chia.net/rpc/), by making it easier to perform the following actions:
 
 - Making requests to the Chia Blockchain RPC.
 - Catch responses and errors with standard try/catch and async/await syntax.
@@ -32,18 +32,18 @@ import sleep from 'sleep-promise';
   const wallet = new Wallet(client);
 
   try {
-    // get list of available publick keys
+    // get list of available public keys
     const publicKeys = await wallet.getPublicKeys();
 
     // bind to sync changes
     const unsubscribeSyncChanges = wallet.onSyncChanged((syncData) => {
-      console.log('do something with synchronisation data');
+      console.log('do something with synchronization data');
     });
 
     // wait 5 minutes
     await sleep(1000 * 60 * 5);
 
-    // unubscribe from synchronisation changes
+    // unsubscribe from synchronization changes
     await unsubscribeSyncChanges();
 
     // wait 5 minutes


### PR DESCRIPTION
Some minor typo fixes and rewording.
Updated the RPC documentation URL to point to docs.chia.net.
Removed line about using packages/* as dependencies in new projects until we're better positioned to publish.