### PR TITLE
expand offered fee section by default for imported offers

### DIFF
--- a/packages/gui/src/components/offers2/OfferBuilderFeeSection.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderFeeSection.tsx
@@ -45,6 +45,7 @@ export default function OfferBuilderFeeSection(props: OfferBuilderFeeSectionProp
     (!fields.length && state === undefined) || // If in builder mode, or in viewer mode when offer hasn't been accepted
     (viewer && imported && !offering); // If in viewer mode when offer has not been accepted and showing the requesting side
   const disableReadOnly = offering && viewer && imported;
+  const expanded = !!fields.length; // Fee section is expanded if there is a field value set. Could be ''.
 
   return (
     <OfferBuilderSection
@@ -52,7 +53,7 @@ export default function OfferBuilderFeeSection(props: OfferBuilderFeeSectionProp
       title={<Trans>Fees</Trans>}
       subtitle={<Trans>Optional network fee to expedite acceptance of your offer</Trans>}
       onAdd={canAdd ? handleAdd : undefined}
-      expanded={!!fields.length}
+      expanded={expanded}
       disableReadOnly={disableReadOnly}
     >
       {loading ? (

--- a/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
@@ -63,6 +63,7 @@ export default function OfferBuilderViewer(props: OfferBuilderViewerProps) {
     validateOfferData();
   }, [isValid, isValidating, offerData, validateOfferData]);
 
+  const setDefaultOfferedFee = !!imported; // When viewing an imported offer, we want to expand the offered fee section by default
   const offerSummaryStringified = JSON.stringify(offerSummary);
   const offerBuilderData = useMemo(() => {
     const offerSummaryParsed = JSON.parse(offerSummaryStringified);
@@ -70,12 +71,12 @@ export default function OfferBuilderViewer(props: OfferBuilderViewerProps) {
       return undefined;
     }
     try {
-      return offerToOfferBuilderData(offerSummaryParsed);
+      return offerToOfferBuilderData(offerSummaryParsed, setDefaultOfferedFee);
     } catch (e) {
       setError(e);
       return undefined;
     }
-  }, [offerSummaryStringified]);
+  }, [offerSummaryStringified, setDefaultOfferedFee]);
 
   const [offeredUnknownCATs, requestedUnknownCATs] = useMemo(() => {
     if (!offerBuilderData || !wallets) {

--- a/packages/gui/src/util/fetchOffer.ts
+++ b/packages/gui/src/util/fetchOffer.ts
@@ -61,7 +61,7 @@ export default async function fetchOffer(offerUrl: string) {
     throw new Error('Failed to check offer validity');
   }
 
-  const offer = offerToOfferBuilderData(offerSummary);
+  const offer = offerToOfferBuilderData(offerSummary, true);
 
   /*
   // get trade record

--- a/packages/gui/src/util/offerToOfferBuilderData.ts
+++ b/packages/gui/src/util/offerToOfferBuilderData.ts
@@ -5,12 +5,16 @@ import type OfferBuilderData from '../@types/OfferBuilderData';
 import type OfferSummary from '../@types/OfferSummary';
 import { launcherIdToNFTId } from './nfts';
 
-export default function offerToOfferBuilderData(offerSummary: OfferSummary): OfferBuilderData {
+export default function offerToOfferBuilderData(
+  offerSummary: OfferSummary,
+  setDefaultOfferedFee: boolean
+): OfferBuilderData {
   const { fees, offered, requested, infos } = offerSummary;
 
   const offeredXch: OfferBuilderData['offered']['xch'] = [];
   const offeredTokens: OfferBuilderData['offered']['tokens'] = [];
   const offeredNfts: OfferBuilderData['offered']['nfts'] = [];
+  const offeredFee: OfferBuilderData['offered']['fee'] = setDefaultOfferedFee ? [{ amount: '' }] : [];
   const requestedXch: OfferBuilderData['requested']['xch'] = [];
   const requestedTokens: OfferBuilderData['requested']['tokens'] = [];
   const requestedNfts: OfferBuilderData['requested']['nfts'] = [];
@@ -62,7 +66,7 @@ export default function offerToOfferBuilderData(offerSummary: OfferSummary): Off
       xch: offeredXch,
       tokens: offeredTokens,
       nfts: offeredNfts,
-      fee: [],
+      fee: offeredFee,
     },
     requested: {
       xch: requestedXch,


### PR DESCRIPTION
When viewing an offer that was imported (from an offer file or data), the offered fee section will now be expanded by default. Behavior is unchanged when creating a new offer or viewing an offer that has already been accepted.

![image](https://user-images.githubusercontent.com/339312/221454956-d57fb8e7-ec82-4a0a-b23f-227e4fe5979f.png)
