### PR TITLE
Display current NFT coin ID and p2 address on the details screen

### DIFF
--- a/packages/api/src/@types/NFTInfo.ts
+++ b/packages/api/src/@types/NFTInfo.ts
@@ -19,6 +19,7 @@ type NFTInfo = {
   royaltyPercentage: number; // e.g. 175 == 1.75%
   royaltyPuzzleHash: string;
   supportsDid: boolean;
+  p2Address: string;
   updaterPuzhash: string;
 
   // Properties added by the frontend

--- a/packages/gui/src/components/nfts/NFTDetails.tsx
+++ b/packages/gui/src/components/nfts/NFTDetails.tsx
@@ -1,4 +1,14 @@
-import { Flex, CardKeyValue, CopyToClipboard, Tooltip, Truncate, truncateValue, Link } from '@chia/core';
+import { toBech32m } from '@chia/api';
+import {
+  Flex,
+  CardKeyValue,
+  CopyToClipboard,
+  Tooltip,
+  Truncate,
+  truncateValue,
+  Link,
+  useCurrencyCode,
+} from '@chia/core';
 import { Trans } from '@lingui/macro';
 import { Box, Typography } from '@mui/material';
 import React, { useMemo } from 'react';
@@ -30,6 +40,7 @@ export default function NFTDetails(props: NFTDetailsProps) {
     didName: minterDIDName,
     isLoading: isLoadingMinterDID,
   } = useNFTMinterDID(nft.$nftId);
+  const currencyCode = useCurrencyCode();
 
   const details = useMemo(() => {
     if (!nft) {
@@ -57,7 +68,30 @@ export default function NFTDetails(props: NFTDetailsProps) {
           </Truncate>
         ),
       },
+      {
+        key: 'nftCoinId',
+        label: <Trans>NFT Coin ID</Trans>,
+        value: (
+          <Truncate ValueProps={{ variant: 'body2' }} tooltip copyToClipboard>
+            {stripHexPrefix(nft.nftCoinId)}
+          </Truncate>
+        ),
+      },
     ].filter(Boolean);
+
+    if (nft.p2Address) {
+      const p2Address = toBech32m(nft.p2Address, currencyCode);
+
+      rows.push({
+        key: 'p2Address',
+        label: <Trans>Owner Address</Trans>,
+        value: (
+          <Truncate ValueProps={{ variant: 'body2' }} tooltip copyToClipboard>
+            {p2Address}
+          </Truncate>
+        ),
+      });
+    }
 
     let hexDIDId;
     let didId;


### PR DESCRIPTION
The current NFT coin ID and the current p2 address (current owner) are now displayed in NFTDetails

![image](https://user-images.githubusercontent.com/339312/204941540-ccd1f0a4-f473-4b55-847f-78f81d4a4cac.png)
