### PR TITLE
Update PlotAddNFT.tsx

### DIFF
--- a/packages/gui/src/components/plot/add/PlotAddNFT.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddNFT.tsx
@@ -53,7 +53,7 @@ const PlotAddNFT = forwardRef((props: Props, ref) => {
       title={
         <Flex gap={1} alignItems="baseline">
           <Box>
-            <Trans>Make plots portable to pools</Trans>
+            <Trans>Plot to a Plot NFT</Trans>
           </Box>
           <Typography variant="body1" color="textSecondary">
             <Trans>(Cannot be changed later)</Trans>

--- a/packages/gui/src/components/plot/add/PlotAddNFT.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddNFT.tsx
@@ -1,4 +1,4 @@
-import { Button, CardStep, Select, Flex, Loading } from '@chia-network/core';
+import { Button, CardStep, Select, Flex, Link, Loading } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { Box, Grid, FormControl, InputLabel, MenuItem, Typography } from '@mui/material';
 import React, { useState, forwardRef } from 'react';

--- a/packages/gui/src/components/plot/add/PlotAddNFT.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddNFT.tsx
@@ -56,7 +56,7 @@ const PlotAddNFT = forwardRef((props: Props, ref) => {
             <Trans>Plot to a Plot NFT</Trans>
           </Box>
           <Typography variant="body1" color="textSecondary">
-            <Trans>(Cannot be changed later)</Trans>
+            <Trans>(Recommended)</Trans>
           </Typography>
         </Flex>
       }

--- a/packages/gui/src/components/plot/add/PlotAddNFT.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddNFT.tsx
@@ -53,10 +53,10 @@ const PlotAddNFT = forwardRef((props: Props, ref) => {
       title={
         <Flex gap={1} alignItems="baseline">
           <Box>
-            <Trans>Join a Pool</Trans>
+            <Trans>Make plots portable to pools</Trans>
           </Box>
           <Typography variant="body1" color="textSecondary">
-            <Trans>(Optional)</Trans>
+            <Trans>(Cannot be changed later)</Trans>
           </Typography>
         </Flex>
       }
@@ -66,7 +66,13 @@ const PlotAddNFT = forwardRef((props: Props, ref) => {
       {!loading && hasNFTs && (
         <>
           <Typography variant="subtitle1">
-            <Trans>Select your Plot NFT from the dropdown or create a new one.</Trans>
+            <Trans>
+              {
+                'Select your Plot NFT from the dropdown or create a new one. If you do not select a plot NFT, the plots you make cannot be used with standard pools later on'
+              }
+              <Link target="_blank" href="https://github.com/Chia-Network/chia-blockchain/wiki/Pooling-User-Guide">
+                Learn more
+            </Trans>
           </Typography>
 
           <Grid spacing={2} direction="column" container>

--- a/packages/gui/src/components/plot/add/PlotAddNFT.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddNFT.tsx
@@ -67,12 +67,14 @@ const PlotAddNFT = forwardRef((props: Props, ref) => {
         <>
           <Typography variant="subtitle1">
             <Trans>
-              {
-                'Select your Plot NFT from the dropdown or create a new one. If you do not select a plot NFT, the plots you make cannot be used with standard pools later on'
-              }
-              <Link target="_blank" href="https://github.com/Chia-Network/chia-blockchain/wiki/Pooling-User-Guide">
-                Learn more
+              Plotting to a Plot NFT allows you the flexibility to join a pool or solo farm. You can easily switch
+              between different pools or solo farming at any time. If you choose not to plot to a Plot NFT, you will
+              need to replot in order to join any of the standard pools.
             </Trans>
+            &nbsp;
+            <Link target="_blank" href="https://docs.chia.net/pool-farming">
+              <Trans>Learn more</Trans>
+            </Link>
           </Typography>
 
           <Grid spacing={2} direction="column" container>


### PR DESCRIPTION
Made the option less likely to cause users to make OG plots by mistake

Changed: "join a pool (Optional)" 
-> "Make plots portable to pools (Cannot be changed later)"

Changed: "Select your Plot NFT from the dropdown or create a new one" -> Select your Plot NFT from the dropdown or create a new one. If you do not select a plot NFT, the plots you make cannot be used with standard pools later on [Learn more]" -> added link to pooling-user-guide