### PR TITLE
update profiles settings tab and support naming a DID at creation

### DIFF
--- a/packages/gui/src/components/settings/IdentitiesPanel.tsx
+++ b/packages/gui/src/components/settings/IdentitiesPanel.tsx
@@ -1,8 +1,9 @@
 import { WalletType } from '@chia-network/api';
 import { useGetDIDQuery, useGetWalletsQuery } from '@chia-network/api-react';
 import { CardListItem, Flex, Truncate } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
 import { Add } from '@mui/icons-material';
-import { Box, Card, CardContent, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { orderBy } from 'lodash';
 import React, { useMemo } from 'react';
@@ -12,10 +13,10 @@ import styled from 'styled-components';
 import { didToDIDId } from '../../util/dids';
 
 const StyledRoot = styled(Box)`
-  min-width: 300px;
+  min-width: 280px;
   height: 100%;
   display: flex;
-  padding-top: ${({ theme }) => `${theme.spacing(3)}`};
+  padding-top: ${({ theme }) => `${theme.spacing(1)}`};
 `;
 
 const StyledBody = styled(Box)`
@@ -48,7 +49,7 @@ function DisplayDid(wallet) {
 
     return (
       <div>
-        <Truncate tooltip copyToClipboard>
+        <Truncate ValueProps={{ variant: 'body2' }} tooltip copyToClipboard>
           {myDidText}
         </Truncate>
       </div>
@@ -93,7 +94,9 @@ export default function IdentitiesPanel() {
       >
         <Flex flexDirection="column" height="100%" width="100%" onClick={handleCreateProfile}>
           <Flex flexDirection="row" justifyContent="space-between">
-            <Typography>Create Profile</Typography>
+            <Typography>
+              <Trans>Create Profile</Trans>
+            </Typography>
             <Add />
           </Flex>
         </Flex>
@@ -115,8 +118,8 @@ export default function IdentitiesPanel() {
           <CardListItem onSelect={handleSelect} key={wallet.id} selected={wallet.id === Number(walletId)}>
             <Flex gap={0.5} flexDirection="column" height="100%" width="100%">
               <Flex>
-                <Typography>
-                  <strong>{primaryTitle}</strong>
+                <Typography variant="body1" sx={{ fontWeight: 500, textOverflow: 'ellipsis', overflow: 'hidden' }}>
+                  {primaryTitle}
                 </Typography>
               </Flex>
               <Flex>

--- a/packages/gui/src/components/settings/IdentitiesPanel.tsx
+++ b/packages/gui/src/components/settings/IdentitiesPanel.tsx
@@ -1,7 +1,9 @@
 import { WalletType } from '@chia-network/api';
 import { useGetDIDQuery, useGetWalletsQuery } from '@chia-network/api-react';
 import { CardListItem, Flex, Truncate } from '@chia-network/core';
+import { Add } from '@mui/icons-material';
 import { Box, Card, CardContent, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { orderBy } from 'lodash';
 import React, { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -10,7 +12,7 @@ import styled from 'styled-components';
 import { didToDIDId } from '../../util/dids';
 
 const StyledRoot = styled(Box)`
-  min-width: 390px;
+  min-width: 300px;
   height: 100%;
   display: flex;
   padding-top: ${({ theme }) => `${theme.spacing(3)}`};
@@ -37,22 +39,6 @@ const StyledContent = styled(Box)`
   min-height: ${({ theme }) => theme.spacing(5)};
 `;
 
-const StyledCard = styled(Card)(
-  ({ theme }) => `
-  width: 100%;
-  border-radius: ${theme.spacing(1)};
-  border: 1px dashed ${theme.palette.divider};
-  background-color: ${theme.palette.background.paper};
-  margin-bottom: ${theme.spacing(1)};
-`
-);
-
-const StyledCardContent = styled(CardContent)(
-  ({ theme }) => `
-  padding-bottom: ${theme.spacing(2)} !important;
-`
-);
-
 function DisplayDid(wallet) {
   const { id } = wallet.wallet;
   const { data: did } = useGetDIDQuery({ walletId: id });
@@ -75,6 +61,7 @@ export default function IdentitiesPanel() {
   const navigate = useNavigate();
   const { walletId } = useParams();
   const { data: wallets, isLoading } = useGetWalletsQuery();
+  const theme = useTheme();
 
   const dids = [];
   if (wallets) {
@@ -92,22 +79,30 @@ export default function IdentitiesPanel() {
     function handleSelectWallet(id: number) {
       navigate(`/dashboard/settings/profiles/${id}`);
     }
-    const didLength = dids.length;
 
-    if (didLength === 0) {
-      return (
-        <StyledCard variant="outlined">
-          <StyledCardContent>
-            <Flex flexDirection="column" height="100%" width="100%">
-              <Typography>No Profiles</Typography>
-            </Flex>
-          </StyledCardContent>
-        </StyledCard>
-      );
+    function handleCreateProfile() {
+      navigate(`/dashboard/settings/profiles/add`);
     }
+
+    const createProfileItem = (
+      <CardListItem
+        variant="outlined"
+        onSelect={handleCreateProfile}
+        key="create-profile"
+        sx={{ border: `1px dashed ${(theme.palette as any).border.main}` }}
+      >
+        <Flex flexDirection="column" height="100%" width="100%" onClick={handleCreateProfile}>
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Typography>Create Profile</Typography>
+            <Add />
+          </Flex>
+        </Flex>
+      </CardListItem>
+    );
+
     const orderedProfiles = orderBy(wallets, ['id'], ['asc']);
 
-    return orderedProfiles
+    const profileItems = orderedProfiles
       .filter((wallet) => [WalletType.DECENTRALIZED_ID].includes(wallet.type))
       .map((wallet) => {
         const primaryTitle = wallet.name;
@@ -131,7 +126,9 @@ export default function IdentitiesPanel() {
           </CardListItem>
         );
       });
-  }, [isLoading, dids.length, wallets, navigate, walletId]);
+
+    return [createProfileItem, ...profileItems];
+  }, [isLoading, wallets, navigate, walletId, theme]);
 
   return (
     <StyledRoot>

--- a/packages/gui/src/components/settings/ProfileAdd.tsx
+++ b/packages/gui/src/components/settings/ProfileAdd.tsx
@@ -1,5 +1,19 @@
-import { useCreateNewWalletMutation, useGetWalletBalanceQuery } from '@chia-network/api-react';
-import { ButtonLoading, chiaToMojo, EstimatedFee, Flex, Form, mojoToChiaLocaleString } from '@chia-network/core';
+import {
+  useCreateNewWalletMutation,
+  useGetCurrentAddressQuery,
+  useGetWalletBalanceQuery,
+} from '@chia-network/api-react';
+import {
+  ButtonLoading,
+  EstimatedFee,
+  Flex,
+  Form,
+  Link,
+  TextField,
+  chiaToMojo,
+  mojoToChiaLocaleString,
+  useCurrencyCode,
+} from '@chia-network/core';
 import { Trans, t } from '@lingui/macro';
 import { Card, Typography } from '@mui/material';
 import React from 'react';
@@ -22,7 +36,8 @@ const StyledCard = styled(Card)(
 type CreateProfileData = {
   backup_dids: [];
   num_of_backup_ids_needed: '0';
-  amount: int;
+  name?: string;
+  amount: number;
   fee: string;
 };
 
@@ -31,23 +46,36 @@ export default function ProfileAdd() {
     defaultValues: {
       backup_dids: [],
       num_of_backup_ids_needed: '0',
+      name: '',
       amount: 1,
       fee: '',
     },
   });
 
+  const currencyCode = (useCurrencyCode() ?? 'XCH').toUpperCase();
+  const isTestnet = currencyCode === 'TXCH';
+  const { data: currentAddress } = useGetCurrentAddressQuery({
+    walletId: 1,
+  });
   const [createProfile, { isLoading: isCreateProfileLoading }] = useCreateNewWalletMutation();
   const { data: balance } = useGetWalletBalanceQuery({
     walletId: 1,
   });
   const navigate = useNavigate();
   const openExternal = useOpenExternal();
+  const spendableBalance = mojoToChiaLocaleString(balance?.spendableBalance);
+  const canCreateProfile = spendableBalance > 0;
 
   function handleClick() {
-    openExternal('https://faucet.chia.net/');
+    const url = `https://${isTestnet ? 'testnet10-faucet.chia.net' : 'faucet.chia.net'}/?address=${currentAddress}`;
+    openExternal(url);
   }
 
   async function handleSubmit(data: CreateProfileData) {
+    if (!canCreateProfile) {
+      throw new Error(t`Your spendable balance must be greater than 1 mojo to create a profile`);
+    }
+
     const fee = data.fee.trim() || '0';
     if (!isNumeric(fee)) {
       throw new Error(t`Please enter a valid numeric fee`);
@@ -57,70 +85,82 @@ export default function ProfileAdd() {
       return;
     }
 
+    let walletName = data.name?.trim();
+    if (walletName?.length === 0) {
+      walletName = undefined;
+    }
+
     const walletId = await createProfile({
       walletType: 'did_wallet',
-      options: { did_type: 'new', backup_dids: [], num_of_backup_ids_needed: '0', amount: 1, fee: chiaToMojo(fee) },
+      options: {
+        did_type: 'new',
+        backup_dids: [],
+        num_of_backup_ids_needed: '0',
+        amount: 1,
+        fee: chiaToMojo(fee),
+        walletName,
+      },
     }).unwrap();
 
     navigate(`/dashboard/settings/profiles/${walletId}`);
   }
 
-  const standardBalance = mojoToChiaLocaleString(balance?.confirmedWalletBalance);
-
   return (
-    <div style={{ width: '100%' }}>
-      <Form methods={methods} onSubmit={handleSubmit}>
-        <Flex flexDirection="column" gap={2.5} paddingBottom={3}>
-          <Typography variant="h6">
-            <Trans>Create a new profile</Trans>
-          </Typography>
-        </Flex>
-        <StyledCard>
-          <Flex flexDirection="column" gap={2.5} paddingBottom={1}>
-            <Trans>
-              <strong>Need some XCH?</strong>
-            </Trans>
-          </Flex>
-          <div style={{ cursor: 'pointer' }}>
-            <Flex paddingBottom={5}>
-              <Typography onClick={handleClick} sx={{ textDecoration: 'underline' }}>
-                Get Mojos from the Chia Faucet
-              </Typography>
+    <Form methods={methods} onSubmit={handleSubmit}>
+      <Flex flexDirection="column" flexGrow={1} marginTop={-0.5}>
+        <Typography variant="h6">
+          <Trans>Create a new profile</Trans>
+        </Typography>
+        <StyledCard sx={{ marginTop: '22px' }}>
+          <Flex flexDirection="column" gap={2}>
+            <Flex flexDirection="column" gap={2}>
+              {!canCreateProfile && (
+                <Flex flexDirection="column" gap={1}>
+                  <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                    <Trans>Need some {currencyCode}?</Trans>
+                  </Typography>
+                  <Link onClick={handleClick}>
+                    <Trans>Get Mojos from the Chia Faucet</Trans>
+                  </Link>
+                </Flex>
+              )}
+              <Flex flexDirection="column" gap={1}>
+                <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                  <Trans>Creating a profile requires 1 mojo</Trans>
+                </Typography>
+                <Typography variant="caption">
+                  <Trans>
+                    Spendable Balance: {spendableBalance} {currencyCode}
+                  </Trans>
+                </Typography>
+              </Flex>
             </Flex>
-          </div>
-          <Flex flexDirection="column" gap={2.5} paddingBottom={1}>
-            <Trans>
-              <strong>Use one (1) mojo to create a Profile.</strong>
-            </Trans>
-          </Flex>
-          <Flex flexDirection="column" gap={2.5} paddingBottom={3}>
-            <Typography variant="caption">
-              <Trans>Balance: {standardBalance} XCH</Trans>
-            </Typography>
-          </Flex>
-          <Flex flexDirection="column" gap={2.5} paddingBottom={1}>
-            <EstimatedFee
-              id="filled-secondary"
-              variant="filled"
-              name="fee"
-              color="secondary"
-              label={<Trans>Fee</Trans>}
+            <TextField
+              name="name"
+              variant="outlined"
+              label={<Trans>Profile Name (Optional)</Trans>}
               fullWidth
-              txType="createDID"
+              autoFocus
             />
-          </Flex>
-          <Flex flexDirection="column" gap={2.5} paddingBottom={3}>
-            <Typography variant="caption">
-              <Trans>Recommended: 0.000005 XCH</Trans>
-            </Typography>
-          </Flex>
-          <Flex justifyContent="flex-end">
-            <ButtonLoading type="submit" variant="contained" color="primary" loading={isCreateProfileLoading}>
-              <Trans>Create</Trans>
-            </ButtonLoading>
+            <Flex flexDirection="column" gap={2.5} paddingBottom={1}>
+              <EstimatedFee
+                id="filled-secondary"
+                variant="filled"
+                name="fee"
+                color="secondary"
+                label={<Trans>Fee</Trans>}
+                fullWidth
+                txType="createDID"
+              />
+            </Flex>
+            <Flex justifyContent="flex-end">
+              <ButtonLoading type="submit" variant="contained" color="primary" loading={isCreateProfileLoading}>
+                <Trans>Create</Trans>
+              </ButtonLoading>
+            </Flex>
           </Flex>
         </StyledCard>
-      </Form>
-    </div>
+      </Flex>
+    </Form>
   );
 }

--- a/packages/gui/src/components/settings/ProfileAdd.tsx
+++ b/packages/gui/src/components/settings/ProfileAdd.tsx
@@ -68,7 +68,7 @@ export default function ProfileAdd() {
   const standardBalance = mojoToChiaLocaleString(balance?.confirmedWalletBalance);
 
   return (
-    <div style={{ width: '70%' }}>
+    <div style={{ width: '100%' }}>
       <Form methods={methods} onSubmit={handleSubmit}>
         <Flex flexDirection="column" gap={2.5} paddingBottom={3}>
           <Typography variant="h6">

--- a/packages/gui/src/components/settings/ProfileView.tsx
+++ b/packages/gui/src/components/settings/ProfileView.tsx
@@ -81,7 +81,7 @@ export default function ProfileView() {
 
     return (
       <div style={{ width: '100%' }}>
-        <StyledCard>
+        <StyledCard sx={{ marginTop: '-16px' }}>
           <Flex flexDirection="column" gap={2.5} paddingBottom={3}>
             <InlineEdit text={nameText} walletId={walletId} />
           </Flex>

--- a/packages/gui/src/components/settings/SettingsProfiles.tsx
+++ b/packages/gui/src/components/settings/SettingsProfiles.tsx
@@ -1,9 +1,8 @@
 import { WalletType } from '@chia-network/api';
 import { useGetWalletsQuery } from '@chia-network/api-react';
-import { Flex, LayoutDashboardSub } from '@chia-network/core';
+import { Flex, LayoutDashboardSub, SettingsHR, SettingsSection, SettingsText } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
-import { Add } from '@mui/icons-material';
-import { IconButton, Typography } from '@mui/material';
+import { Grid } from '@mui/material';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 
@@ -43,30 +42,35 @@ export default function SettingsProfiles() {
     }
   }, [isLoading, profileStartDisplay, didList, navigate]);
 
-  function navAdd() {
-    navigate(`/dashboard/settings/profiles/add`);
-  }
-
   return (
-    <div>
-      <Flex flexDirection="row" style={{ width: '350px' }}>
-        <Flex flexGrow={1}>
-          <Typography variant="h4">
-            <Trans>Profiles</Trans>
-          </Typography>
+    <Grid container style={{ maxWidth: '624px' }} gap={3}>
+      <Grid item>
+        <Flex flexDirection="column" gap={1}>
+          <SettingsSection>
+            <Trans>Profiles (DIDs)</Trans>
+          </SettingsSection>
+          <SettingsText>
+            <Trans>
+              A profile is a decentralized identifier (DID) that you can prove control and ownership of without having
+              to rely on any centralized authority. You can have as many DIDs as you want that can be used to represent
+              different aspects of your identity like establishing provenance of creation or ownership for NFTs.
+            </Trans>
+          </SettingsText>
         </Flex>
-        <Flex alignSelf="end">
-          <IconButton onClick={navAdd}>
-            <Add />
-          </IconButton>
-        </Flex>
-      </Flex>
-      <Routes>
-        <Route element={<LayoutDashboardSub sidebar={<IdentitiesPanel />} outlet />}>
-          <Route path=":walletId" element={<ProfileView />} />
-          <Route path="add" element={<ProfileAdd />} />
-        </Route>
-      </Routes>
-    </div>
+      </Grid>
+
+      <Grid item xs={12} sm={12} lg={12}>
+        <SettingsHR />
+      </Grid>
+
+      <Grid item xs={12} sm={12} lg={12}>
+        <Routes>
+          <Route element={<LayoutDashboardSub sidebar={<IdentitiesPanel />} outlet />}>
+            <Route path=":walletId" element={<ProfileView />} />
+            <Route path="add" element={<ProfileAdd />} />
+          </Route>
+        </Routes>
+      </Grid>
+    </Grid>
   );
 }


### PR DESCRIPTION
The profiles tab more closely matches the other settings tabs now.
Creating a new profile supports providing a name at the point of creation.
Minor tweaks to support pre-filling the faucet with the user's receive address.
Assorted styling tweaks.

![image](https://user-images.githubusercontent.com/339312/223233702-eaa88a39-0472-4a92-870d-ba45c89b69ec.png)
![image](https://user-images.githubusercontent.com/339312/223233800-3145e160-2d9c-4d9f-94b9-15eeaefb17e9.png)
