### PR TITLE
Enable MintGarden offer sharing on mainnet

### DIFF
--- a/packages/gui/src/components/offers/OfferShareDialog.tsx
+++ b/packages/gui/src/components/offers/OfferShareDialog.tsx
@@ -1508,14 +1508,10 @@ export default function OfferShareDialog(props: OfferShareDialogProps) {
         component: OfferShareHashgreenDialog,
         props: commonDialogProps,
       },
-      ...(testnet
-        ? {
-            [OfferSharingService.MintGarden]: {
-              component: OfferShareMintGardenDialog,
-              props: commonDialogProps,
-            },
-          }
-        : {}),
+      [OfferSharingService.MintGarden]: {
+        component: OfferShareMintGardenDialog,
+        props: commonDialogProps,
+      },
       [OfferSharingService.OfferBin]: {
         component: OfferShareOfferBinDialog,
         props: commonDialogProps,
@@ -1549,7 +1545,7 @@ export default function OfferShareDialog(props: OfferShareDialogProps) {
       });
 
     return options;
-  }, [isNFTOffer, testnet, showSendOfferNotificationDialog, address]);
+  }, [isNFTOffer, showSendOfferNotificationDialog, address]);
 
   useEffect(() => {
     if (sendOfferNotificationOpen && offerURL && notificationDestination && notificationDestinationType) {


### PR DESCRIPTION
MintGarden now natively supports hosting offer, so we'd love to enable the offer upload on mainnet too!