### PR TITLE
Temporary workaround issue using openDialog() on WalletConnect dialogs.

### DIFF
--- a/packages/gui/src/components/walletConnect/WalletConnectAddConnectionDialog.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectAddConnectionDialog.tsx
@@ -16,7 +16,8 @@ import { Box, Divider, Dialog, DialogContent, DialogTitle, IconButton, Typograph
 import React, { useEffect, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
-import useWalletConnectContext from '../../hooks/useWalletConnectContext';
+// import useWalletConnectContext from '../../hooks/useWalletConnectContext';
+import { WalletConnectContext } from './WalletConnectProvider';
 import HeroImage from './images/walletConnectToChia.svg';
 
 enum Step {
@@ -32,13 +33,15 @@ type FormData = {
 export type WalletConnectAddConnectionDialogProps = {
   onClose?: (topic?: string) => void;
   open?: boolean;
+  context: WalletConnectContext;
 };
 
 export default function WalletConnectAddConnectionDialog(props: WalletConnectAddConnectionDialogProps) {
-  const { onClose = () => {}, open = false } = props;
+  const { context, onClose = () => {}, open = false } = props;
 
   const [step, setStep] = useState<Step>(Step.CONNECT);
-  const { pair, isLoading: isLoadingWallet } = useWalletConnectContext();
+  // const { pair, isLoading: isLoadingWallet } = useWalletConnectContext();
+  const { pair, isLoading: isLoadingWallet } = context;
   const { data: keys, isLoading: isLoadingPublicKeys } = useGetKeysQuery();
   const { data: fingerprint, isLoading: isLoadingLoggedInFingerprint } = useGetLoggedInFingerprintQuery();
   const mainnet = useCurrencyCode() === 'XCH';

--- a/packages/gui/src/components/walletConnect/WalletConnectConnectedDialog.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectConnectedDialog.tsx
@@ -5,20 +5,23 @@ import CloseIcon from '@mui/icons-material/Close';
 import { Box, Divider, Dialog, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
 import React, { useMemo, useState } from 'react';
 
-import useWalletConnectContext from '../../hooks/useWalletConnectContext';
+// import useWalletConnectContext from '../../hooks/useWalletConnectContext';
+import { WalletConnectContext } from './WalletConnectProvider';
 import HeroImage from './images/walletConnectConnected.svg';
 
 export type WalletConnectAddConnectionDialogProps = {
   onClose?: () => void;
   open?: boolean;
   topic: string;
+  context: WalletConnectContext;
 };
 
 export default function WalletConnectConnectedDialog(props: WalletConnectAddConnectionDialogProps) {
-  const { topic, onClose = () => {}, open = false } = props;
+  const { context, topic, onClose = () => {}, open = false } = props;
   const [isProcessing, setIsProcessing] = useState(false);
   const showError = useShowError();
-  const { pairs, disconnect, isLoading: isLoadingWallet } = useWalletConnectContext();
+  // const { pairs, disconnect, isLoading: isLoadingWallet } = useWalletConnectContext();
+  const { pairs, disconnect, isLoading: isLoadingWallet } = context;
   const { data: keys, isLoading: isLoadingPublicKeys } = useGetKeysQuery();
 
   const pair = pairs.getPair(topic);

--- a/packages/gui/src/components/walletConnect/WalletConnectConnections.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectConnections.tsx
@@ -6,7 +6,7 @@ import {
   Edit as EditIcon,
 } from '@mui/icons-material';
 import { Button, ListItemIcon, Typography, Divider } from '@mui/material';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import useWalletConnectContext from '../../hooks/useWalletConnectContext';
 import useWalletConnectPreferences from '../../hooks/useWalletConnectPreferences';
@@ -23,16 +23,17 @@ export default function WalletConnectConnections(props: WalletConnectConnections
   const openDialog = useOpenDialog();
   const showError = useShowError();
   const { enabled, setEnabled } = useWalletConnectPreferences();
-  const { disconnect, pairs, isLoading } = useWalletConnectContext();
+  const context = useWalletConnectContext();
+  const { disconnect, pairs, isLoading } = context;
 
-  async function handleAddConnection() {
+  const handleAddConnection = useCallback(async () => {
     onClose?.();
-    const topic = await openDialog(<WalletConnectAddConnectionDialog />);
+    const topic = await openDialog(<WalletConnectAddConnectionDialog context={context} />);
 
     if (topic) {
-      await openDialog(<WalletConnectConnectedDialog topic={topic} />);
+      await openDialog(<WalletConnectConnectedDialog topic={topic} context={context} />);
     }
-  }
+  }, [onClose, openDialog, context]);
 
   async function handleDisconnect(topic: string) {
     try {
@@ -47,10 +48,13 @@ export default function WalletConnectConnections(props: WalletConnectConnections
     setEnabled(true);
   }
 
-  function handleShowMoreInfo(topic: string) {
-    onClose?.();
-    openDialog(<WalletConnectPairInfoDialog topic={topic} />);
-  }
+  const handleShowMoreInfo = useCallback(
+    (topic: string) => {
+      onClose?.();
+      openDialog(<WalletConnectPairInfoDialog topic={topic} context={context} />);
+    },
+    [onClose, openDialog, context]
+  );
 
   const pairsList = pairs.get();
 

--- a/packages/gui/src/components/walletConnect/WalletConnectPairInfoDialog.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectPairInfoDialog.tsx
@@ -5,20 +5,23 @@ import CloseIcon from '@mui/icons-material/Close';
 import { Divider, Dialog, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
 import React, { useMemo, useState } from 'react';
 
-import useWalletConnectContext from '../../hooks/useWalletConnectContext';
+// import useWalletConnectContext from '../../hooks/useWalletConnectContext';
 import WalletConnectMetadata from './WalletConnectMetadata';
+import { WalletConnectContext } from './WalletConnectProvider';
 
 export type WalletConnectPairInfoDialogProps = {
   onClose?: () => void;
   open?: boolean;
   topic: string;
+  context: WalletConnectContext;
 };
 
 export default function WalletConnectPairInfoDialog(props: WalletConnectPairInfoDialogProps) {
-  const { topic, onClose = () => {}, open = false } = props;
+  const { context, topic, onClose = () => {}, open = false } = props;
   const [isProcessing, setIsProcessing] = useState(false);
   const showError = useShowError();
-  const { pairs, disconnect, isLoading: isLoadingWallet } = useWalletConnectContext();
+  // const { pairs, disconnect, isLoading: isLoadingWallet } = useWalletConnectContext();
+  const { pairs, disconnect, isLoading: isLoadingWallet } = context;
   const { data: keys, isLoading: isLoadingPublicKeys } = useGetKeysQuery();
 
   const pair = useMemo(() => pairs.getPair(topic), [topic, pairs]);


### PR DESCRIPTION
Without this change, the WalletConnect dialogs don't have access to the WC context, causing the error:
'useWalletConnectContext must be used within a WalletConnectProvider'