### PR TITLE
fix skip version logic and allow localStorage overrides for testing

### DIFF
--- a/packages/core/src/components/LayoutDashboard/LayoutDashboard.tsx
+++ b/packages/core/src/components/LayoutDashboard/LayoutDashboard.tsx
@@ -1,10 +1,4 @@
-import {
-  useGetLoggedInFingerprintQuery,
-  useGetKeyQuery,
-  useFingerprintSettings,
-  useLocalStorage,
-} from '@chia-network/api-react';
-import { useAppVersion } from '@chia-network/core';
+import { useGetLoggedInFingerprintQuery, useGetKeyQuery, useFingerprintSettings } from '@chia-network/api-react';
 import { Exit as ExitIcon } from '@chia-network/icons';
 import { t, Trans } from '@lingui/macro';
 import { ExitToApp as ExitToAppIcon, Edit as EditIcon } from '@mui/icons-material';
@@ -28,7 +22,6 @@ import useGetLatestVersionFromWebsite from '../../hooks/useGetLatestVersionFromW
 import useOpenDialog from '../../hooks/useOpenDialog';
 import EmojiAndColorPicker from '../../screens/SelectKey/EmojiAndColorPicker';
 import SelectKeyRenameForm from '../../screens/SelectKey/SelectKeyRenameForm';
-import compareAppVersions from '../../utils/compareAppVersion';
 import Flex from '../Flex';
 import Link from '../Link';
 import Loading from '../Loading';
@@ -116,11 +109,8 @@ export default function LayoutDashboard(props: LayoutDashboardProps) {
     emoji: ``,
     color: 'green',
   });
-  const [skipVersion, setSkipVersion] = useLocalStorage<string>('skipVersion', '');
-  const { latestVersion, downloadUrl, blogUrl } = useGetLatestVersionFromWebsite(skipVersion !== '');
-  const { version } = useAppVersion();
-  const versionComparisonResult = latestVersion ? compareAppVersions(version, latestVersion) : 0;
-  const newVersionAvailable = versionComparisonResult === -1;
+  const { appVersion, latestVersion, newVersionAvailable, isVersionSkipped, addVersionToSkip, downloadUrl, blogUrl } =
+    useGetLatestVersionFromWebsite();
 
   const openDialog = useOpenDialog();
 
@@ -134,11 +124,11 @@ export default function LayoutDashboard(props: LayoutDashboardProps) {
         openDialog(<NewerAppVersionAvailable currentVersion={ver} />);
       }
     }
-    if (!preventDualCheck.current && version) {
-      (window as any).ipcRenderer.on('checkForUpdates', () => checkForUpdates(version));
+    if (!preventDualCheck.current && appVersion) {
+      (window as any).ipcRenderer.on('checkForUpdates', () => checkForUpdates(appVersion));
       preventDualCheck.current = true;
     }
-  }, [openDialog, version]);
+  }, [openDialog, appVersion]);
 
   async function handleLogout() {
     localStorage.setItem('visibilityFilters', JSON.stringify(['visible']));
@@ -156,7 +146,7 @@ export default function LayoutDashboard(props: LayoutDashboardProps) {
   }
 
   function isNewVersionBannerShown() {
-    return latestVersion && version && skipVersion !== latestVersion && newVersionAvailable;
+    return newVersionAvailable && !isVersionSkipped;
   }
 
   function renderNewVersionBanner() {
@@ -175,9 +165,11 @@ export default function LayoutDashboard(props: LayoutDashboardProps) {
           }}
         >
           <Trans>New version {latestVersion} available</Trans>
-          <Button color="secondary" variant="outlined" size="small" onClick={() => setSkipVersion(latestVersion || '')}>
-            <Trans>Skip</Trans>
-          </Button>
+          {latestVersion && (
+            <Button color="secondary" variant="outlined" size="small" onClick={() => addVersionToSkip(latestVersion)}>
+              <Trans>Skip</Trans>
+            </Button>
+          )}
           {blogUrl && (
             <Link target="_blank" href={blogUrl} sx={{ textDecoration: 'none !important' }}>
               <Button color="secondary" variant="outlined" size="small" sx={{ boxShadow: 'none' }}>

--- a/packages/core/src/hooks/useAppVersion.ts
+++ b/packages/core/src/hooks/useAppVersion.ts
@@ -1,7 +1,9 @@
+import { useLocalStorage } from '@chia-network/api-react';
 import { useState, useEffect } from 'react';
 
 export default function useAppVersion() {
   const [version, setVersion] = useState<string | undefined>(undefined);
+  const [appVersionOverride] = useLocalStorage<string>('appVersionOverride', '');
 
   async function getVersion() {
     const currentVersion = await window.ipcRenderer.invoke('getVersion');
@@ -13,7 +15,7 @@ export default function useAppVersion() {
   }, []);
 
   return {
-    version,
+    version: appVersionOverride || version,
     isLoading: version === undefined,
   };
 }

--- a/packages/core/src/hooks/useGetLatestVersionFromWebsite.ts
+++ b/packages/core/src/hooks/useGetLatestVersionFromWebsite.ts
@@ -1,18 +1,48 @@
-import { useState, useEffect } from 'react';
+import { useLocalStorage } from '@chia-network/api-react';
+import { useCallback, useState, useEffect } from 'react';
 
-export default function useGetLatestVersionFromWebsite(skipVersionExists: boolean) {
+import compareAppVersions from '../utils/compareAppVersion';
+import useAppVersion from './useAppVersion';
+
+type UseGetLatestVersionFromWebsiteResult = {
+  appVersion: string | undefined;
+  latestVersion: string | null;
+  downloadUrl: string | undefined;
+  releaseNotesUrl: string | undefined;
+  blogUrl: string | undefined;
+  isLoading: boolean;
+  newVersionAvailable: boolean;
+  isVersionSkipped: boolean;
+  skipVersions: string[] | undefined;
+  addVersionToSkip: (version: string) => void;
+};
+
+export default function useGetLatestVersionFromWebsite(): UseGetLatestVersionFromWebsiteResult {
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [downloadPath, setDownloadPath] = useState<string | null>(null);
   const [releaseNotesPath, setReleaseNotesPath] = useState<string | null>(null);
   const [blogPath, setBlogPath] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [latestVersionURL] = useLocalStorage<string>(
+    'latestVersionURL',
+    'https://download.chia.net/latest/latest.json'
+  );
+  const [skipVersions, setSkipVersions] = useLocalStorage<string[]>('skipVersions', []);
+  const { version: appVersion } = useAppVersion();
+  const versionComparisonResult = latestVersion ? compareAppVersions(appVersion, latestVersion) : 0;
+  const newVersionAvailable = versionComparisonResult === -1;
+  const isVersionSkipped = skipVersions?.includes(latestVersion ?? '') ?? false;
+
+  const addVersionToSkip = useCallback(
+    (version: string) => {
+      setSkipVersions((prev) => [...(prev ?? []), version]);
+    },
+    [setSkipVersions]
+  );
 
   useEffect(() => {
-    if (skipVersionExists) {
-      return;
-    }
     const { ipcRenderer } = window as any;
-    ipcRenderer.invoke('fetchHtmlContent', 'https://download.chia.net/latest/latest.json').then((obj: any) => {
+    ipcRenderer.invoke('fetchHtmlContent', latestVersionURL).then((obj: any) => {
       try {
         const { version, downloadPageUrl, releaseNotesUrl, blogUrl } = obj.data;
         setTimeout(() => {
@@ -27,11 +57,22 @@ export default function useGetLatestVersionFromWebsite(skipVersionExists: boolea
            from chia.net, we just ignore showing reminder dialog */
       }
     });
-  }, [skipVersionExists]);
+  }, [latestVersionURL]);
 
   const downloadUrl = downloadPath ? new URL(downloadPath, 'https://www.chia.net/').toString() : undefined;
   const releaseNotesUrl = releaseNotesPath ? new URL(releaseNotesPath, 'https://www.chia.net/').toString() : undefined;
   const blogUrl = blogPath ? new URL(blogPath, 'https://www.chia.net/').toString() : undefined;
 
-  return { latestVersion, isLoading, downloadUrl, releaseNotesUrl, blogUrl };
+  return {
+    appVersion,
+    latestVersion,
+    newVersionAvailable,
+    isVersionSkipped,
+    skipVersions,
+    addVersionToSkip,
+    isLoading,
+    downloadUrl,
+    releaseNotesUrl,
+    blogUrl,
+  };
 }


### PR DESCRIPTION
When a new version is available, the banner includes a "Skip" button, which had the effect of blocking all future updates regardless of version.

This PR modifies the logic to maintain a `skipVersions` list and will display future updates that aren't included in the list.

For testing purposes, the following localStorage key/values have been added:
`latestVersionURL`: URL string that references an alternate latest.json file for testing different payloads
`appVersionOverride`: version string to override the version that the app believes is current