### PR TITLE
Refactor all forms that are not using react-hook-form

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -24,7 +24,7 @@
         "moment": "2.29.4",
         "qs": "6.10.3",
         "react-dropzone": "11.5.1",
-        "react-hook-form": "7.24.1",
+        "react-hook-form": "7.41.5",
         "react-number-format": "4.9.1",
         "react-redux": "7.2.6",
         "react-scroll-to-bottom": "4.2.0",
@@ -10228,9 +10228,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.24.1.tgz",
-      "integrity": "sha512-UndVzKetChAsO+qkRo/6vOgaeTP60x324mHQ4iXVgHDvFjd+X/caWW0/QuAqipt8Bs7pyKH8147UQCrPTYFc2g==",
+      "version": "7.41.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+      "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -10239,7 +10239,7 @@
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {
@@ -19157,9 +19157,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.24.1.tgz",
-      "integrity": "sha512-UndVzKetChAsO+qkRo/6vOgaeTP60x324mHQ4iXVgHDvFjd+X/caWW0/QuAqipt8Bs7pyKH8147UQCrPTYFc2g=="
+      "version": "7.41.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+      "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "moment": "2.29.4",
     "qs": "6.10.3",
     "react-dropzone": "11.5.1",
-    "react-hook-form": "7.24.1",
+    "react-hook-form": "7.41.5",
     "react-number-format": "4.9.1",
     "react-redux": "7.2.6",
     "react-scroll-to-bottom": "4.2.0",

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -97,7 +97,7 @@ export default function TextField(props: TextFieldProps): JSX.Element {
   } = useFormContext();
   const normalizedRules = React.useMemo(() => normalizeRules(rules), [rules]);
   const render = React.useCallback(
-    ({ field: { onChange, value } }) => {
+    ({ field: { onChange, value, ref } }) => {
       function handleChange(...args) {
         onChange(...args);
         if (baseOnChange) {
@@ -119,6 +119,7 @@ export default function TextField(props: TextFieldProps): JSX.Element {
 
       return (
         <MaterialTextField
+          inputRef={ref}
           value={value}
           onChange={handleChange}
           inputProps={{

--- a/packages/gui/package-lock.json
+++ b/packages/gui/package-lock.json
@@ -45,7 +45,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-dropzone": "11.5.1",
-        "react-hook-form": "7.24.1",
+        "react-hook-form": "7.41.5",
         "react-hotkeys-hook": "3.4.7",
         "react-number-format": "4.9.1",
         "react-redux": "7.2.6",
@@ -13156,8 +13156,9 @@
       "license": "MIT"
     },
     "node_modules/react-hook-form": {
-      "version": "7.24.1",
-      "license": "MIT",
+      "version": "7.41.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+      "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -13166,7 +13167,7 @@
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-hotkeys-hook": {
@@ -24114,7 +24115,9 @@
       "version": "3.2.0"
     },
     "react-hook-form": {
-      "version": "7.24.1"
+      "version": "7.41.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+      "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q=="
     },
     "react-hotkeys-hook": {
       "version": "3.4.7",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -171,7 +171,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-dropzone": "11.5.1",
-    "react-hook-form": "7.24.1",
+    "react-hook-form": "7.41.5",
     "react-hotkeys-hook": "3.4.7",
     "react-number-format": "4.9.1",
     "react-redux": "7.2.6",

--- a/packages/gui/src/components/settings/SetPassphrasePrompt.tsx
+++ b/packages/gui/src/components/settings/SetPassphrasePrompt.tsx
@@ -7,6 +7,9 @@ import {
   useValidateChangePassphraseParams,
   useOpenDialog,
   Suspender,
+  Form,
+  TextField,
+  Checkbox,
 } from '@chia-network/core';
 import { t, Trans } from '@lingui/macro';
 import {
@@ -16,7 +19,6 @@ import {
 } from '@mui/icons-material';
 import {
   Box,
-  Checkbox,
   Dialog,
   DialogContent,
   DialogContentText,
@@ -24,10 +26,17 @@ import {
   FormControlLabel,
   IconButton,
   InputAdornment,
-  TextField,
   Tooltip,
 } from '@mui/material';
 import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+type SetPassphrasePromptFormData = {
+  passphrase: string;
+  passphraseConfirmation: string;
+  passphraseHint: string;
+  savePassphrase: boolean;
+};
 
 type Props = {
   onSuccess: () => void;
@@ -40,22 +49,19 @@ export default function SetPassphrasePrompt(props: Props) {
   const { data: keyringState, isLoading } = useGetKeyringStatusQuery();
   const [setKeyringPassphrase, { isLoading: isLoadingSetKeyringPassphrase }] = useSetKeyringPassphraseMutation();
   const [validateChangePassphraseParams] = useValidateChangePassphraseParams();
-  let passphraseInput: HTMLInputElement | null;
-  let confirmationInput: HTMLInputElement | null;
-  let passphraseHintInput: HTMLInputElement | null;
-  let savePassphraseCheckbox: HTMLInputElement | null = null;
+
+  const formMethods = useForm<SetPassphrasePromptFormData>({
+    defaultValues: {
+      passphrase: '',
+      passphraseConfirmation: '',
+      passphraseHint: '',
+      savePassphrase: false,
+    },
+  });
+
   const [showPassphraseText1, setShowPassphraseText1] = useState(false);
   const [showPassphraseText2, setShowPassphraseText2] = useState(false);
   const [showCapsLock, setShowCapsLock] = useState(false);
-
-  const [needsFocusAndSelect, setNeedsFocusAndSelect] = React.useState(false);
-  useEffect(() => {
-    if (needsFocusAndSelect && passphraseInput) {
-      passphraseInput.focus();
-      passphraseInput.select();
-      setNeedsFocusAndSelect(false);
-    }
-  });
 
   async function validateDialog(passphrase: string, confirmation: string): Promise<boolean> {
     let isValid = false;
@@ -73,13 +79,13 @@ export default function SetPassphrasePrompt(props: Props) {
     return isValid;
   }
 
-  async function handleSubmit() {
-    const passphrase: string = passphraseInput?.value ?? '';
-    const confirmation: string = confirmationInput?.value ?? '';
-    const passphraseHint: string = passphraseHintInput?.value ?? '';
-    const savePassphrase: boolean = savePassphraseCheckbox?.checked ?? false;
-    const isValid = await validateDialog(passphrase, confirmation);
-
+  async function handleSubmit({
+    passphrase,
+    passphraseConfirmation,
+    passphraseHint,
+    savePassphrase,
+  }: SetPassphrasePromptFormData) {
+    const isValid = await validateDialog(passphrase, passphraseConfirmation);
     if (isValid) {
       try {
         await setKeyringPassphrase({
@@ -96,10 +102,10 @@ export default function SetPassphrasePrompt(props: Props) {
             <Trans>Failed to set passphrase: {error.message}</Trans>
           </AlertDialog>
         );
-        setNeedsFocusAndSelect(true);
+        formMethods.setFocus('passphrase', { shouldSelect: true });
       }
     } else {
-      setNeedsFocusAndSelect(true);
+      formMethods.setFocus('passphrase', { shouldSelect: true });
     }
   }
 
@@ -109,7 +115,7 @@ export default function SetPassphrasePrompt(props: Props) {
 
   async function handleKeyDown(e: React.KeyboardEvent) {
     const keyHandlerMapping: { [key: string]: () => Promise<void> } = {
-      Enter: handleSubmit,
+      Enter: formMethods.handleSubmit(handleSubmit),
       Escape: handleCancel,
     };
 
@@ -152,129 +158,118 @@ export default function SetPassphrasePrompt(props: Props) {
       <DialogTitle id="form-dialog-title">
         <Trans>Set Passphrase</Trans>
       </DialogTitle>
-      <DialogContent>
-        <DialogContentText>
-          <Trans>Enter a strong passphrase to secure your keys:</Trans>
-        </DialogContentText>
-        <Flex flexDirection="row" gap={1.5} alignItems="center">
-          <TextField
-            autoFocus
-            disabled={isLoadingSetKeyringPassphrase}
-            color="secondary"
-            margin="dense"
-            id="passphraseInput"
-            label={<Trans>Passphrase</Trans>}
-            placeholder="Passphrase"
-            // eslint-disable-next-line no-return-assign -- Yes we want assignment instead of comparison
-            inputRef={(input) => (passphraseInput = input)}
-            type={showPassphraseText1 ? 'text' : 'password'}
-            InputProps={{
-              endAdornment: (
-                <Flex alignItems="center">
-                  <InputAdornment position="end">
-                    {showCapsLock && (
-                      <Flex>
-                        <KeyboardCapslockIcon />
-                      </Flex>
-                    )}
-                    <IconButton onClick={() => setShowPassphraseText1((s) => !s)}>
-                      <VisibilityIcon />
-                    </IconButton>
-                  </InputAdornment>
-                </Flex>
-              ),
-            }}
-            data-testid="SetPassphrasePrompt-passphrase"
-            fullWidth
-          />
-        </Flex>
-        <Flex flexDirection="row" gap={1.5} alignItems="center">
-          <TextField
-            disabled={isLoadingSetKeyringPassphrase}
-            color="secondary"
-            margin="dense"
-            id="confirmationInput"
-            label={<Trans>Confirm Passphrase</Trans>}
-            placeholder="Confirm Passphrase"
-            // eslint-disable-next-line no-return-assign -- Yes we want assignment instead of comparison
-            inputRef={(input) => (confirmationInput = input)}
-            type={showPassphraseText2 ? 'text' : 'password'}
-            InputProps={{
-              endAdornment: (
-                <Flex alignItems="center">
-                  <InputAdornment position="end">
-                    {showCapsLock && (
-                      <Flex>
-                        <KeyboardCapslockIcon />
-                      </Flex>
-                    )}
-                    <IconButton onClick={() => setShowPassphraseText2((s) => !s)}>
-                      <VisibilityIcon />
-                    </IconButton>
-                  </InputAdornment>
-                </Flex>
-              ),
-            }}
-            data-testid="SetPassphrasePrompt-confirm-passphrase"
-            fullWidth
-          />
-        </Flex>
-        {!!canSetPassphraseHint && (
-          <TextField
-            disabled={isLoadingSetKeyringPassphrase}
-            color="secondary"
-            margin="dense"
-            id="passphraseHintInput"
-            label={<Trans>Passphrase Hint (Optional)</Trans>}
-            placeholder={t`Passphrase Hint`}
-            // eslint-disable-next-line no-return-assign -- Yes we want assignment instead of comparison
-            inputRef={(input) => (passphraseHintInput = input)}
-            data-testid="SetPassphrasePrompt-hint"
-            fullWidth
-          />
-        )}
-        {!!canSavePassphrase && (
-          <Box display="flex" alignItems="center">
-            <FormControlLabel
-              control={
-                <Checkbox
-                  disabled={isLoadingSetKeyringPassphrase}
-                  name="cleanupKeyringPostMigration"
-                  // eslint-disable-next-line no-return-assign -- Yes we want assignment instead of comparison
-                  inputRef={(input) => (savePassphraseCheckbox = input)}
-                />
-              }
-              label={t`Save passphrase`}
-              style={{ marginRight: '8px' }}
-              data-testid="SetPassphrasePrompt-save-passphrase"
+      <Form methods={formMethods} onSubmit={formMethods.handleSubmit(handleSubmit)}>
+        <DialogContent>
+          <DialogContentText>
+            <Trans>Enter a strong passphrase to secure your keys:</Trans>
+          </DialogContentText>
+          <Flex flexDirection="row" gap={1.5} alignItems="center">
+            <TextField
+              autoFocus
+              disabled={isLoadingSetKeyringPassphrase}
+              color="secondary"
+              margin="dense"
+              name="passphrase"
+              label={<Trans>Passphrase</Trans>}
+              placeholder="Passphrase"
+              type={showPassphraseText1 ? 'text' : 'password'}
+              InputProps={{
+                endAdornment: (
+                  <Flex alignItems="center">
+                    <InputAdornment position="end">
+                      {showCapsLock && (
+                        <Flex>
+                          <KeyboardCapslockIcon />
+                        </Flex>
+                      )}
+                      <IconButton onClick={() => setShowPassphraseText1((s) => !s)}>
+                        <VisibilityIcon />
+                      </IconButton>
+                    </InputAdornment>
+                  </Flex>
+                ),
+              }}
+              data-testid="SetPassphrasePrompt-passphrase"
+              fullWidth
             />
-            <Tooltip
-              title={t`Your passphrase can be stored in your system's secure credential store. Chia will be able to access your keys without prompting for your passphrase.`}
-            >
-              <HelpIcon style={{ color: '#c8c8c8', fontSize: 12 }} />
-            </Tooltip>
-          </Box>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button
-          disabled={isLoadingSetKeyringPassphrase}
-          onClick={handleCancel}
-          variant="outlined"
-          data-testid="SetPassphrasePrompt-cancel"
-        >
-          <Trans>Cancel</Trans>
-        </Button>
-        <Button
-          disabled={isLoadingSetKeyringPassphrase}
-          onClick={handleSubmit}
-          color="primary"
-          variant="contained"
-          data-testid="SetPassphrasePrompt-set-passphrase"
-        >
-          <Trans>Set Passphrase</Trans>
-        </Button>
-      </DialogActions>
+          </Flex>
+          <Flex flexDirection="row" gap={1.5} alignItems="center">
+            <TextField
+              disabled={isLoadingSetKeyringPassphrase}
+              color="secondary"
+              margin="dense"
+              name="passphraseConfirmation"
+              label={<Trans>Confirm Passphrase</Trans>}
+              placeholder="Confirm Passphrase"
+              type={showPassphraseText2 ? 'text' : 'password'}
+              InputProps={{
+                endAdornment: (
+                  <Flex alignItems="center">
+                    <InputAdornment position="end">
+                      {showCapsLock && (
+                        <Flex>
+                          <KeyboardCapslockIcon />
+                        </Flex>
+                      )}
+                      <IconButton onClick={() => setShowPassphraseText2((s) => !s)}>
+                        <VisibilityIcon />
+                      </IconButton>
+                    </InputAdornment>
+                  </Flex>
+                ),
+              }}
+              data-testid="SetPassphrasePrompt-confirm-passphrase"
+              fullWidth
+            />
+          </Flex>
+          {!!canSetPassphraseHint && (
+            <TextField
+              disabled={isLoadingSetKeyringPassphrase}
+              color="secondary"
+              margin="dense"
+              name="passphraseHint"
+              label={<Trans>Passphrase Hint (Optional)</Trans>}
+              placeholder={t`Passphrase Hint`}
+              data-testid="SetPassphrasePrompt-hint"
+              fullWidth
+            />
+          )}
+          {!!canSavePassphrase && (
+            <Box display="flex" alignItems="center">
+              <FormControlLabel
+                control={<Checkbox disabled={isLoadingSetKeyringPassphrase} name="savePassphrase" />}
+                label={t`Save passphrase`}
+                style={{ marginRight: '8px' }}
+                data-testid="SetPassphrasePrompt-save-passphrase"
+              />
+              <Tooltip
+                title={t`Your passphrase can be stored in your system's secure credential store. Chia will be able to access your keys without prompting for your passphrase.`}
+              >
+                <HelpIcon style={{ color: '#c8c8c8', fontSize: 12 }} />
+              </Tooltip>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            disabled={isLoadingSetKeyringPassphrase}
+            onClick={handleCancel}
+            variant="outlined"
+            data-testid="SetPassphrasePrompt-cancel"
+          >
+            <Trans>Cancel</Trans>
+          </Button>
+          <Button
+            disabled={isLoadingSetKeyringPassphrase}
+            type="submit"
+            color="primary"
+            variant="contained"
+            data-testid="SetPassphrasePrompt-set-passphrase"
+          >
+            <Trans>Set Passphrase</Trans>
+          </Button>
+        </DialogActions>
+      </Form>
     </Dialog>
   );
 }

--- a/packages/gui/src/components/settings/SettingsPanel.tsx
+++ b/packages/gui/src/components/settings/SettingsPanel.tsx
@@ -37,7 +37,7 @@ export default function SettingsPanel() {
     return <Suspender />;
   }
 
-  const { userPassphraseIsSet, needsMigration } = keyringStatus;
+  const { userPassphraseIsSet, needsMigration = false } = keyringStatus;
 
   async function changePassphraseSucceeded() {
     closeChangePassphrase();

--- a/packages/wallets/package-lock.json
+++ b/packages/wallets/package-lock.json
@@ -22,7 +22,7 @@
         "moment": "2.29.4",
         "qs": "6.10.3",
         "react-dropzone": "11.5.1",
-        "react-hook-form": "7.24.1",
+        "react-hook-form": "7.41.5",
         "react-redux": "7.2.6",
         "react-scroll-to-bottom": "4.2.0",
         "react-use": "17.3.2",
@@ -8966,9 +8966,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-hook-form": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.24.1.tgz",
-      "integrity": "sha512-UndVzKetChAsO+qkRo/6vOgaeTP60x324mHQ4iXVgHDvFjd+X/caWW0/QuAqipt8Bs7pyKH8147UQCrPTYFc2g==",
+      "version": "7.41.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+      "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -8977,7 +8977,7 @@
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {
@@ -17349,9 +17349,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-hook-form": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.24.1.tgz",
-      "integrity": "sha512-UndVzKetChAsO+qkRo/6vOgaeTP60x324mHQ4iXVgHDvFjd+X/caWW0/QuAqipt8Bs7pyKH8147UQCrPTYFc2g=="
+      "version": "7.41.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+      "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -38,7 +38,7 @@
     "moment": "2.29.4",
     "qs": "6.10.3",
     "react-dropzone": "11.5.1",
-    "react-hook-form": "7.24.1",
+    "react-hook-form": "7.41.5",
     "react-redux": "7.2.6",
     "react-scroll-to-bottom": "4.2.0",
     "react-use": "17.3.2",

--- a/packages/wallets/src/components/PasteMnemonic.tsx
+++ b/packages/wallets/src/components/PasteMnemonic.tsx
@@ -1,6 +1,12 @@
+import { Form, TextField } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 import React from 'react';
+import { useForm } from 'react-hook-form';
+
+type MnemonicPasteFormData = {
+  mnemonicList: string;
+};
 
 type Props = {
   onSuccess: (mnemonicList: string) => void;
@@ -9,10 +15,14 @@ type Props = {
 
 export default function MnemonicPaste(props: Props) {
   const { onSuccess, onCancel } = props;
-  let mnemonicListInput: HTMLInputElement | null;
 
-  async function handleSubmit() {
-    const mnemonicList: string = mnemonicListInput?.value ?? '';
+  const formMethods = useForm<MnemonicPasteFormData>({
+    defaultValues: {
+      mnemonicList: '',
+    },
+  });
+
+  async function handleSubmit({ mnemonicList }: MnemonicPasteFormData) {
     onSuccess(mnemonicList);
   }
 
@@ -22,7 +32,7 @@ export default function MnemonicPaste(props: Props) {
 
   async function handleKeyDown(e: React.KeyboardEvent) {
     const keyHandlerMapping: { [key: string]: () => Promise<void> } = {
-      Enter: handleSubmit,
+      Enter: formMethods.handleSubmit(handleSubmit),
       Escape: handleCancel,
     };
     const handler: () => Promise<void> | undefined = keyHandlerMapping[e.key];
@@ -41,38 +51,34 @@ export default function MnemonicPaste(props: Props) {
       <DialogTitle id="form-dialog-title">
         <Trans>Paste Mnemonic (24 words)</Trans>
       </DialogTitle>
-      <DialogContent>
-        <TextField
-          autoFocus
-          multiline
-          rows={5}
-          color="secondary"
-          margin="dense"
-          id="mnemonicListInput"
-          variant="filled"
-          inputRef={(input) => (mnemonicListInput = input)}
-          type="password"
-          fullWidth
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button
-          onClick={handleCancel}
-          color="secondary"
-          variant="contained"
-          style={{ marginBottom: '8px', marginRight: '8px' }}
-        >
-          <Trans>Cancel</Trans>
-        </Button>
-        <Button
-          onClick={handleSubmit}
-          color="primary"
-          variant="contained"
-          style={{ marginBottom: '8px', marginRight: '8px' }}
-        >
-          <Trans>Import</Trans>
-        </Button>
-      </DialogActions>
+      <Form methods={formMethods} onSubmit={formMethods.handleSubmit(handleSubmit)}>
+        <DialogContent>
+          <TextField
+            autoFocus
+            multiline
+            rows={5}
+            color="secondary"
+            margin="dense"
+            name="mnemonicList"
+            variant="filled"
+            type="password"
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleCancel}
+            color="secondary"
+            variant="contained"
+            style={{ marginBottom: '8px', marginRight: '8px' }}
+          >
+            <Trans>Cancel</Trans>
+          </Button>
+          <Button type="submit" color="primary" variant="contained" style={{ marginBottom: '8px', marginRight: '8px' }}>
+            <Trans>Import</Trans>
+          </Button>
+        </DialogActions>
+      </Form>
     </Dialog>
   );
 }


### PR DESCRIPTION
- Tested (including submitting via pressing enter key)
- react-hook-form had to be updated to support `shouldSelect: true`
- Fixed bug: ChangePassphrasePrompt was never displayed