### PR TITLE
added walletconnect app permissions gui

### DIFF
--- a/packages/gui/src/hooks/useWalletConnectPairs.ts
+++ b/packages/gui/src/hooks/useWalletConnectPairs.ts
@@ -20,6 +20,7 @@ export type Pairs = {
   removeSessionFromPair: (sessionTopic: string) => void;
 
   bypassCommand: (sessionTopic: string, command: string, confirm: boolean) => void;
+  removeBypassCommand: (sessionTopic: string, command: string) => void;
   resetBypass: () => void;
 };
 
@@ -118,6 +119,30 @@ export default function useWalletConnectPairs(): Pairs {
     });
   }, []);
 
+  const removeBypassCommand = useCallback((sessionTopic: string, command: string) => {
+    const deleteCommand = (commands: Record<string, boolean> | undefined) => {
+      const newBypassCommands = { ...commands };
+      delete newBypassCommands[command];
+      return newBypassCommands;
+    };
+
+    const [, setPairs] = pairsRef.current;
+    setPairs((pairs: Pair[]) => {
+      const pair = pairs.find((item) => item.sessions?.find((session) => session.topic === sessionTopic));
+      if (!pair) {
+        throw new Error('Pair not found');
+      }
+
+      return pairs.map((item) => ({
+        ...item,
+        bypassCommands:
+          item.topic === pair.topic && item.bypassCommands && typeof item.bypassCommands[command] !== undefined
+            ? deleteCommand(item.bypassCommands)
+            : item.bypassCommands,
+      }));
+    });
+  }, []);
+
   const resetBypass = useCallback(() => {
     const [, setPairs] = pairsRef.current;
 
@@ -144,6 +169,7 @@ export default function useWalletConnectPairs(): Pairs {
 
       removeSessionFromPair,
       bypassCommand,
+      removeBypassCommand,
       resetBypass,
     }),
     [
@@ -157,6 +183,7 @@ export default function useWalletConnectPairs(): Pairs {
       removePairBySession,
       removeSessionFromPair,
       bypassCommand,
+      removeBypassCommand,
       resetBypass,
     ]
   );

--- a/packages/gui/src/hooks/useWalletConnectPreferences.ts
+++ b/packages/gui/src/hooks/useWalletConnectPreferences.ts
@@ -3,22 +3,18 @@ import { useCallback } from 'react';
 
 export type WalletConnectPreferences = {
   enabled?: boolean;
-  autoConfirm?: boolean;
   allowConfirmationFingerprintChange?: boolean;
 };
 
 export default function useWalletConnectPreferences(): {
   enabled: boolean;
   setEnabled: (enabled: boolean) => void;
-  autoConfirm: boolean;
-  setAutoConfirm: (enabled: boolean) => void;
   allowConfirmationFingerprintChange: boolean;
   setAllowConfirmationFingerprintChange: (enabled: boolean) => void;
 } {
   const [preferences, setPreferences] = useLocalStorage<WalletConnectPreferences>('walletConnectPreferences', {});
 
   const enabled = preferences?.enabled ?? false;
-  const autoConfirm = preferences?.autoConfirm ?? false;
   const allowConfirmationFingerprintChange = preferences?.allowConfirmationFingerprintChange ?? false;
 
   const setEnabled = useCallback(
@@ -26,16 +22,6 @@ export default function useWalletConnectPreferences(): {
       setPreferences((currentPreferences: WalletConnectPreferences) => ({
         ...currentPreferences,
         enabled: value,
-      }));
-    },
-    [setPreferences]
-  );
-
-  const setAutoConfirm = useCallback(
-    (value: boolean) => {
-      setPreferences((currentPreferences: WalletConnectPreferences) => ({
-        ...currentPreferences,
-        autoConfirm: value,
       }));
     },
     [setPreferences]
@@ -54,8 +40,6 @@ export default function useWalletConnectPreferences(): {
   return {
     enabled,
     setEnabled,
-    autoConfirm,
-    setAutoConfirm,
     allowConfirmationFingerprintChange,
     setAllowConfirmationFingerprintChange,
   };


### PR DESCRIPTION
The new section allows users to manage the permissions that they have granted to each app.
Users can choose to automatically confirm or reject any read-only commands by toggling the switch, or delete the permission to be prompted every time the command is run.

![image](https://user-images.githubusercontent.com/98060724/224462646-f0a2a074-0f25-45c2-9c80-dafd44832b0b.png)
