### PR TITLE
added compareAppVersions function with tests

### DIFF
--- a/packages/core/src/components/LayoutDashboard/LayoutDashboard.tsx
+++ b/packages/core/src/components/LayoutDashboard/LayoutDashboard.tsx
@@ -28,6 +28,7 @@ import useGetLatestVersionFromWebsite from '../../hooks/useGetLatestVersionFromW
 import useOpenDialog from '../../hooks/useOpenDialog';
 import EmojiAndColorPicker from '../../screens/SelectKey/EmojiAndColorPicker';
 import SelectKeyRenameForm from '../../screens/SelectKey/SelectKeyRenameForm';
+import compareAppVersions from '../../utils/compareAppVersion';
 import Flex from '../Flex';
 import Link from '../Link';
 import Loading from '../Loading';
@@ -118,6 +119,8 @@ export default function LayoutDashboard(props: LayoutDashboardProps) {
   const [skipVersion, setSkipVersion] = useLocalStorage<string>('skipVersion', '');
   const { latestVersion, downloadUrl, blogUrl } = useGetLatestVersionFromWebsite(skipVersion !== '');
   const { version } = useAppVersion();
+  const versionComparisonResult = latestVersion ? compareAppVersions(version, latestVersion) : 0;
+  const newVersionAvailable = versionComparisonResult === -1;
 
   const openDialog = useOpenDialog();
 
@@ -153,7 +156,7 @@ export default function LayoutDashboard(props: LayoutDashboardProps) {
   }
 
   function isNewVersionBannerShown() {
-    return latestVersion && version && skipVersion !== latestVersion && latestVersion !== version.split('-')[0];
+    return latestVersion && version && skipVersion !== latestVersion && newVersionAvailable;
   }
 
   function renderNewVersionBanner() {

--- a/packages/core/src/components/LayoutDashboard/NewerAppVersionAvailable.tsx
+++ b/packages/core/src/components/LayoutDashboard/NewerAppVersionAvailable.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import useGetLatestVersionFromWebsite from '../../hooks/useGetLatestVersionFromWebsite';
 import useOpenExternal from '../../hooks/useOpenExternal';
+import compareAppVersions from '../../utils/compareAppVersion';
 import Button from '../Button';
 import Flex from '../Flex';
 import Link from '../Link';
@@ -24,6 +25,8 @@ export default function AppVersionWarning(props: AppVersionWarningProps) {
   } = useGetLatestVersionFromWebsite(false);
   const [open, setOpen] = React.useState<boolean>(true);
   const openExternal = useOpenExternal();
+  const versionComparisonResult = latestVersion ? compareAppVersions(currentVersion, latestVersion) : 0;
+  const newVersionAvailable = versionComparisonResult === -1;
 
   function renderSpinner() {
     return (
@@ -83,14 +86,14 @@ export default function AppVersionWarning(props: AppVersionWarningProps) {
         <DialogTitle id="alert-dialog-title">
           {isLoadingVersion ? (
             <Trans>Checking for updates...</Trans>
-          ) : latestVersion === currentVersion ? (
-            <Trans>You're up to date</Trans>
-          ) : (
+          ) : newVersionAvailable ? (
             <Trans>A new version of Chia is available!</Trans>
+          ) : (
+            <Trans>You're up to date</Trans>
           )}
         </DialogTitle>
         <DialogContent>
-          {isLoadingVersion ? renderSpinner() : latestVersion === currentVersion ? renderUpToDate() : renderVersions()}
+          {isLoadingVersion ? renderSpinner() : newVersionAvailable ? renderVersions() : renderUpToDate()}
         </DialogContent>
         <DialogActions>
           <Button
@@ -103,7 +106,7 @@ export default function AppVersionWarning(props: AppVersionWarningProps) {
           >
             <Trans>Close</Trans>
           </Button>
-          {!isLoadingVersion && latestVersion !== currentVersion && downloadUrl && (
+          {!isLoadingVersion && newVersionAvailable && downloadUrl && (
             <Button
               onClick={() => {
                 openExternal(downloadUrl);

--- a/packages/core/src/utils/compareAppVersion.test.ts
+++ b/packages/core/src/utils/compareAppVersion.test.ts
@@ -1,0 +1,44 @@
+import compareAppVersions from './compareAppVersion';
+
+describe('compareAppVersions', () => {
+  test('should correctly compare equal versions', () => {
+    expect(compareAppVersions('1.0.0', '1.0.0')).toBe(0);
+  });
+
+  test('should correctly compare major versions', () => {
+    expect(compareAppVersions('2.0.0', '1.0.0')).toBe(1);
+    expect(compareAppVersions('1.0.0', '2.0.0')).toBe(-1);
+  });
+
+  test('should correctly compare minor versions', () => {
+    expect(compareAppVersions('1.2.0', '1.1.0')).toBe(1);
+    expect(compareAppVersions('1.1.0', '1.2.0')).toBe(-1);
+  });
+
+  test('should correctly compare patch versions', () => {
+    expect(compareAppVersions('1.0.2', '1.0.1')).toBe(1);
+    expect(compareAppVersions('1.0.1', '1.0.2')).toBe(-1);
+  });
+
+  test('should correctly compare pre-release versions', () => {
+    expect(compareAppVersions('1.0.0-alpha', '1.0.0-beta')).toBe(-1);
+    expect(compareAppVersions('1.0.0-beta', '1.0.0-alpha')).toBe(1);
+  });
+
+  test('should correctly compare pre-release and release versions', () => {
+    expect(compareAppVersions('1.0.0', '1.0.0-alpha')).toBe(1);
+    expect(compareAppVersions('1.0.0-alpha', '1.0.0')).toBe(-1);
+  });
+
+  test('should correctly compare complex version strings', () => {
+    expect(compareAppVersions('1.3.6-dev157', '1.7.0b6')).toBe(-1);
+    expect(compareAppVersions('1.7.0b6', '1.6.1')).toBe(1);
+    expect(compareAppVersions('1.6.1', '1.6.1')).toBe(0);
+  });
+
+  test('should throw an error for invalid version strings', () => {
+    expect(() => compareAppVersions('1.0.0', '1.0.0.1')).toThrowError('Invalid version string: 1.0.0.1');
+    expect(() => compareAppVersions('1.0', '1.0.0')).toThrowError('Invalid version string: 1.0');
+    expect(() => compareAppVersions('1.a.0', '1.0.0')).toThrowError('Invalid version string: 1.a.0');
+  });
+});

--- a/packages/core/src/utils/compareAppVersion.test.ts
+++ b/packages/core/src/utils/compareAppVersion.test.ts
@@ -1,6 +1,21 @@
-import compareAppVersions from './compareAppVersion';
+import compareAppVersions, { parseVersion } from './compareAppVersion';
 
 describe('compareAppVersions', () => {
+  // Variable to store the original console.error function
+  let originalConsoleError: typeof console.error;
+
+  beforeEach(() => {
+    // Store the original console.error function
+    originalConsoleError = console.error;
+    // Replace console.error with a mocked function to suppress the output
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    // Restore the original console.error function after each test
+    console.error = originalConsoleError;
+  });
+
   test('should correctly compare equal versions', () => {
     expect(compareAppVersions('1.0.0', '1.0.0')).toBe(0);
   });
@@ -36,9 +51,15 @@ describe('compareAppVersions', () => {
     expect(compareAppVersions('1.6.1', '1.6.1')).toBe(0);
   });
 
+  test('should return zero for invalid version strings', () => {
+    expect(compareAppVersions('1.0.0', '1.0.0.1')).toBe(0);
+    expect(compareAppVersions('1.0', '1.0.0')).toBe(0);
+    expect(compareAppVersions('1.0.0', '1.a.0')).toBe(0);
+  });
+
   test('should throw an error for invalid version strings', () => {
-    expect(() => compareAppVersions('1.0.0', '1.0.0.1')).toThrowError('Invalid version string: 1.0.0.1');
-    expect(() => compareAppVersions('1.0', '1.0.0')).toThrowError('Invalid version string: 1.0');
-    expect(() => compareAppVersions('1.a.0', '1.0.0')).toThrowError('Invalid version string: 1.a.0');
+    expect(() => parseVersion('1.0.0.1')).toThrowError('Invalid version string: 1.0.0.1');
+    expect(() => parseVersion('1.0')).toThrowError('Invalid version string: 1.0');
+    expect(() => parseVersion('1.a.0')).toThrowError('Invalid version string: 1.a.0');
   });
 });

--- a/packages/core/src/utils/compareAppVersion.ts
+++ b/packages/core/src/utils/compareAppVersion.ts
@@ -14,7 +14,7 @@ type NonNullableKeys<T> = {
 
 // Function to parse a version string into an AppVersion object.
 // Throws an error if the version string is invalid.
-function parseVersion(version: string): AppVersion {
+export function parseVersion(version: string): AppVersion {
   // Regular expression to match version strings in the format of X.Y.Z[-preRelease]
   const versionRegex = /^(\d+)\.(\d+)\.(\d+)(?:-?([a-z0-9]+))?$/i;
   const match = version.match(versionRegex);
@@ -38,9 +38,18 @@ function parseVersion(version: string): AppVersion {
 // - a negative value if versionA is less than versionB,
 // - zero if both versions are equal.
 function compareAppVersions(versionA: string, versionB: string): number {
-  // Parse both version strings into AppVersion objects.
-  const parsedA = parseVersion(versionA);
-  const parsedB = parseVersion(versionB);
+  let parsedA: AppVersion;
+  let parsedB: AppVersion;
+
+  try {
+    // Parse both version strings into AppVersion objects.
+    parsedA = parseVersion(versionA);
+    parsedB = parseVersion(versionB);
+  } catch (error) {
+    console.error(error);
+    // If either version string is invalid, return zero.
+    return 0;
+  }
 
   // Array of non-nullable keys for the AppVersion type.
   const nonNullableKeys: NonNullableKeys<AppVersion>[] = ['major', 'minor', 'patch'];

--- a/packages/core/src/utils/compareAppVersion.ts
+++ b/packages/core/src/utils/compareAppVersion.ts
@@ -1,0 +1,77 @@
+// Type definition for a parsed app version, with non-nullable major, minor, and patch numbers,
+// and an optional pre-release identifier.
+type AppVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  preRelease: string | null;
+};
+
+// Utility type to extract the keys of the properties in the type T that are not nullable.
+type NonNullableKeys<T> = {
+  [K in keyof T]: null extends T[K] ? never : K;
+}[keyof T];
+
+// Function to parse a version string into an AppVersion object.
+// Throws an error if the version string is invalid.
+function parseVersion(version: string): AppVersion {
+  // Regular expression to match version strings in the format of X.Y.Z[-preRelease]
+  const versionRegex = /^(\d+)\.(\d+)\.(\d+)(?:-?([a-z0-9]+))?$/i;
+  const match = version.match(versionRegex);
+
+  // If the version string doesn't match the regex, throw an error.
+  if (!match) {
+    throw new Error(`Invalid version string: ${version}`);
+  }
+
+  // Return the parsed version object.
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+    preRelease: match[4] || null,
+  };
+}
+
+// Function to compare two version strings, returning:
+// - a positive value if versionA is greater than versionB,
+// - a negative value if versionA is less than versionB,
+// - zero if both versions are equal.
+function compareAppVersions(versionA: string, versionB: string): number {
+  // Parse both version strings into AppVersion objects.
+  const parsedA = parseVersion(versionA);
+  const parsedB = parseVersion(versionB);
+
+  // Array of non-nullable keys for the AppVersion type.
+  const nonNullableKeys: NonNullableKeys<AppVersion>[] = ['major', 'minor', 'patch'];
+
+  // Compare the major, minor, and patch versions.
+  for (const key of nonNullableKeys) {
+    if (parsedA[key] > parsedB[key]) {
+      return 1;
+    }
+    if (parsedA[key] < parsedB[key]) {
+      return -1;
+    }
+  }
+
+  // If both versions have no pre-release identifiers, they are considered equal.
+  if (parsedA.preRelease === null && parsedB.preRelease === null) {
+    return 0;
+  }
+
+  // If versionA has no pre-release identifier, it is considered greater than versionB.
+  if (parsedA.preRelease === null) {
+    return 1;
+  }
+
+  // If versionB has no pre-release identifier, it is considered greater than versionA.
+  if (parsedB.preRelease === null) {
+    return -1;
+  }
+
+  // Compare pre-release identifiers lexicographically.
+  return parsedA.preRelease.localeCompare(parsedB.preRelease);
+}
+
+export default compareAppVersions;


### PR DESCRIPTION
Added a version comparison function to determine whether the latest published app version is actually newer than the running version. Previously the version comparison was a simple string comparison.

Includes tests that cover the new functionality.