### PR TITLE
Fixed broken `useThrottleQuery`

### DIFF
--- a/packages/api-react/src/hooks/useThrottleQuery.ts
+++ b/packages/api-react/src/hooks/useThrottleQuery.ts
@@ -19,6 +19,9 @@ export default function useThrottleQuery(
 
   const refState = useRef<any>();
 
+  // Warning: Do not replace `useMemo` with `useCallback` below.
+  // `useMemo` is correct.
+  // lodash's `throttle` returns a function and does not execute the throttled function.
   const processUpdate = useMemo(
     () =>
       throttle(() => forceUpdate(), wait, {

--- a/packages/api-react/src/hooks/useThrottleQuery.ts
+++ b/packages/api-react/src/hooks/useThrottleQuery.ts
@@ -1,5 +1,5 @@
 import { throttle } from 'lodash';
-import { useRef, useCallback } from 'react';
+import { useRef, useMemo } from 'react';
 
 import useForceUpdate from './useForceUpdate';
 
@@ -19,7 +19,7 @@ export default function useThrottleQuery(
 
   const refState = useRef<any>();
 
-  const processUpdate = useCallback(
+  const processUpdate = useMemo(
     () =>
       throttle(() => forceUpdate(), wait, {
         leading,


### PR DESCRIPTION
This is a fix for https://github.com/Chia-Network/chia-blockchain/issues/14639

## Note 1
This targets `main` branch. Feel free to change target to `release/1.7.1`.

## Note 2
Please check carefully whether fixing/reactivating `useThrottleQuery` does not cause bad side-effect.
Before this PR, `useThrottleQuery` didn't trigger state update / re-rendering because of below.
```typescript
  // Calling `processUpdate()` here just returns a plain function and not executing the function!!
  // It took me hours to notice...
  // If you want to execute the throttled function, you need to write like
  // `processUpdate()();`
  // But I choose to replace `useCallback` with `useMemo`.
  const processUpdate = useCallback(
    () =>
      throttle(() => forceUpdate(), wait, {
        leading,
        trailing,
      }),
    [wait, leading, trailing, forceUpdate]
  );
```
After this PR is merged, components will start to re-render again.
It's unlikely that bad things happen by this change but just be carefull.