### PR TITLE
added add and remove full nodes

### DIFF
--- a/packages/gui/src/components/fullNode/FullNodeConnections.tsx
+++ b/packages/gui/src/components/fullNode/FullNodeConnections.tsx
@@ -1,11 +1,19 @@
 import { Connection } from '@chia/api';
 import { useGetFullNodeConnectionsQuery } from '@chia/api-react';
-import { Card, FormatBytes, FormatLargeNumber, Loading, Table } from '@chia/core';
+import { Card, FormatBytes, FormatLargeNumber, IconButton, Loading, Table, useOpenDialog } from '@chia/core';
 import { Trans } from '@lingui/macro';
-import { Tooltip } from '@mui/material';
+import { Button, Tooltip } from '@mui/material';
+import { Delete as DeleteIcon } from '@mui/icons-material';
+import styled from 'styled-components';
+import FullNodeAddConnection from './FullNodeAddConnection';
+import FullNodeCloseConnection from './FullNodeCloseConnection';
 import React from 'react';
 
 import { service_connection_types } from '../../util/service_names';
+
+const StyledIconButton = styled(IconButton)`
+  padding: 0.2rem;
+`;
 
 const cols = [
   {
@@ -52,13 +60,39 @@ const cols = [
     field: (row: Connection) => <FormatLargeNumber value={row.peakHeight} />,
     title: <Trans>Height</Trans>,
   },
+  {
+    title: <Trans>Actions</Trans>,
+    field(row: Connection) {
+      return (
+        <FullNodeCloseConnection nodeId={row.nodeId}>
+          {({ onClose }) => (
+            <StyledIconButton onClick={onClose}>
+              <DeleteIcon />
+            </StyledIconButton>
+          )}
+        </FullNodeCloseConnection>
+      );
+    },
+  },
 ];
 
 export default function Connections() {
+  const openDialog = useOpenDialog();
   const { data: connections, isLoading } = useGetFullNodeConnectionsQuery();
 
+  function handleAddPeer() {
+    openDialog(<FullNodeAddConnection />);
+  }
+
   return (
-    <Card title={<Trans>Full Node Connections</Trans>}>
+    <Card
+      title={<Trans>Full Node Connections</Trans>}
+      action={
+        <Button onClick={handleAddPeer} variant="outlined">
+          <Trans>Connect to other peers</Trans>
+        </Button>
+      }
+    >
       {isLoading ? (
         <Loading center />
       ) : !connections?.length ? (


### PR DESCRIPTION
Re-added feature to allow a GUI to remove a full node to which the wallet is connected or to add a specific node by ip address and port