### PR TITLE
fix infinite re-rendering bug when defaultValue object value is returned

### DIFF
--- a/packages/api-react/src/hooks/useLocalStorage.ts
+++ b/packages/api-react/src/hooks/useLocalStorage.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 import EventEmitter from '../utils/EventEmitter';
+import { isEqual } from './usePrefs';
 
 const eventEmitter = new EventEmitter();
 
@@ -18,11 +19,16 @@ function getValueFromLocalStorage<T>(key: string): T | undefined {
   }
 }
 
-export default function useLocalStorage<T>(
+export default function useLocalStorage<T extends keyof (string | undefined)>(
   key: string,
   defaultValue?: T
 ): [T | undefined, (value: T | ((value: T | undefined) => T)) => void] {
   const [storedValue, setStoredValue] = useState<T | undefined>(getValueFromLocalStorage(key));
+  const defaultValueRef = useRef(defaultValue);
+
+  if (!isEqual(defaultValueRef.current, defaultValue)) {
+    defaultValueRef.current = defaultValue;
+  }
 
   const setValue = useCallback(
     (value: T | ((nv: T | undefined) => T)) => {

--- a/packages/api-react/src/hooks/usePrefs.ts
+++ b/packages/api-react/src/hooks/usePrefs.ts
@@ -28,7 +28,7 @@ function setPreferences(key: string, value: Serializable) {
   (window as any).preferences[key] = value;
 }
 
-function isEqual(a: Serializable, b: Serializable) {
+export function isEqual(a: Serializable, b: Serializable) {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
@@ -39,6 +39,11 @@ export default function usePrefs<T extends Serializable>(
   const [value, setValue] = useState<T>(getPreferences(key));
   const valueRef = useRef(value);
   valueRef.current = value;
+  const defaultValueRef = useRef(defaultValue);
+
+  if (!isEqual(defaultValueRef.current, defaultValue)) {
+    defaultValueRef.current = defaultValue;
+  }
 
   const handleSetValue = useCallback(
     (newValueOrFn: T | ((nv: T) => T)) => {
@@ -76,5 +81,5 @@ export default function usePrefs<T extends Serializable>(
     };
   }, [handleOnChange]);
 
-  return [value ?? defaultValue, handleSetValue];
+  return [(valueRef.current ?? defaultValueRef.current) as T, handleSetValue];
 }


### PR DESCRIPTION
Components/hooks that use the `usePrefs` and `useLocalStorage` hooks may hit an infinite re-render bug if the default value passed to `usePrefs`/`useLocalStorage` is an object and that default value is returned.

NFT gallery makes use of a few hooks that call `usePrefs` with a default value of `{}`. When the default value is returned from `usePrefs` and then that value is used in another hook's dependency array, that hook will always trigger a re-render as `{} === {}` is `false`.

This change adds a ref to hold the default value and only updates the ref is the value's serialized form changes.