### PR TITLE
invalidate some RTK caches when logging into a key

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -433,7 +433,7 @@ export const walletApi = apiWithTag.injectEndpoints({
     }),
 
     logIn: mutation(build, WalletService, 'logIn', {
-      invalidatesTags: ['LoggedInFingerprint'],
+      invalidatesTags: ['LoggedInFingerprint', 'Address', 'Wallets', 'Transactions', 'WalletBalance', 'Notification'],
     }),
 
     getPrivateKey: query(build, WalletService, 'getPrivateKey', {


### PR DESCRIPTION
The current wallet address wasn't being updated when logging into a newly created key. This change will invalidate several of the RTK caches when the login mutation is invoked, causing the current wallet address to refresh properly, along with wallets/balances/notifications