### PR TITLE
add getCATWalletInfo query to call cat_asset_id_to_name RPC

### DIFF
--- a/packages/api-react/src/services/index.ts
+++ b/packages/api-react/src/services/index.ts
@@ -142,6 +142,7 @@ export const {
   // CAT wallet hooks
   useCreateNewCATWalletMutation,
   useCreateCATWalletForExistingMutation,
+  useGetCATWalletInfoQuery,
   useGetCATAssetIdQuery,
   useGetCatListQuery,
   useGetCATNameQuery,

--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -21,6 +21,7 @@ import onCacheEntryAddedInvalidate from '../utils/onCacheEntryAddedInvalidate';
 const apiWithTag = api.enhanceEndpoints({
   addTagTypes: [
     'Address',
+    'CATWalletInfo',
     'DID',
     'DIDCoinInfo',
     'DIDInfo',
@@ -1200,6 +1201,15 @@ export const walletApi = apiWithTag.injectEndpoints({
       ],
     }),
 
+    getCATWalletInfo: build.query<{ walletId: number; name?: string }, { assetId: string }>({
+      query: ({ assetId }) => ({
+        command: 'getWalletIdAndName',
+        service: CAT,
+        args: [assetId],
+      }),
+      providesTags: (result, _error, { assetId }) => (result ? [{ type: 'CATWalletInfo', id: assetId }] : []),
+    }),
+
     getCATAssetId: build.query<
       string,
       {
@@ -2332,6 +2342,7 @@ export const {
   // CAT
   useCreateNewCATWalletMutation,
   useCreateCATWalletForExistingMutation,
+  useGetCATWalletInfoQuery,
   useGetCATAssetIdQuery,
   useGetCatListQuery,
   useGetCATNameQuery,

--- a/packages/api/src/wallets/CAT.ts
+++ b/packages/api/src/wallets/CAT.ts
@@ -15,6 +15,12 @@ export default class CATWallet extends Wallet {
     });
   }
 
+  async getWalletIdAndName(assetId: string) {
+    return this.command('cat_asset_id_to_name', {
+      assetId,
+    });
+  }
+
   async getAssetId(walletId: number) {
     return this.command('cat_get_asset_id', {
       walletId,

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -411,6 +411,19 @@ const walletConnectCommands: WalletConnectCommand[] = [
     ],
   },
   {
+    command: 'getCATWalletInfo',
+    label: <Trans>Get CAT Wallet Info</Trans>,
+    service: ServiceName.WALLET,
+    bypassConfirm: true,
+    params: [
+      {
+        name: WalletConnectCommandParamName.ASSET_ID,
+        label: <Trans>Asset Id</Trans>,
+        type: 'string',
+      },
+    ],
+  },
+  {
     command: 'getCATAssetId',
     label: <Trans>Get CAT Asset Id</Trans>,
     service: ServiceName.WALLET,


### PR DESCRIPTION
Adds the `useGetCATWalletInfoQuery` hook to fetch wallet info for a CAT given its asset id. The returned data includes the CAT's name (if assigned) as well as the wallet id.

This change also exposes the `getCATWalletInfo` WalletConnect command.