### PR TITLE
update getWallets api/hook to set includeData to false by default

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -76,17 +76,14 @@ export const walletApi = apiWithTag.injectEndpoints({
       providesTags: ['LoggedInFingerprint'],
     }),
 
-    getWallets: build.query<Wallet[], undefined>({
-      /*
-      query: () => ({
-        command: 'getWallets',
-      }),
-      */
-      async queryFn(_args, _queryApi, _extraOptions, fetchWithBQ) {
+    getWallets: build.query<Wallet[], { includeData?: boolean }>({
+      // eslint-disable-next-line @typescript-eslint/default-param-last -- Can't change the order of the parameters
+      async queryFn({ includeData = false } = {}, _queryApi, _extraOptions, fetchWithBQ) {
         try {
           const { data, error } = await fetchWithBQ({
             command: 'getWallets',
             service: WalletService,
+            args: [includeData],
           });
 
           if (error) {

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -13,8 +13,10 @@ export default class Wallet extends Service {
     return this.command('get_logged_in_fingerprint');
   }
 
-  async getWallets() {
-    return this.command('get_wallets');
+  async getWallets(includeData: boolean = false) {
+    return this.command('get_wallets', {
+      includeData,
+    });
   }
 
   async getTransaction(transactionId: string) {

--- a/packages/gui/src/@types/WalletConnectCommandParamName.ts
+++ b/packages/gui/src/@types/WalletConnectCommandParamName.ts
@@ -9,6 +9,7 @@ enum WalletConnectCommandParamName {
   FEE = 'fee',
   FINGERPRINT = 'fingerprint',
   ID = 'id',
+  INCLUDE_DATA = 'includeData',
   INCLUDE_MY_OFFERS = 'includeMyOffers',
   INCLUDE_TAKEN_OFFERS = 'includeTakenOffers',
   LAUNCHER_ID = 'launcherId',

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -27,6 +27,13 @@ const walletConnectCommands: WalletConnectCommand[] = [
     label: <Trans>Get Wallets</Trans>,
     service: ServiceName.WALLET,
     bypassConfirm: true,
+    params: [
+      {
+        name: WalletConnectCommandParamName.INCLUDE_DATA,
+        type: 'boolean',
+        label: <Trans>Include Wallet Metadata</Trans>,
+      },
+    ],
   },
   {
     command: 'getTransaction',


### PR DESCRIPTION
The `get_wallets` RPC defaults to including wallet metadata, which can be rather large for DID wallets. Since the GUI never uses this metadata, the getWallets query now defaults to setting `include_data` to false.

The WalletConnect `getWallets` command has been updated to expose the `includeData` param, allowing Dapps to request the metadata if desired.