### PR TITLE
Add absent libgbm1 dependency

### DIFF
--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -93,6 +93,7 @@
       "afterInstall": "../../../build_scripts/assets/deb/postinst.sh",
       "afterRemove": "../../../build_scripts/assets/deb/prerm.sh",
       "depends": [
+        "libgbm1",
         "libgtk-3-0", "libnotify4", "libnss3", "libxss1", "libxtst6", "xdg-utils", "libatspi2.0-0", "libuuid1", "libsecret-1-0"
       ]
     },

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -91,7 +91,10 @@
     },
     "deb": {
       "afterInstall": "../../../build_scripts/assets/deb/postinst.sh",
-      "afterRemove": "../../../build_scripts/assets/deb/prerm.sh"
+      "afterRemove": "../../../build_scripts/assets/deb/prerm.sh",
+      "depends": [
+        "libgtk-3-0", "libnotify4", "libnss3", "libxss1", "libxtst6", "xdg-utils", "libatspi2.0-0", "libuuid1", "libsecret-1-0"
+      ]
     },
     "rpm": {
       "afterInstall": "../../../build_scripts/assets/rpm/postinst.sh",


### PR DESCRIPTION
Fixes [issue 14554 from the main repo](https://github.com/Chia-Network/chia-blockchain/issues/14554)

`dpkg -I` applied to the latest .deb of chia-blockchain GUI shows the following list of dependencies:

`Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0`

However, as it was mentioned in the [issue 14554](https://github.com/Chia-Network/chia-blockchain/issues/14554) from the main chia-blockchain repo, this .deb lacks the dependency from `libgbm1`, and if being run shows the following error:

```
/# chia-blockchain
chia-blockchain: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory
```

So I added the missing dependency in `package.json` according to [the electron-builder docs](https://www.electron.build/configuration/linux#debian-package-options). I have checked with`dpkg -I` that .deb package built from my PR had this required dependency and no existed dependency had been lost:

`Depends: libgbm1, libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0`

Also I had to explicitly list all default dependencies in the `package.json` in order not to override them. For clarity I made it in a separate commit.