### PR TITLE
suppress offer conflict dialog if there are no conflicts

### DIFF
--- a/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
+++ b/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
@@ -122,7 +122,8 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
         const dialog = (
           <OfferEditorConflictAlertDialog
             assetsToUnlock={assetsRequiredToBeUnlocked}
-            assetsBetterUnlocked={assetsBetterToBeUnlocked}
+            // assetsBetterUnlocked={assetsBetterToBeUnlocked}
+            assetsBetterUnlocked={[]} // Ignoring assetsBetterToBeUnlocked to avoid displaying the dialog unnecessarily
             allowSecureCancelling
           />
         );


### PR DESCRIPTION
We'll only show the offer conflict dialog if one or more offers have assets with a status of `conflictsWithNewOffer`