### PR TITLE
fix nft selection when creating nft for nft offer notification

### DIFF
--- a/packages/gui/src/components/offers/OfferShareDialog.tsx
+++ b/packages/gui/src/components/offers/OfferShareDialog.tsx
@@ -1405,8 +1405,10 @@ export default function OfferShareDialog(props: OfferShareDialogProps) {
   const [sendOfferNotificationOpen, setSendOfferNotificationOpen] = React.useState(false);
   const [offerURL, setOfferURL] = React.useState('');
   const [suppressShareOnCreate, setSuppressShareOnCreate] = useSuppressShareOnCreate();
-  const isNFTOffer = offerContainsAssetOfType(offerRecord.summary, 'singleton');
-  const nftLauncherId = isNFTOffer ? offerAssetIdForAssetType(OfferAsset.NFT, offerRecord.summary) : undefined;
+  const isNFTOffer = offerContainsAssetOfType(offerRecord.summary, 'singleton', 'requested');
+  const nftLauncherId = isNFTOffer
+    ? offerAssetIdForAssetType(OfferAsset.NFT, offerRecord.summary, 'requested')
+    : undefined;
   const nftId = nftLauncherId ? launcherIdToNFTId(nftLauncherId) : undefined;
 
   const showSendOfferNotificationDialog = useCallback(


### PR DESCRIPTION
When creating an NFT or NFT offer, or an offer where an NFT is being offered but not requested, we were incorrectly creating an offer notification for the offered NFT instead of the requested NFT. This change updates the offer sharing code to look for a requested NFT and supports creating an offer notification in the event that a requested NFT is found.