### PR TITLE
Add check commands and refactor prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     "publish": "lerna publish",
     "postinstall": "npm run bootstrap && npm run prettier:postinstall",
     "prettier:postinstall": "prettier --write **/package.json **/package-lock.json",
-    "prettier:format": "prettier --write",
-    "prettier:format:all": "npm run prettier:format -- '**/*.{ts,tsx,js,jsx}'",
-    "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
+    "check": "npm run check:lint ; npm run check:prettier ; npm run check:types",
+    "check:lint": "eslint . --ext .ts,.tsx,.js,.jsx",
+    "check:prettier": "prettier --check --ignore-path .gitignore .",
+    "check:types": "lerna exec -- npm run check:types",
     "autofix": "npm run autofix:lint ; npm run autofix:prettier",
     "autofix:lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
-    "autofix:prettier": "prettier --write --ignore-path .gitignore '**/*.{js,jsx,ts,tsx}'",
+    "autofix:prettier": "prettier --write --ignore-path .gitignore .",
     "build": "lerna run build",
     "build:watch": "lerna run build:watch",
     "start:gui": "lerna run start --scope @chia-network/gui",
@@ -47,17 +48,6 @@
     "lerna-audit": "^1.3.3",
     "prettier": "2.7.1",
     "typescript": "^4.5.4"
-  },
-  "lint-staged": {
-    "./{*,{api,packages,test,utils}/**/*}.{js,ts,jsx,tsx}": [
-      "prettier --write",
-      "eslint",
-      "git add"
-    ],
-    "*.{json,md}": [
-      "prettier --write",
-      "git add"
-    ]
   },
   "version": "1.2.10-dev132"
 }

--- a/packages/api-react/package.json
+++ b/packages/api-react/package.json
@@ -14,6 +14,7 @@
     "build:js": "rollup -c",
     "build:watch": "rollup -c -w",
     "build:types": "tsc --emitDeclarationOnly",
+    "check:types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,6 +15,7 @@
     "build:js": "rollup -c",
     "build:watch": "rollup -c -w",
     "build:types": "tsc --emitDeclarationOnly",
+    "check:types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "locale:clean": "lingui extract --clean",
     "locale:compile": "lingui compile",
     "locale": "lingui extract && lingui compile",
+    "check:types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -125,6 +125,7 @@
     "locale:clean": "lingui extract --clean",
     "locale:compile": "lingui compile",
     "locale": "lingui extract && lingui compile",
+    "check:types": "tsc --noEmit",
     "test:playwright": "cross-env PLAYWRIGHT_TESTS=true playwright test",
     "test": "jest"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -14,6 +14,7 @@
     "build:js": "rollup -c",
     "build:watch": "rollup -c -w",
     "build:types": "tsc --emitDeclarationOnly",
+    "check:types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -17,6 +17,7 @@
     "locale:clean": "lingui extract --clean",
     "locale:compile": "lingui compile",
     "locale": "lingui extract && lingui compile",
+    "check:types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
- new script: npm run check which will run TS, Eslint and prettier checks
- npm run check:types will run TS check in each repo
- prettier config updated to prettify non js files too
- lint-staged config removed, since it is not used at all (lint-staged not installed)