### PR TITLE
fix crash when creating a plotNFT (fix 1396)

### DIFF
--- a/packages/gui/src/components/plotNFT/PlotNFTUnconfirmedCard.tsx
+++ b/packages/gui/src/components/plotNFT/PlotNFTUnconfirmedCard.tsx
@@ -45,7 +45,7 @@ export default function PlotNFTUnconfirmedCard(props: Props) {
     if (transaction?.confirmed) {
       remove(transaction.name);
     }
-  }, [remove, transaction?.confirmed, transaction.name]);
+  }, [remove, transaction?.confirmed, transaction?.name]);
 
   if (isLoading || transaction?.confirmed) {
     return null;


### PR DESCRIPTION
fixes a bad dereference on a hook dependency array addition.