### PR TITLE
Refactor NFT metadata LRU implementation

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -16,3 +16,4 @@ export { default as mojoToChiaLocaleString } from './mojoToChiaLocaleString';
 export { default as sleep } from './sleep';
 export { default as useColorModeValue, getColorModeValue } from './useColorModeValue';
 export { default as validAddress } from './validAddress';
+export { default as LRU, lruCreate } from './lru';

--- a/packages/core/src/utils/lru.test.ts
+++ b/packages/core/src/utils/lru.test.ts
@@ -1,0 +1,83 @@
+import LRU, { DEFAULT_MAX_LRU_SIZE, lruCreate } from './lru';
+
+describe('lru', () => {
+  describe('#create', () => {
+    it('should create an empty LRU', () => {
+      const lru = new LRU<string, string>();
+      expect(lru.size).toBe(0);
+      expect(lru.capacity).toBe(DEFAULT_MAX_LRU_SIZE);
+    });
+    it('should support custom capacity', () => {
+      const lru = new LRU<string, string>(10);
+      expect(lru.size).toBe(0);
+      expect(lru.capacity).toBe(10);
+    });
+  });
+  describe('#set', () => {
+    it('should set a value', () => {
+      const lru = new LRU<string, string>();
+      lru.set('foo', 'bar');
+      expect(lru.size).toBe(1);
+      expect(lru.get('foo')).toBe('bar');
+    });
+    it('should overwrite a value', () => {
+      const lru = new LRU<string, string>();
+      lru.set('foo', 'bar');
+      lru.set('foo', 'baz');
+      expect(lru.size).toBe(1);
+      expect(lru.get('foo')).toBe('baz');
+    });
+    it('should delete the oldest entry when capacity is reached', () => {
+      const lru = new LRU<string, string>(2);
+      lru.set('a', '1');
+      lru.set('b', '2');
+      lru.set('c', '3');
+      expect(lru.size).toBe(2);
+      expect(lru.get('a')).toBeUndefined();
+      expect(lru.get('b')).toBe('2');
+      expect(lru.get('c')).toBe('3');
+    });
+  });
+  describe('#get', () => {
+    it('should get undefined for unknown keys', () => {
+      const lru = new LRU<string, string>();
+      expect(lru.get('foo')).toBeUndefined();
+      lru.set('foo', 'bar');
+      expect(lru.get('foo')).toBe('bar');
+    });
+  });
+  describe('#delete', () => {
+    it('should delete a value', () => {
+      const lru = new LRU<string, string>();
+      lru.set('foo', 'bar');
+      expect(lru.get('foo')).toBe('bar');
+      expect(lru.size).toBe(1);
+      lru.delete('foo');
+      expect(lru.size).toBe(0);
+      expect(lru.get('foo')).toBeUndefined();
+    });
+  });
+  describe('#size', () => {
+    it('should return the number of entries', () => {
+      const lru = new LRU<string, string>();
+      expect(lru.size).toBe(0);
+      lru.set('a', '1');
+      expect(lru.size).toBe(1);
+      lru.set('b', '2');
+      expect(lru.size).toBe(2);
+    });
+  });
+});
+
+describe('lruCreate factory function', () => {
+  it('should create an empty LRU', () => {
+    const lru = lruCreate<string, string>();
+    expect(lru.size).toBe(0);
+    expect(lru.capacity).toBe(DEFAULT_MAX_LRU_SIZE);
+  });
+  it('should support custom capacity', () => {
+    const lru = lruCreate<string, string>(10);
+    expect(lru.size).toBe(0);
+    expect(lru.capacity).toBe(10);
+  });
+});

--- a/packages/core/src/utils/lru.ts
+++ b/packages/core/src/utils/lru.ts
@@ -1,0 +1,51 @@
+export const DEFAULT_MAX_LRU_SIZE = 300;
+
+// LRU cache implementation
+export default class LRU<K, V> {
+  private map: Map<K, V>;
+
+  private max: number;
+
+  constructor(max: number = DEFAULT_MAX_LRU_SIZE) {
+    this.map = new Map();
+    this.max = max;
+  }
+
+  get(key: K): V | undefined {
+    const value = this.map.get(key);
+
+    if (value) {
+      this.map.delete(key);
+
+      this.map.set(key, value);
+    }
+
+    return value;
+  }
+
+  set(key: K, value: V) {
+    if (this.map.size >= this.max) {
+      // delete oldest entry
+      this.map.delete(this.map.keys().next().value);
+    }
+
+    this.map.set(key, value);
+  }
+
+  delete(key: K) {
+    this.map.delete(key);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  get capacity(): number {
+    return this.max;
+  }
+}
+
+// LRU's constructor isn't visible outside of the package, so we need to export a factory function
+export function lruCreate<K, V>(max: number = DEFAULT_MAX_LRU_SIZE): LRU<K, V> {
+  return new LRU<K, V>(max);
+}

--- a/packages/gui/src/components/app/AppProviders.tsx
+++ b/packages/gui/src/components/app/AppProviders.tsx
@@ -21,6 +21,7 @@ import { Outlet } from 'react-router-dom';
 import WebSocket from 'ws';
 
 import { i18n, defaultLocale, locales } from '../../config/locales';
+import LRUsProvider from '../lrus/LRUsProvider';
 import WalletConnectProvider, { WalletConnectChiaProjectId } from '../walletConnect/WalletConnectProvider';
 import AppState from './AppState';
 
@@ -75,22 +76,24 @@ export default function App(props: AppProps) {
       <LocaleProvider i18n={i18n} defaultLocale={defaultLocale} locales={locales}>
         <ThemeProvider theme={theme} fonts global>
           <ErrorBoundary>
-            <ModalDialogsProvider>
-              <WalletConnectProvider projectId={WalletConnectChiaProjectId}>
-                {isReady ? (
-                  <Suspense fallback={<LayoutLoading />}>
-                    <AppState>{outlet ? <Outlet /> : children}</AppState>
-                  </Suspense>
-                ) : (
-                  <LayoutLoading>
-                    <Typography variant="body1">
-                      <Trans>Loading configuration</Trans>
-                    </Typography>
-                  </LayoutLoading>
-                )}
-                <ModalDialogs />
-              </WalletConnectProvider>
-            </ModalDialogsProvider>
+            <LRUsProvider>
+              <ModalDialogsProvider>
+                <WalletConnectProvider projectId={WalletConnectChiaProjectId}>
+                  {isReady ? (
+                    <Suspense fallback={<LayoutLoading />}>
+                      <AppState>{outlet ? <Outlet /> : children}</AppState>
+                    </Suspense>
+                  ) : (
+                    <LayoutLoading>
+                      <Typography variant="body1">
+                        <Trans>Loading configuration</Trans>
+                      </Typography>
+                    </LayoutLoading>
+                  )}
+                  <ModalDialogs />
+                </WalletConnectProvider>
+              </ModalDialogsProvider>
+            </LRUsProvider>
           </ErrorBoundary>
         </ThemeProvider>
       </LocaleProvider>

--- a/packages/gui/src/components/lrus/LRUsProvider.tsx
+++ b/packages/gui/src/components/lrus/LRUsProvider.tsx
@@ -1,0 +1,33 @@
+import LRU, { lruCreate } from '@chia-network/core';
+import React, { ReactNode, createContext, useCallback, useMemo, useState } from 'react';
+
+export interface LRUsContextData<K, V> {
+  getLRU: (name: string) => LRU<K, V>;
+}
+
+export const LRUsContext = createContext<LRUsContextData<string, any> | undefined>(undefined);
+
+export type LRUsProviderProps = {
+  children?: ReactNode;
+};
+
+export default function LRUsProvider(props: LRUsProviderProps) {
+  const { children } = props;
+
+  const [LRUs, setLRUs] = useState<Record<string, LRU | undefined>>({});
+
+  const getLRU = useCallback(
+    (name: string) => {
+      let lru = LRUs[name];
+      if (!lru) {
+        lru = lruCreate<string, any>();
+        setLRUs((prev) => ({ ...prev, [name]: lru }));
+      }
+      return lru;
+    },
+    [LRUs]
+  );
+  const value = useMemo(() => ({ getLRU }), [getLRU]);
+
+  return <LRUsContext.Provider value={value}>{children}</LRUsContext.Provider>;
+}

--- a/packages/gui/src/hooks/useNFTMetadata.ts
+++ b/packages/gui/src/hooks/useNFTMetadata.ts
@@ -112,7 +112,9 @@ export default function useNFTsMetadata(nfts: NFTInfo[]) {
   }
 
   useEffect(() => {
-    getMetadata(nft);
+    if (nft) {
+      getMetadata(nft);
+    }
   }, [nft]);
 
   function loadReload() {

--- a/packages/gui/src/hooks/useNFTMetadata.ts
+++ b/packages/gui/src/hooks/useNFTMetadata.ts
@@ -1,49 +1,28 @@
-import type NFTInfo from '@chia/api';
-import { useEffect, useState, useCallback } from 'react';
+import type NFTInfo from '@chia-network/api';
+import type LRU from '@chia-network/core';
+import { useEffect, useState } from 'react';
 
 import { eventEmitter } from '../components/nfts/NFTContextualActions';
 import getRemoteFileContent from '../util/getRemoteFileContent';
+import useNFTMetadataLRU from './useNFTMetadataLRU';
 
 export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
 
-export const lruMap = new Map();
-
-(window as any).lru_map = lruMap;
-
-export function lruGet(key: string) {
-  const value = lruMap.get(key);
-  if (value) {
-    lruMap.delete(key);
-
-    lruMap.set(key, value);
-  }
-
-  return value;
-}
-
-export function lruSet(key: string, value: any) {
-  if (lruMap.size >= 2000) {
-    // delete oldest entry
-    lruMap.delete(lruMap.keys().next().value);
-  }
-  lruMap.set(key, value);
-}
-
-export function getMetadataObject(nftId) {
+export function getMetadataObject(nftId: string, lru: LRU<string, any>) {
   let parsedMetadataObject = {};
   try {
     // ============= TRY MEMORY CACHE FIRST ============== //
-    const lru = lruGet(nftId);
-    if (lru) {
-      if (typeof lru === 'object') {
-        lruMap.delete(nftId);
+    const cached = lru.get(nftId);
+    if (cached) {
+      if (typeof cached === 'object') {
+        lru.delete(nftId);
       } else {
-        parsedMetadataObject = JSON.parse(lru);
+        parsedMetadataObject = JSON.parse(cached);
       }
     } else {
       // ============= TRY LOCALSTORAGE CACHE SECOND ============== //
       const lsCache = localStorage.getItem(`metadata-cache-${nftId}`);
-      lruSet(nftId, lsCache);
+      lru.set(nftId, lsCache);
       if (lsCache) {
         parsedMetadataObject = JSON.parse(lsCache);
       }
@@ -58,6 +37,7 @@ export default function useNFTsMetadata(nfts: NFTInfo[]) {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [errorContent, setErrorContent] = useState<string | undefined>();
   const [metadata, setMetadata] = useState<any>();
+  const lru = useNFTMetadataLRU();
 
   async function getMetadata(nft) {
     setIsLoading(true);
@@ -66,7 +46,7 @@ export default function useNFTsMetadata(nfts: NFTInfo[]) {
     const uri = nft?.metadataUris?.[0];
     const nftId = nft?.$nftId;
 
-    const metadataObject = getMetadataObject(nftId);
+    const metadataObject = getMetadataObject(nftId, lru);
 
     if (metadataObject.error) {
       setErrorContent(metadataObject.error);
@@ -101,7 +81,7 @@ export default function useNFTsMetadata(nfts: NFTInfo[]) {
 
       if (!isValid) {
         setErrorContent('Metadata hash mismatch');
-        lruSet(nftId, JSON.stringify({ isValid: false }));
+        lru.set(nftId, JSON.stringify({ isValid: false }));
       }
 
       if (['utf8', 'utf-8'].includes(encoding.toLowerCase())) {
@@ -115,7 +95,7 @@ export default function useNFTsMetadata(nfts: NFTInfo[]) {
         isValid: false,
         error: 'Invalid URI',
       });
-      lruSet(nftId, errorStringified);
+      lru.set(nftId, errorStringified);
       localStorage.setItem(`metadata-cache-${nft.$nftId}`, errorStringified);
       setErrorContent('Invalid URI');
     }
@@ -125,7 +105,7 @@ export default function useNFTsMetadata(nfts: NFTInfo[]) {
         metadata: metadataContent,
         isValid: true,
       });
-      lruSet(nftId, stringifiedCacheObject);
+      lru.set(nftId, stringifiedCacheObject);
       localStorage.setItem(`metadata-cache-${nft.$nftId}`, stringifiedCacheObject);
     }
     setIsLoading(false);

--- a/packages/gui/src/hooks/useNFTMetadataLRU.ts
+++ b/packages/gui/src/hooks/useNFTMetadataLRU.ts
@@ -1,0 +1,16 @@
+import LRU from '@chia-network/core';
+import { useContext } from 'react';
+
+import { LRUsContext } from '../components/lrus/LRUsProvider';
+
+const NFT_METADATA_LRU_NAME = 'nftMetadata';
+
+export default function useNFTMetadataLRU(): LRU<string, any> {
+  const context = useContext(LRUsContext);
+
+  if (!context) {
+    throw new Error('useNFTMetadataLRU must be used within a LRUsProvider');
+  }
+
+  return context.getLRU(NFT_METADATA_LRU_NAME);
+}


### PR DESCRIPTION
Adds an LRU cache class and factory function in @chia-network/core.

Adds a React Context named LRUsContext that maintains a mapping of named LRUs. Currently we only use an LRU named "nftMetadata" for managing the in-memory NFT metadata cache. The LRUsContext provider is installed in AppProviders.

Updates the previous LRU call sites to use the new `useNFTMetadataLRU` hook, providing an object oriented interface to using the LRU.

Tests added to fully cover the LRU class implementation.