### PR TITLE
Update version check to account for '+' (PEP440 local version)

### DIFF
--- a/packages/gui/src/components/app/AppState.tsx
+++ b/packages/gui/src/components/app/AppState.tsx
@@ -173,8 +173,8 @@ export default function AppState(props: Props) {
     // backendVersion can be in the format of 1.6.1, 1.7.0b3, or 1.7.0b3.dev123
     // version can be in the format of 1.6.1, 1.7.0b3, 1.7.0-b2.dev123, or 1.7.0b3-dev123
 
-    const backendVersionClean = backendVersion.replace(/[-.]/g, '');
-    const guiVersionClean = version.replace(/[-.]/g, '');
+    const backendVersionClean = backendVersion.replace(/[-+.]/g, '');
+    const guiVersionClean = version.replace(/[-+.]/g, '');
 
     if (backendVersionClean !== guiVersionClean) {
       return (


### PR DESCRIPTION
Fix version comparison issue with custom builds that make use of the PEP440 local version component. Reported by the community.

Testing notes:
Tested with a backend and frontend version string that contained `+og.1.2.0` and `-og.1.2.0` respectively. Also tested expected version strings for normal builds.