### PR TITLE
Introduction of AddressBook & User friendly names.

### DIFF
--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -16,3 +16,4 @@ export { default as useShowError } from './useShowError';
 export { default as useSkipMigration } from './useSkipMigration';
 export { default as useTrans } from './useTrans';
 export { default as useValidateChangePassphraseParams } from './useValidateChangePassphraseParams';
+export { default as useAddressBook } from './useAddressBook';

--- a/packages/core/src/hooks/useAddressBook.tsx
+++ b/packages/core/src/hooks/useAddressBook.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+
+export default function useAddressBook(): [
+  IAddressContact[],
+  (friendName: string, address: string) => void,
+  (address: string) => IAddressContact | undefined
+] {
+  const [addressBook, setAddressBook] = useState<IAddressContact[]>([]);
+
+  function getAddressBook() {
+    if (localStorage.getItem('addressbook') === null) {
+      return [];
+    }
+    const addresses: IAddressContact[] = JSON.parse(localStorage.getItem('addressbook'));
+    setAddressBook(addresses);
+  }
+
+  function addAddress(friendlyName: string, address: string) {
+    const newAddress: IAddressContact = {
+      friendlyname: friendlyName,
+      address,
+    };
+    addressBook.push(newAddress);
+    setAddressBook(addressBook);
+    localStorage.setItem('addressbook', JSON.stringify(addressBook));
+  }
+
+  function getContactByAddress(findAddress: string): IAddressContact | undefined {
+    const existing = addressBook.find((x) => x.address.toLowerCase() === findAddress.toLowerCase());
+    return existing;
+  }
+
+  useEffect(() => {
+    getAddressBook();
+  }, []);
+
+  return [addressBook, addAddress, getContactByAddress];
+}
+
+interface IAddressContact {
+  friendlyname: string;
+  address: string;
+}

--- a/packages/gui/src/components/addressbook/AddAddress.tsx
+++ b/packages/gui/src/components/addressbook/AddAddress.tsx
@@ -1,4 +1,4 @@
-import { TextField, ButtonLoading, Card, Flex, Form, useAddressBook } from '@chia-network/core';
+import { TextField, ButtonLoading, Card, Flex, Form, useAddressBook, useOpenDialog } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { Typography, Grid } from '@mui/material';
 import React from 'react';
@@ -13,9 +13,8 @@ export default function AddAddress() {
     },
   });
   const navigate = useNavigate();
-
   const [s, add] = useAddressBook();
-  async function handleSubmit(formData: AddAddressData) {
+  function handleSubmit(formData: AddAddressData) {
     add(formData.friendlyname, formData.address);
     navigate('/dashboard/addressbook');
   }

--- a/packages/gui/src/components/addressbook/AddAddress.tsx
+++ b/packages/gui/src/components/addressbook/AddAddress.tsx
@@ -1,0 +1,80 @@
+import { TextField, ButtonLoading, Card, Flex, Form, useAddressBook } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { Typography, Grid } from '@mui/material';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+export default function AddAddress() {
+  const methods = useForm<AddAddressData>({
+    defaultValues: {
+      address: '',
+      friendlyname: '',
+    },
+  });
+  const navigate = useNavigate();
+
+  const [s, add] = useAddressBook();
+  async function handleSubmit(formData: AddAddressData) {
+    add(formData.friendlyname, formData.address);
+    navigate('/dashboard/addressbook');
+  }
+
+  return (
+    <Flex flexDirection="column" gap={4} alignItems="stretch">
+      <Flex gap={4} flexDirection="column">
+        <Flex flexDirection="column" gap={1}>
+          <Typography variant="h5">
+            <Trans>Add Address</Trans>
+          </Typography>
+          <Typography variant="body2" color="textSecondary">
+            <Trans>Address book is a way of managing addresses using a friendly name.</Trans>
+          </Typography>
+        </Flex>
+      </Flex>
+
+      <Card>
+        <Form methods={methods} onSubmit={handleSubmit}>
+          <Grid spacing={2} container>
+            <Grid xs={12} item>
+              <TextField
+                name="address"
+                variant="filled"
+                color="secondary"
+                fullWidth
+                label={<Trans>Address / Puzzle hash</Trans>}
+                data-testid="address"
+                InputProps={{
+                  readOnly: false,
+                }}
+                required
+              />
+            </Grid>
+            <Grid xs={12} item>
+              <TextField
+                name="friendlyname"
+                variant="filled"
+                color="secondary"
+                fullWidth
+                label={<Trans>Friendly name</Trans>}
+                data-testid="friendlyname"
+                required
+                InputProps={{
+                  readOnly: false,
+                }}
+              />
+            </Grid>
+
+            <Grid xs={12} item>
+              <Flex justifyContent="flex-end">
+                <ButtonLoading type="submit" variant="contained" color="primary" loading={false}>
+                  <Trans>Save</Trans>
+                </ButtonLoading>
+              </Flex>
+            </Grid>
+          </Grid>
+        </Form>
+      </Card>
+    </Flex>
+  );
+}

--- a/packages/gui/src/components/addressbook/AddressBook.tsx
+++ b/packages/gui/src/components/addressbook/AddressBook.tsx
@@ -1,0 +1,18 @@
+import { LayoutDashboardSub } from '@chia-network/core';
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+
+import AddAddress from './AddAddress';
+import ListAddress from './ListAddress';
+
+export function AddressBook() {
+  return (
+    <LayoutDashboardSub>
+      <Routes>
+        <Route path="list" element={<ListAddress />} />
+        <Route path="add" element={<AddAddress />} />
+        <Route path="/" element={<Navigate to="list" />} />
+      </Routes>
+    </LayoutDashboardSub>
+  );
+}

--- a/packages/gui/src/components/addressbook/ListAddress.tsx
+++ b/packages/gui/src/components/addressbook/ListAddress.tsx
@@ -1,12 +1,68 @@
-import { Button, ButtonLoading, Card, Flex, useAddressBook } from '@chia-network/core';
+import { Button, Card, Flex, useAddressBook, TableControlled, Row } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
-import { Box, Typography, Table, TableBody, TableCell, TableRow } from '@mui/material';
+import { Typography, Tooltip } from '@mui/material';
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+
+const cols = (address: IAddressContact) => [
+  {
+    width: '100%',
+    field: (row: Row) => (
+      <Flex gap={1}>
+        <Tooltip title={<Trans>Address</Trans>}>
+          <span>
+            <Trans>{row.address}</Trans>
+          </span>
+        </Tooltip>
+      </Flex>
+    ),
+    title: <Trans>Address</Trans>,
+  },
+  {
+    field: (row: Row) => (
+      <Flex gap={1}>
+        <Tooltip title={<Trans>Friendly Name</Trans>}>
+          <span>
+            <Trans>{row.friendlyname}</Trans>
+          </span>
+        </Tooltip>
+      </Flex>
+    ),
+    title: <Trans>Friendly Name</Trans>,
+  },
+  {
+    field: (row: Row) => (
+      <Flex gap={1}>
+        <Tooltip title={<Trans>Remove Address</Trans>}>
+          <Button
+            type="button"
+            onClick={() => console.log('Attempting to remove contact')}
+            variant="contained"
+            color="secondary"
+          >
+            <Trans>Remove</Trans>
+          </Button>
+        </Tooltip>
+      </Flex>
+    ),
+  },
+];
 
 export default function ListAddress() {
+  const navigate = useNavigate();
   const [addresses] = useAddressBook();
   useEffect(() => {}, [addresses]);
+  const [rowsPerPage, setRowsPerPage] = useState<number>(5);
+  const [page, setPage] = useState<number>(0);
+  function handlePageChange(rowsPerPageLocal: number, pageLocal: number) {
+    setRowsPerPage(rowsPerPageLocal);
+    setPage(pageLocal);
+  }
+
+  function createNewContact() {
+    navigate('/dashboard/addressbook/add');
+  }
+
   return (
     <Flex flexDirection="column" gap={4} alignItems="stretch">
       <Flex gap={4} flexDirection="column">
@@ -20,26 +76,31 @@ export default function ListAddress() {
         </Flex>
       </Flex>
       <Flex justifyContent="flex-end">
-        <Link to="/dashboard/addressbook/add">
-          <ButtonLoading type="submit" variant="contained" color="primary" loading={false}>
-            <Trans>Create</Trans>
-          </ButtonLoading>
-        </Link>
+        <Button type="button" onClick={createNewContact} variant="contained" color="primary" loading={false}>
+          <Trans>Create</Trans>
+        </Button>
       </Flex>
       <Card>
-        <TableBody>
-          {addresses.map((row, index) => (
-            // eslint-disable-next-line react/no-array-index-key -- Number of rows never change
-            <TableRow key={index}>
-              <TableCell component="th" fullwidth scope="row">
-                {row.friendlyname}
-              </TableCell>
-              <TableCell onClick={row.onClick} align="right">
-                {row.address}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
+        <TableControlled
+          cols={cols()}
+          rows={addresses ?? []}
+          rowsPerPageOptions={[5, 10, 25, 50, 10]}
+          page={page}
+          rowsPerPage={rowsPerPage}
+          count={addresses?.length}
+          isLoading={false}
+          expandedCellShift={0}
+          onPageChange={handlePageChange}
+          uniqueField="name"
+          caption={
+            !addresses?.length && (
+              <Typography variant="body2" align="center">
+                <Trans>No Contacts</Trans>
+              </Typography>
+            )
+          }
+          pages={!!addresses?.length}
+        />
       </Card>
     </Flex>
   );

--- a/packages/gui/src/components/addressbook/ListAddress.tsx
+++ b/packages/gui/src/components/addressbook/ListAddress.tsx
@@ -1,0 +1,46 @@
+import { Button, ButtonLoading, Card, Flex, useAddressBook } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { Box, Typography, Table, TableBody, TableCell, TableRow } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+
+export default function ListAddress() {
+  const [addresses] = useAddressBook();
+  useEffect(() => {}, [addresses]);
+  return (
+    <Flex flexDirection="column" gap={4} alignItems="stretch">
+      <Flex gap={4} flexDirection="column">
+        <Flex flexDirection="column" gap={1}>
+          <Typography variant="h5">
+            <Trans>Address Book</Trans>
+          </Typography>
+          <Typography variant="body2" color="textSecondary">
+            <Trans>Address book is a way of managing addresses using a friendly name.</Trans>
+          </Typography>
+        </Flex>
+      </Flex>
+      <Flex justifyContent="flex-end">
+        <Link to="/dashboard/addressbook/add">
+          <ButtonLoading type="submit" variant="contained" color="primary" loading={false}>
+            <Trans>Create</Trans>
+          </ButtonLoading>
+        </Link>
+      </Flex>
+      <Card>
+        <TableBody>
+          {addresses.map((row, index) => (
+            // eslint-disable-next-line react/no-array-index-key -- Number of rows never change
+            <TableRow key={index}>
+              <TableCell component="th" fullwidth scope="row">
+                {row.friendlyname}
+              </TableCell>
+              <TableCell onClick={row.onClick} align="right">
+                {row.address}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Card>
+    </Flex>
+  );
+}

--- a/packages/gui/src/components/app/AppRouter.tsx
+++ b/packages/gui/src/components/app/AppRouter.tsx
@@ -3,6 +3,7 @@ import { WalletAdd, WalletImport, Wallets } from '@chia-network/wallets';
 import React from 'react';
 import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 
+import { AddressBook } from '../addressbook/AddressBook';
 import Block from '../block/Block';
 import DashboardSideBar from '../dashboard/DashboardSideBar';
 import Farm from '../farm/Farm';
@@ -47,6 +48,7 @@ export default function AppRouter() {
               <Route path="dashboard/nfts/*" element={<NFTs />} />
               <Route path="dashboard/*" element={<Navigate to="wallets" />} />
               <Route path="dashboard/settings/*" element={<Settings />} />
+              <Route path="dashboard/addressbook/*" element={<AddressBook />} />
             </Route>
           ) : (
             <Route
@@ -68,6 +70,7 @@ export default function AppRouter() {
               <Route path="dashboard/plot/*" element={<Plot />} />
               <Route path="dashboard/farm/*" element={<Farm />} />
               <Route path="dashboard/pool/*" element={<Pool />} />
+              <Route path="dashboard/addressbook/*" element={<AddressBook />} />
             </Route>
           )}
         </Route>

--- a/packages/gui/src/components/dashboard/DashboardSideBar.tsx
+++ b/packages/gui/src/components/dashboard/DashboardSideBar.tsx
@@ -8,6 +8,7 @@ import {
   Offers as OffersIcon,
   Tokens as TokensIcon,
   Settings as SettingsIcon,
+  Settings as AddressBookIcon,
 } from '@chia-network/icons';
 import { Trans } from '@lingui/macro';
 import { Box } from '@mui/material';
@@ -62,6 +63,12 @@ export default function DashboardSideBar(props: DashboardSideBarProps) {
           icon={OffersIcon}
           title={<Trans>Offers</Trans>}
           data-testid="DashboardSideBar-offers"
+        />
+        <SideBarItem
+          to="/dashboard/addressbook"
+          icon={AddressBookIcon}
+          title={<Trans>Address Book</Trans>}
+          data-testid="DashboardSideBar-addressbook"
         />
 
         {!simple && (

--- a/packages/wallets/src/components/WalletHistory.tsx
+++ b/packages/wallets/src/components/WalletHistory.tsx
@@ -125,11 +125,13 @@ const getCols = (type: WalletType, isSyncing, getOfferRecord, navigate, getConta
             }
           >
             <span>
-              {getContactByAddress(row.toAddress) !== undefined && (
-                <Chip size="small" variant="outlined" label={getContactByAddress(row.toAddress).friendlyname} />
-              )}
+              <span>
+                {getContactByAddress(row.toAddress) !== undefined && (
+                  <Chip size="small" variant="outlined" label={getContactByAddress(row.toAddress).friendlyname} />
+                )}
+              </span>
+              <span>{shouldObscureAddress ? `${row.toAddress.slice(0, 20)}...` : row.toAddress}</span>
             </span>
-            <span>{shouldObscureAddress ? `${row.toAddress.slice(0, 20)}...` : row.toAddress}</span>
           </Tooltip>
           <Flex gap={0.5}>
             {isConfirmed ? (

--- a/packages/wallets/src/components/WalletSend.tsx
+++ b/packages/wallets/src/components/WalletSend.tsx
@@ -13,9 +13,10 @@ import {
   getTransactionResult,
   useIsSimulator,
   TooltipIcon,
+  useAddressBook,
 } from '@chia-network/core';
 import { Trans, t } from '@lingui/macro';
-import { Button, Grid, Typography } from '@mui/material';
+import { Button, Grid, Typography, Autocomplete } from '@mui/material';
 import React from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import isNumeric from 'validator/es/lib/isNumeric';
@@ -41,6 +42,12 @@ export default function WalletSend(props: SendCardProps) {
   const openDialog = useOpenDialog();
   const [sendTransaction, { isLoading: isSendTransactionLoading }] = useSendTransactionMutation();
   const [farmBlock] = useFarmBlockMutation();
+  const [addresses, addAddress, getContactByAddress] = useAddressBook();
+  const options = addresses.map((item: { label: string; value: string }) => ({
+    label: `${item.address} (${item.friendlyname})`,
+    value: item.address,
+  }));
+
   const methods = useForm<SendTransactionData>({
     defaultValues: {
       address: '',
@@ -146,7 +153,6 @@ export default function WalletSend(props: SendCardProps) {
     // Workaround to force a re-render of the form. Without this, the fee field will not be cleared.
     setSubmissionCount((prev: number) => prev + 1);
   }
-
   return (
     <Form methods={methods} key={submissionCount} onSubmit={handleSubmit}>
       <Flex gap={2} flexDirection="column">
@@ -163,15 +169,23 @@ export default function WalletSend(props: SendCardProps) {
         <Card>
           <Grid spacing={2} container>
             <Grid xs={12} item>
-              <TextField
-                name="address"
-                variant="filled"
-                color="secondary"
-                fullWidth
+              <Autocomplete
+                options={options}
+                getOptionLabel={(option) => option?.value || option}
+                renderOption={(props: object, option: any, state: object) => <div {...props}>{option?.label}</div>}
+                renderInput={(params) => (
+                  <TextField
+                    name="address"
+                    required
+                    {...params}
+                    label={<Trans>Address / Puzzle hash</Trans>}
+                    variant="outlined"
+                  />
+                )}
+                freeSolo
                 disabled={isSubmitting}
-                label={<Trans>Address / Puzzle hash</Trans>}
                 data-testid="WalletSend-address"
-                required
+                autoSelect
               />
             </Grid>
             <Grid xs={12} md={6} item>


### PR DESCRIPTION
This is my first stab at contributing to the chia project.

This draft PR is a Proof of Concept that proposes to introduce an AddressBook into the chia-gui, allowing addresses to be associated with a user-friendly name. This will allow for easy management of sending transactions to known addresses. It will make it easy to identify where transactions have come from - if known at all.

This PR contains the PoC of having an component for storing contacts in LocalStorage
- an add & list component for listing & creating a contact with a friendly name into local storage.
- Update to WalletHistory component to include showing a friendly name against an address. 
- Update to WalletSend to change the address textbox to an autocomplete that is populated from the contacts stored in localstorage. 

Currently missing from this PoC
- Unit Tests
- Remove & Edit buttons on the contacts lists.
- Validating addresses are valid.
- Validating address is not already a contact.

Some current screenshots: 
![image](https://user-images.githubusercontent.com/23059552/218225339-a44c2c3b-35aa-4e24-99d4-6baadcd45eb9.png)

<img width="1119" alt="autocomplete address book drop down" src="https://user-images.githubusercontent.com/23059552/218284817-1e63c751-8d5e-4704-a2d2-2fca1b3c5bf3.png">

<img width="1118" alt="Selecting an address from address book autocomplete" src="https://user-images.githubusercontent.com/23059552/218284826-88e9dc08-ed67-48c3-be09-85dbd6820dc9.png">

<img width="1199" alt="Screenshot 2023-02-12 at 15 37 00" src="https://user-images.githubusercontent.com/23059552/218320771-4bd8b484-39a0-4f60-aa9c-7e97c287a480.png">


