### PR TITLE
fix countering offer flow and allow countering from viewing an offer from a notification

### DIFF
--- a/packages/gui/src/components/notification/Notification.tsx
+++ b/packages/gui/src/components/notification/Notification.tsx
@@ -48,7 +48,7 @@ export default function Notification(props: NotificationProps) {
           offerData,
           offerSummary,
           imported: true,
-          counterOffer: canCounterOffer,
+          canCounterOffer,
           address: puzzleHash,
         },
       });

--- a/packages/gui/src/components/notification/Notification.tsx
+++ b/packages/gui/src/components/notification/Notification.tsx
@@ -20,9 +20,21 @@ export type NotificationProps = {
 
 export default function Notification(props: NotificationProps) {
   const {
-    notification: { offer, offerSummary, offerData, error, offered, requested, height },
+    notification: {
+      offer,
+      offerSummary,
+      offerData,
+      error,
+      offered,
+      requested,
+      height,
+      metadata: {
+        data: { puzzleHash },
+      },
+    },
     onClick,
   } = props;
+  const canCounterOffer = puzzleHash?.length > 0;
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -36,6 +48,8 @@ export default function Notification(props: NotificationProps) {
           offerData,
           offerSummary,
           imported: true,
+          counterOffer: canCounterOffer,
+          address: puzzleHash,
         },
       });
     }

--- a/packages/gui/src/components/notification/NotificationSendDialog.tsx
+++ b/packages/gui/src/components/notification/NotificationSendDialog.tsx
@@ -188,11 +188,11 @@ export default function NotificationSendDialog(props: NotificationSendDialogProp
                 </Flex>
               ) : (
                 <Flex flexDirection="column" alignItems="center" gap={3}>
-                  {isNFTOffer ? (
+                  {isNFTOffer && (
                     <Box sx={nftPreviewContainer}>
                       <NFTPreview nft={nft} disableThumbnail setNFTCardMetadata={setMetadata} />
                     </Box>
-                  ) : null}
+                  )}
                   {/* <Flex flexDirection="column" alignItems="center" gap={1}>
                     <Typography variant="h6">
                       <Trans>Message the NFT Holder</Trans>

--- a/packages/gui/src/components/notification/NotificationSendDialog.tsx
+++ b/packages/gui/src/components/notification/NotificationSendDialog.tsx
@@ -47,34 +47,36 @@ type NotificationSendDialogFormData = {
 
 export type NotificationSendDialogProps = {
   offerURL: string;
-  nftId: string;
+  destination: string;
+  destinationType: 'address' | 'nft';
   // recommendedAmount?: string;
   open?: boolean;
   onClose?: () => void;
-  address?: string;
 };
 
 export default function NotificationSendDialog(props: NotificationSendDialogProps) {
   const {
     offerURL,
-    nftId,
+    destination,
+    destinationType,
     // recommendedAmount = DEFAULT_MESSAGE_COST,
     onClose = () => ({}),
     open = false,
-    address: defaultAddress = '',
     ...rest
   } = props;
+  const isNFTOffer = destinationType === 'nft';
+  const defaultAddress = isNFTOffer ? '' : destination;
+  const launcherId = launcherIdFromNFTId(isNFTOffer ? destination : '');
   const methods = useForm<NotificationSendDialogFormData>({
     defaultValues: { address: defaultAddress, amount: '0.0001', allowCounterOffer: true, fee: '' },
   });
-  const launcherId = launcherIdFromNFTId(nftId ?? '');
   const currencyCode = useCurrencyCode();
   const openDialog = useOpenDialog();
-  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' });
+  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' }, { skip: !launcherId });
   const { data: currentAddress = '' } = useGetCurrentAddressQuery({ walletId: 1 });
   const [sendNotifications] = useSendNotificationsMutation();
   const [, setMetadata] = React.useState<any>({});
-  const [isLoading, setIsLoading] = React.useState(true);
+  const [isLoading, setIsLoading] = React.useState(isNFTOffer);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const address = methods.watch('address');
   const allowCounterOffer = methods.watch('allowCounterOffer');
@@ -186,9 +188,11 @@ export default function NotificationSendDialog(props: NotificationSendDialogProp
                 </Flex>
               ) : (
                 <Flex flexDirection="column" alignItems="center" gap={3}>
-                  <Box sx={nftPreviewContainer}>
-                    <NFTPreview nft={nft} disableThumbnail setNFTCardMetadata={setMetadata} />
-                  </Box>
+                  {isNFTOffer ? (
+                    <Box sx={nftPreviewContainer}>
+                      <NFTPreview nft={nft} disableThumbnail setNFTCardMetadata={setMetadata} />
+                    </Box>
+                  ) : null}
                   {/* <Flex flexDirection="column" alignItems="center" gap={1}>
                     <Typography variant="h6">
                       <Trans>Message the NFT Holder</Trans>
@@ -205,7 +209,11 @@ export default function NotificationSendDialog(props: NotificationSendDialogProp
                     <Grid item xs={12}>
                       <Flex flexDirection="column" gap={1}>
                         <Typography variant="caption" color="textPrimary">
-                          <Trans>NFT holder address</Trans>
+                          {isNFTOffer ? (
+                            <Trans>NFT holder address</Trans>
+                          ) : (
+                            <Trans>Notification recipient's address</Trans>
+                          )}
                         </Typography>
                         <TextField
                           variant="filled"
@@ -227,7 +235,11 @@ export default function NotificationSendDialog(props: NotificationSendDialogProp
                     <Grid item xs={12}>
                       <Flex flexDirection="column" gap={1}>
                         <Typography variant="caption" color="textPrimary">
-                          <Trans>Cost to send notification to the NFT holder</Trans>
+                          {isNFTOffer ? (
+                            <Trans>Cost to send notification to the NFT holder</Trans>
+                          ) : (
+                            <Trans>Cost to send notification</Trans>
+                          )}
                         </Typography>
                         <Amount
                           variant="filled"
@@ -269,7 +281,13 @@ export default function NotificationSendDialog(props: NotificationSendDialogProp
                               onChange={handleToggleAllowCounterOffer}
                             />
                           }
-                          label={<Trans>Allow the NFT holder to send a counter offer</Trans>}
+                          label={
+                            isNFTOffer ? (
+                              <Trans>Allow the NFT holder to send a counter offer</Trans>
+                            ) : (
+                              <Trans>Allow the recipient to send a counter offer</Trans>
+                            )
+                          }
                         />
                         <Typography
                           variant="caption"

--- a/packages/gui/src/components/offers/OfferManager.tsx
+++ b/packages/gui/src/components/offers/OfferManager.tsx
@@ -368,12 +368,10 @@ export function CreateOffer() {
   const testnet = useCurrencyCode() === 'TXCH';
 
   async function handleOfferCreated(obj: { offerRecord: any; offerData: any }) {
-    const { offerRecord, offerData, address, nftId } = obj;
+    const { offerRecord, offerData, address } = obj;
 
-    console.log('handleOfferCreated address:');
-    console.log(address);
-    console.log('nftId:');
-    console.log(nftId);
+    // console.log('handleOfferCreated address:');
+    // console.log(address);
     await openDialog(
       <OfferShareDialog
         offerRecord={offerRecord}
@@ -399,7 +397,7 @@ export function CreateOffer() {
               nftIds={locationState?.nftIds}
               nftWalletId={locationState?.nftWalletId}
               referrerPath={locationState?.referrerPath}
-              counterOffer={locationState?.counterOffer}
+              isCounterOffer={locationState?.isCounterOffer}
               address={locationState?.address}
               offer={locationState?.offer}
               onOfferCreated={handleOfferCreated}
@@ -452,7 +450,7 @@ export function CreateOffer() {
               offerSummary={locationState?.offerSummary}
               imported={locationState?.imported}
               referrerPath={locationState?.referrerPath}
-              counterOffer={locationState?.counterOffer}
+              canCounterOffer={locationState?.canCounterOffer}
               address={locationState?.address}
             />
           }

--- a/packages/gui/src/components/offers/OfferManager.tsx
+++ b/packages/gui/src/components/offers/OfferManager.tsx
@@ -1,4 +1,4 @@
-import { OfferTradeRecord } from '@chia-network/api';
+import { OfferTradeRecord, toBech32m } from '@chia-network/api';
 import { useCancelOfferMutation, useGetWalletsQuery } from '@chia-network/api-react';
 import {
   Button,
@@ -365,13 +365,13 @@ export function CreateOffer() {
   const locationState = getLocationState(); // For cases where we know that the state has been serialized
   const openDialog = useOpenDialog();
   const [saveOffer] = useSaveOfferFile();
-  const testnet = useCurrencyCode() === 'TXCH';
+  const currencyCode = useCurrencyCode();
+  const testnet = currencyCode === 'TXCH';
 
-  async function handleOfferCreated(obj: { offerRecord: any; offerData: any }) {
-    const { offerRecord, offerData, address } = obj;
+  async function handleOfferCreated(obj: { offerRecord: any; offerData: any; address?: string }) {
+    const { offerRecord, offerData, address: ph } = obj;
+    const address = ph && currencyCode ? toBech32m(ph, currencyCode.toLowerCase()) : undefined;
 
-    // console.log('handleOfferCreated address:');
-    // console.log(address);
     await openDialog(
       <OfferShareDialog
         offerRecord={offerRecord}

--- a/packages/gui/src/components/offers/OfferManager.tsx
+++ b/packages/gui/src/components/offers/OfferManager.tsx
@@ -368,8 +368,12 @@ export function CreateOffer() {
   const testnet = useCurrencyCode() === 'TXCH';
 
   async function handleOfferCreated(obj: { offerRecord: any; offerData: any }) {
-    const { offerRecord, offerData, address } = obj;
+    const { offerRecord, offerData, address, nftId } = obj;
 
+    console.log('handleOfferCreated address:');
+    console.log(address);
+    console.log('nftId:');
+    console.log(nftId);
     await openDialog(
       <OfferShareDialog
         offerRecord={offerRecord}
@@ -446,9 +450,10 @@ export function CreateOffer() {
               isMyOffer={locationState?.isMyOffer}
               offerData={locationState?.offerData}
               offerSummary={locationState?.offerSummary}
-              offerFilePath={locationState?.offerFilePath}
               imported={locationState?.imported}
               referrerPath={locationState?.referrerPath}
+              counterOffer={locationState?.counterOffer}
+              address={locationState?.address}
             />
           }
         />

--- a/packages/gui/src/components/offers/OfferShareDialog.tsx
+++ b/packages/gui/src/components/offers/OfferShareDialog.tsx
@@ -30,14 +30,15 @@ import debug from 'debug';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import useAssetIdName, { AssetIdMapEntry } from '../../hooks/useAssetIdName';
+import useResolveNFTOffer from '../../hooks/useResolveNFTOffer';
 import useSuppressShareOnCreate from '../../hooks/useSuppressShareOnCreate';
-import { launcherIdToNFTId } from '../../util/nfts';
+// import { launcherIdToNFTId } from '../../util/nfts';
 import NotificationSendDialog from '../notification/NotificationSendDialog';
 import { NFTOfferSummary } from './NFTOfferViewer';
-import OfferAsset from './OfferAsset';
+// import OfferAsset from './OfferAsset';
 import OfferSummary from './OfferSummary';
 import {
-  offerAssetIdForAssetType,
+  // offerAssetIdForAssetType,
   offerContainsAssetOfType,
   shortSummaryForOffer,
   suggestedFilenameForOffer,
@@ -1405,11 +1406,25 @@ export default function OfferShareDialog(props: OfferShareDialogProps) {
   const [sendOfferNotificationOpen, setSendOfferNotificationOpen] = React.useState(false);
   const [offerURL, setOfferURL] = React.useState('');
   const [suppressShareOnCreate, setSuppressShareOnCreate] = useSuppressShareOnCreate();
-  const isNFTOffer = offerContainsAssetOfType(offerRecord.summary, 'singleton', 'requested');
-  const nftLauncherId = isNFTOffer
-    ? offerAssetIdForAssetType(OfferAsset.NFT, offerRecord.summary, 'requested')
-    : undefined;
-  const nftId = nftLauncherId ? launcherIdToNFTId(nftLauncherId) : undefined;
+  // const isNFTOffer = offerContainsAssetOfType(offerRecord.summary, 'singleton', 'requested');
+  // const nftLauncherId = isNFTOffer
+  //   ? offerAssetIdForAssetType(OfferAsset.NFT, offerRecord.summary, 'requested')
+  //   : undefined;
+  // const nftId = nftLauncherId ? launcherIdToNFTId(nftLauncherId) : undefined;
+
+  const { /* isResolving, */ ownedNFTId /* , ownedNFTOfferSide */ } = useResolveNFTOffer({
+    offerSummary: offerRecord.summary,
+  });
+
+  // console.log('isResolving:');
+  // console.log(isResolving);
+  // console.log('ownedNFTId:');
+  // console.log(ownedNFTId);
+  // console.log('ownedNFTOfferSide:');
+  // console.log(ownedNFTOfferSide);
+
+  const isNFTOffer = ownedNFTId !== undefined;
+  const nftId = ownedNFTId;
 
   const showSendOfferNotificationDialog = useCallback(
     (localOpen: boolean, localOfferURL: string) => {

--- a/packages/gui/src/components/offers/OfferShareDialog.tsx
+++ b/packages/gui/src/components/offers/OfferShareDialog.tsx
@@ -32,17 +32,10 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import useAssetIdName, { AssetIdMapEntry } from '../../hooks/useAssetIdName';
 import useResolveNFTOffer from '../../hooks/useResolveNFTOffer';
 import useSuppressShareOnCreate from '../../hooks/useSuppressShareOnCreate';
-// import { launcherIdToNFTId } from '../../util/nfts';
 import NotificationSendDialog from '../notification/NotificationSendDialog';
 import { NFTOfferSummary } from './NFTOfferViewer';
-// import OfferAsset from './OfferAsset';
 import OfferSummary from './OfferSummary';
-import {
-  // offerAssetIdForAssetType,
-  offerContainsAssetOfType,
-  shortSummaryForOffer,
-  suggestedFilenameForOffer,
-} from './utils';
+import { offerContainsAssetOfType, shortSummaryForOffer, suggestedFilenameForOffer } from './utils';
 
 const log = debug('chia-gui:offers');
 

--- a/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
+++ b/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
@@ -52,7 +52,7 @@ export type CreateOfferBuilderProps = {
   referrerPath?: string;
   onOfferCreated: (obj: { offerRecord: any; offerData: any; address?: string }) => void;
   nftIds?: string[];
-  counterOffer?: boolean;
+  isCounterOffer?: boolean;
   offer?: OfferBuilderData;
   address?: string;
 };
@@ -66,7 +66,7 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
     nftId,
     nftWalletId,
     nftIds,
-    counterOffer = false,
+    isCounterOffer = false,
     offer,
     address,
   } = props;
@@ -77,9 +77,6 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
   const { offers, isLoading: isOffersLoading } = useWalletOffers(-1, 0, true, false, 'RELEVANCE', false);
   const [createOfferForIds] = useCreateOfferForIdsMutation();
   const offerBuilderRef = useRef<{ submit: () => void } | undefined>(undefined);
-
-  console.log('CreateOfferBuilder nftId:');
-  console.log(nftId);
 
   const defaultValues = useMemo(() => {
     if (offer) {
@@ -173,7 +170,7 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
         <Flex alignItems="center" justifyContent="space-between" gap={2}>
           <OfferNavigationHeader referrerPath={referrerPath} />
           <ButtonLoading variant="contained" color="primary" onClick={handleCreateOffer} disableElevation>
-            {counterOffer ? <Trans>Create Counter Offer</Trans> : <Trans>Create Offer</Trans>}
+            {isCounterOffer ? <Trans>Create Counter Offer</Trans> : <Trans>Create Offer</Trans>}
           </ButtonLoading>
         </Flex>
 

--- a/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
+++ b/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
@@ -78,6 +78,9 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
   const [createOfferForIds] = useCreateOfferForIdsMutation();
   const offerBuilderRef = useRef<{ submit: () => void } | undefined>(undefined);
 
+  console.log('CreateOfferBuilder nftId:');
+  console.log(nftId);
+
   const defaultValues = useMemo(() => {
     if (offer) {
       return offer;
@@ -148,7 +151,7 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
         navigate(-1);
 
         if (!suppressShareOnCreate) {
-          onOfferCreated({ offerRecord, offerData, address });
+          onOfferCreated({ offerRecord, offerData, address, nftId });
         }
       } catch (error) {
         if ((error as Error).message.startsWith('insufficient funds')) {
@@ -161,7 +164,7 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
         }
       }
     },
-    [wallets, createOfferForIds, navigate, suppressShareOnCreate, onOfferCreated, address, openDialog, offers]
+    [wallets, createOfferForIds, navigate, suppressShareOnCreate, onOfferCreated, address, openDialog, offers, nftId]
   );
 
   return (

--- a/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
@@ -33,7 +33,7 @@ export type OfferBuilderViewerProps = {
   isMyOffer?: boolean;
   imported?: boolean;
   hideHeader?: boolean;
-  counterOffer?: boolean;
+  canCounterOffer?: boolean;
   address?: string; // where to send a counter offer
   fee?: string; // in mojos
 };
@@ -47,7 +47,7 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
     isMyOffer = false,
     imported = false,
     hideHeader = false,
-    counterOffer = false,
+    canCounterOffer = false,
     address,
     fee,
   } = props;
@@ -134,7 +134,6 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
   const missingRequestedCATs = !!requestedUnknownCATs?.length;
 
   const canAccept = !!offerData;
-  const canCounter = counterOffer;
   const disableAccept = missingOfferedCATs || showInvalid;
 
   const isLoading = isLoadingWallets || !offerBuilderData || isOffersLoading;
@@ -165,7 +164,7 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
     navigate('/dashboard/offers/builder', {
       state: {
         referrerPath: location.pathname,
-        counterOffer: true,
+        isCounterOffer: true,
         address,
         offer,
       },
@@ -191,7 +190,7 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
           <Flex alignItems="center" justifyContent="space-between" gap={2}>
             <OfferNavigationHeader referrerPath={referrerPath} />
             <Flex flexDirection="row" gap={1}>
-              {canCounter && (
+              {canCounterOffer && (
                 <Button variant="outlined" color="primary" onClick={handleCounterOffer} disableElevation>
                   <Trans>Counter Offer</Trans>
                 </Button>

--- a/packages/gui/src/components/offers2/OfferIncomingTable.tsx
+++ b/packages/gui/src/components/offers2/OfferIncomingTable.tsx
@@ -161,6 +161,7 @@ export default function OfferIncomingTable(props: OfferIncomingTableProps) {
           referrerPath: location.pathname,
           counterOffer: true,
           address,
+          nftId,
           offer,
         },
       });
@@ -178,13 +179,24 @@ export default function OfferIncomingTable(props: OfferIncomingTableProps) {
   }
 
   function handleShowOffer(id: string) {
-    const { offerData, offerSummary } = filteredNotifications.find((notification) => notification.id === id);
+    const {
+      offerData,
+      offerSummary,
+      metadata: {
+        data: { puzzleHash },
+      },
+    } = filteredNotifications.find((notification) => notification.id === id);
+    const canCounterOffer = puzzleHash?.length > 0;
+
     navigate('/dashboard/offers/view', {
       state: {
         referrerPath: location.pathname,
         offerData,
         offerSummary,
         imported: true,
+        counterOffer: canCounterOffer,
+        address: puzzleHash,
+        nftId,
       },
     });
   }

--- a/packages/gui/src/components/offers2/OfferIncomingTable.tsx
+++ b/packages/gui/src/components/offers2/OfferIncomingTable.tsx
@@ -145,7 +145,6 @@ export default function OfferIncomingTable(props: OfferIncomingTableProps) {
     try {
       const {
         offer,
-        // offerSummary,
         metadata: {
           data: { puzzleHash },
         },
@@ -156,7 +155,6 @@ export default function OfferIncomingTable(props: OfferIncomingTableProps) {
       }
 
       const address = currencyCode && puzzleHash ? toBech32m(puzzleHash, currencyCode.toLowerCase()) : '';
-      // const nftLauncherId = offerAssetIdForAssetType(OfferAsset.NFT, offerSummary, 'offered');
 
       navigate('/dashboard/offers/builder', {
         state: {

--- a/packages/gui/src/components/offers2/OfferIncomingTable.tsx
+++ b/packages/gui/src/components/offers2/OfferIncomingTable.tsx
@@ -145,6 +145,7 @@ export default function OfferIncomingTable(props: OfferIncomingTableProps) {
     try {
       const {
         offer,
+        // offerSummary,
         metadata: {
           data: { puzzleHash },
         },
@@ -155,13 +156,13 @@ export default function OfferIncomingTable(props: OfferIncomingTableProps) {
       }
 
       const address = currencyCode && puzzleHash ? toBech32m(puzzleHash, currencyCode.toLowerCase()) : '';
+      // const nftLauncherId = offerAssetIdForAssetType(OfferAsset.NFT, offerSummary, 'offered');
 
       navigate('/dashboard/offers/builder', {
         state: {
           referrerPath: location.pathname,
-          counterOffer: true,
+          isCounterOffer: true,
           address,
-          nftId,
           offer,
         },
       });
@@ -194,9 +195,8 @@ export default function OfferIncomingTable(props: OfferIncomingTableProps) {
         offerData,
         offerSummary,
         imported: true,
-        counterOffer: canCounterOffer,
+        canCounterOffer,
         address: puzzleHash,
-        nftId,
       },
     });
   }

--- a/packages/gui/src/hooks/useResolveNFTOffer.ts
+++ b/packages/gui/src/hooks/useResolveNFTOffer.ts
@@ -1,0 +1,79 @@
+import { toBech32m, OfferSummaryRecord } from '@chia-network/api';
+import { useSignMessageByIdMutation } from '@chia-network/api-react';
+import { useCallback, useMemo, useState } from 'react';
+
+type NFTsByOfferSide = {
+  requested?: string[];
+  offered?: string[];
+};
+
+function allNFTsByOfferSide(offerSummary: OfferSummaryRecord, sides: ('requested' | 'offered')[]): NFTsByOfferSide {
+  const allNFTs: NFTsByOfferSide = {};
+  sides.forEach((side) => {
+    allNFTs[side] = Object.keys(offerSummary[side])
+      .filter((assetId) => (offerSummary.infos[assetId]?.type as any) === 'singleton')
+      .map((assetId) => toBech32m(assetId, 'nft'));
+  });
+
+  return allNFTs;
+}
+
+async function findFirstOwnedNFT(
+  nftIds: string[],
+  resolveOwnership: (nftId: string) => Promise<boolean>
+): Promise<string | undefined> {
+  // eslint-disable-next-line no-restricted-syntax -- Stop on first match
+  for (const nftId of nftIds) {
+    // eslint-disable-next-line no-await-in-loop -- Stop on first match
+    const owned = await resolveOwnership(nftId);
+    if (owned) {
+      return nftId;
+    }
+  }
+
+  return undefined;
+}
+
+export type UseResolveNFTOfferParams = {
+  offerSummary: OfferSummaryRecord;
+};
+
+export default function useResolveNFTOffer({ offerSummary }: UseResolveNFTOfferParams) {
+  const [signMessageById] = useSignMessageByIdMutation();
+  const [resolved, setResolved] = useState(false);
+  const [ownedNFTId, setOwnedNFTId] = useState<string | undefined>(undefined);
+  const [ownedNFTOfferSide, setOwnedNFTOfferSide] = useState<'requested' | 'offered' | undefined>(undefined);
+
+  // Hacky test to determine if a given NFT is owned by the user
+  const signWithNFT = useCallback(
+    async (nftId: string) => {
+      const { data: result } = await signMessageById({ id: nftId, message: 'x' });
+      return result?.success ?? false;
+    },
+    [signMessageById]
+  );
+
+  const nftsBySide: NFTsByOfferSide = useMemo(
+    () => allNFTsByOfferSide(offerSummary, ['requested', 'offered']),
+    [offerSummary]
+  );
+
+  useMemo(async () => {
+    const sides = Object.keys(nftsBySide);
+
+    // eslint-disable-next-line no-restricted-syntax -- Stop on first match
+    for (const side of sides as ('requested' | 'offered')[]) {
+      // eslint-disable-next-line no-await-in-loop -- Stop on first match
+      const ownedNftId = await findFirstOwnedNFT(nftsBySide[side]!, signWithNFT);
+      if (ownedNftId) {
+        setOwnedNFTId(ownedNftId);
+        setOwnedNFTOfferSide(side);
+        break;
+      }
+    }
+
+    setResolved(true);
+  }, [nftsBySide, signWithNFT, setOwnedNFTId, setOwnedNFTOfferSide, setResolved]);
+
+  return { isResolving: !resolved, ownedNFTId, ownedNFTOfferSide };
+}


### PR DESCRIPTION
The core change here is that there's a check that's performed to determine if the NFTs in an offer belong to the user. The result of this check informs how the send notification dialog behaves -- whether to show the NFT details for an NFT the user is attempting to acquire.