### PR TITLE
Fix issue preventing the gallery from initially loading

### DIFF
--- a/packages/gui/src/hooks/useAllowFilteredShow.tsx
+++ b/packages/gui/src/hooks/useAllowFilteredShow.tsx
@@ -60,7 +60,7 @@ async function getMetadata(nft: NFTInfo | undefined, lru: LRU<string, any>) {
     lru.set(nftId, stringifiedCacheObject);
     localStorage.setItem(`metadata-cache-${nft.$nftId}`, stringifiedCacheObject);
   }
-  return { nftId: nft?.$nftId, metadata };
+  return { ...nft, nftId: nft?.$nftId, metadata };
 }
 
 export default function useAllowFilteredShow(nfts: NFTInfo[], hideObjectionableContent: boolean, isLoading: boolean) {


### PR DESCRIPTION
`getMetadata()` was returning a partial object containing just the nftId and metadata. It needs to return the existing NFTInfo object + the nftId and metadata.