### PR TITLE
add default fee of zero to fee estimator

### DIFF
--- a/packages/core/src/components/EstimatedFee/EstimatedFee.tsx
+++ b/packages/core/src/components/EstimatedFee/EstimatedFee.tsx
@@ -272,7 +272,7 @@ export default function EstimatedFee(props: FeeProps) {
 
   useEffect(() => {
     if (formattedEstimates) {
-      if (!defaultFee) {
+      if (!defaultFee && !isLoading) {
         const defaultVal = formattedEstimates.find((formattedEstimate) => formattedEstimate.estimate === 0);
         if (defaultVal) {
           setSelectedValue(defaultVal.estimate);


### PR DESCRIPTION
When estimates were still being loaded, the default 5 minute option was being selected. After the estimates finished loading, that selection could be populated by a non-zero fee value when the desired behavior is to select the 0 fee option.

This change will cause the default selection of 0 to be made.