### PR TITLE
launch daemon if self_hostname === ui.daemon_host

### DIFF
--- a/packages/gui/src/util/manageDaemonLifetime.ts
+++ b/packages/gui/src/util/manageDaemonLifetime.ts
@@ -5,9 +5,10 @@ import { readConfigFile } from './loadConfig';
 export default function manageDaemonLifetime(net?: string): boolean {
   try {
     const config = readConfigFile(net);
-    const selfHostname = get(config, 'ui.daemon_host', 'localhost');
+    const selfHostname = get(config, 'self_hostname', 'localhost');
+    const uiDaemonHost = get(config, 'ui.daemon_host', 'localhost');
 
-    return selfHostname === 'localhost';
+    return selfHostname === uiDaemonHost;
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       // configuration file does not exists, use default value


### PR DESCRIPTION
When overriding config.yaml values that specify localhost by default, this change will allow the GUI to launch the daemon if `self_hostname` equals `ui:daemon_host`

Fixes issue https://github.com/Chia-Network/chia-blockchain/issues/14468

Repro steps for the original issue:

1) Update config.yaml such that all localhost values are replaced by the machine's local IP (e.g. 192.168.1.100)
2) With the daemon and all services stopped, launch the GUI

Observe:

1) The GUI fails to launch the daemon and is stuck on the loading keyring screen