### PR TITLE
Added address book prototype v2

### DIFF
--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -17,3 +17,4 @@ export { default as useSkipMigration } from './useSkipMigration';
 export { default as useTrans } from './useTrans';
 export { default as useValidateChangePassphraseParams } from './useValidateChangePassphraseParams';
 export { default as useWalletThemeColor } from './useWalletThemeColor';
+export { default as useAddressBook } from './useAddressBook';

--- a/packages/core/src/hooks/useAddressBook.tsx
+++ b/packages/core/src/hooks/useAddressBook.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+
+export default function useAddressBook(): [
+  IAddressContact[] | undefined, // contacts
+  (
+    name: string,
+    addresses: IContactAddress[],
+    dids: IContactDID[],
+    notes: string,
+    nftid: string,
+    domainnames: IContactDomainName[]
+  ) => void, // addContact
+  (contactid: number) => void, // removeContact
+  (contactid: number) => IAddressContact | undefined, // getContactContactId
+  (contact: IAddressContact, contactid: number) => void,
+  (address: string) => IAddressContact | undefined // getContactByAddress
+] {
+  // editContact
+  const [addressBook, setAddressBook] = useState<IAddressContact[]>([]);
+  const LOCAL_STORAGE_KEY = 'addressbook';
+  const contactBookJSON = JSON.stringify(addressBook);
+  useEffect(() => {
+    if (localStorage.getItem(LOCAL_STORAGE_KEY) === undefined || localStorage.getItem(LOCAL_STORAGE_KEY) === null) {
+      setAddressBook([]);
+    } else {
+      const addresses: IAddressContact[] = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
+      setAddressBook([...addresses]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (addressBook !== undefined) localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(addressBook));
+  }, [contactBookJSON, addressBook]);
+
+  function getNewContactId(): number {
+    if (addressBook.length === 0 || addressBook === undefined) return 1;
+    return Math.max(...addressBook.map((o) => o.contactid)) + 1;
+  }
+
+  function addContact(
+    name: string,
+    addresses: IContactAddress[],
+    dids: IContactDID[],
+    notes: string,
+    nftid: string,
+    domainnames: IContactDomainName[]
+  ) {
+    const contactid = getNewContactId();
+    const newAddress: IAddressContact = {
+      contactid,
+      name,
+      addresses: [...addresses],
+      dids,
+      notes,
+      nftid,
+      domainnames,
+    };
+
+    setAddressBook([...addressBook, newAddress]);
+  }
+
+  function removeContact(contactId: number) {
+    const filteredContacts = addressBook.filter((contact) => contact.contactid !== contactId);
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(filteredContacts));
+    setAddressBook([...filteredContacts]);
+  }
+
+  function getContactByContactId(contactid: number) {
+    const found = addressBook.find((contact) => contact.contactid === contactid);
+    return found;
+  }
+
+  function editContact(contact: IAddressContact, contactid: number) {
+    const found = addressBook.find((c) => c.contactid === contactid);
+    return found;
+  }
+
+  function getContactByAddress(address: string) {
+    const result = addressBook.find(
+      (ab) => ab.addresses !== undefined && ab.addresses.some((c) => c.address === address)
+    );
+    return result;
+  }
+
+  return [addressBook, addContact, removeContact, getContactByContactId, editContact, getContactByAddress];
+}
+
+interface IAddressContact {
+  contactid: number;
+  name: string;
+  addresses: IContactAddress[];
+  dids: IContactDID[];
+  notes: string;
+  nftid: string;
+  domainnames: IContactDomainName[];
+}
+
+interface IContactAddress {
+  name: string;
+  address: string;
+}
+
+interface IContactDID {
+  did: string;
+}
+
+interface IContactDomainName {
+  domainname: string;
+}

--- a/packages/gui/src/components/addressbook/AddressBook.tsx
+++ b/packages/gui/src/components/addressbook/AddressBook.tsx
@@ -1,0 +1,21 @@
+import { LayoutDashboardSub } from '@chia-network/core';
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+
+import AddressBookSideBar from './AddressBookSideBar';
+import ContactAdd from './ContactAdd';
+import ContactEdit from './ContactEdit';
+import ContactSummary from './ContactSummary';
+
+export default function AddressBook() {
+  return (
+    <Routes>
+      <Route element={<LayoutDashboardSub sidebar={<AddressBookSideBar />} outlet />}>
+        <Route path="/new" element={<ContactAdd />} />
+        <Route path="edit/:contactid" element={<ContactEdit />} />
+        <Route path=":contactid" element={<ContactSummary />} />
+        <Route path="*" element={<div />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/packages/gui/src/components/addressbook/AddressBookMenuItem.tsx
+++ b/packages/gui/src/components/addressbook/AddressBookMenuItem.tsx
@@ -1,0 +1,59 @@
+import { useGetNFTInfoQuery } from '@chia-network/api-react';
+import { IconButton, CardListItem } from '@chia-network/core';
+import { MoreVert } from '@mui/icons-material';
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+
+import { launcherIdFromNFTId } from '../../util/nfts';
+import NFTPreview from '../nfts/NFTPreview';
+
+export default function AddressBookMenuItem({ contact }) {
+  const { contactid } = useParams();
+  const navigate = useNavigate();
+
+  function handleSelectContact(id: number) {
+    navigate(`/dashboard/addressbook/${id}`);
+  }
+  const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
+  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' });
+
+  function getImage() {
+    if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
+
+    return <img height={50} width={50} style={{ backgroundColor: 'grey', color: 'grey' }} />;
+  }
+
+  return (
+    <CardListItem
+      onSelect={() => handleSelectContact(Number(contact.contactid))}
+      key={contact.contactid}
+      selected={Number(contact.contactid) === Number(contactid)}
+      data-testid={`WalletsSidebar-wallet-${contactid}`}
+    >
+      <div
+        style={{
+          display: 'flex',
+          minHeight: '60px',
+          height: '60px',
+          paddingBottom: '10px',
+        }}
+      >
+        <div style={{ paddingLeft: '10px', paddingRight: '10px', flex: 'flex-start' }}>{getImage()}</div>
+        <div style={{ flexGrow: 4, flexBasis: '100', paddingRight: '20px', overflow: 'hidden' }}>
+          <div>
+            <span style={{ fontWeight: 'bold', fontSize: '1.2rem' }}>
+              {contact.name !== '' ? contact.name : 'Unnamed Contact'}
+            </span>
+          </div>
+        </div>
+        <div style={{ justifyContent: 'flex-end' }}>
+          <span style={{ top: '50%', verticalAlign: 'middle' }}>
+            <IconButton>
+              <MoreVert />
+            </IconButton>
+          </span>
+        </div>
+      </div>
+    </CardListItem>
+  );
+}

--- a/packages/gui/src/components/addressbook/AddressBookMenuItem.tsx
+++ b/packages/gui/src/components/addressbook/AddressBookMenuItem.tsx
@@ -1,11 +1,11 @@
-import { useGetNFTInfoQuery } from '@chia-network/api-react';
+// import { useGetNFTInfoQuery } from '@chia-network/api-react';
 import { IconButton, CardListItem } from '@chia-network/core';
 import { MoreVert } from '@mui/icons-material';
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import { launcherIdFromNFTId } from '../../util/nfts';
-import NFTPreview from '../nfts/NFTPreview';
+// import { launcherIdFromNFTId } from '../../util/nfts';
+// import NFTPreview from '../nfts/NFTPreview';
 
 export default function AddressBookMenuItem({ contact }) {
   const { contactid } = useParams();
@@ -14,11 +14,13 @@ export default function AddressBookMenuItem({ contact }) {
   function handleSelectContact(id: number) {
     navigate(`/dashboard/addressbook/${id}`);
   }
-  const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
-  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' });
+
+  // commented out - until this stops throwing an error when not a valid nft
+  // const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
+  // const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' });
 
   function getImage() {
-    if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
+    // if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
 
     return <img height={50} width={50} style={{ backgroundColor: 'grey', color: 'grey' }} />;
   }

--- a/packages/gui/src/components/addressbook/AddressBookProvider.tsx
+++ b/packages/gui/src/components/addressbook/AddressBookProvider.tsx
@@ -1,0 +1,21 @@
+import { useAddressBook } from '@chia-network/core';
+import React, { createContext, useEffect, useMemo } from 'react';
+
+const initialState = {
+  addressBook: [],
+};
+
+export const AddressBookContext = createContext(initialState);
+
+export default function AddressBookProvider({ children }) {
+  const [addressBook, addContact, removeContact, getContactByContactId, editContact, getContactByAddress] =
+    useAddressBook();
+
+  const value = useMemo(
+    () => [addressBook, addContact, removeContact, getContactByContactId, editContact, getContactByAddress],
+    [addressBook, addContact, removeContact, getContactByContactId, editContact, getContactByAddress]
+  );
+
+  useEffect(() => {}, []);
+  return <AddressBookContext.Provider value={value}>{children}</AddressBookContext.Provider>;
+}

--- a/packages/gui/src/components/addressbook/AddressBookSideBar.tsx
+++ b/packages/gui/src/components/addressbook/AddressBookSideBar.tsx
@@ -1,0 +1,114 @@
+import { ButtonLoading, Flex } from '@chia-network/core';
+import type { IAddressContact } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { TextField, Typography } from '@mui/material';
+import React, { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import AddressBookMenuItem from './AddressBookMenuItem';
+import { AddressBookContext } from './AddressBookProvider';
+
+export default function AddressBookSideBar() {
+  const [filter, setFilter] = useState<string>('');
+  const navigate = useNavigate();
+  const [addressBook, ,] = useContext(AddressBookContext);
+
+  // Function that filters a contact by a child property using either
+  // - address.name or address.address
+  // - did
+  // - domain name
+  // - contact name
+  function filterArray(arrayList, search: string) {
+    return arrayList.filter((item: IAddressContact) => {
+      const { dids, domainnames, addresses, name } = item;
+
+      if (search === '') return true;
+
+      // filter by address name or address
+      if (addresses && addresses.length > 0) {
+        const filteredAddressesByName = addresses.filter(
+          (t: any) =>
+            (t.name && t.name.toLowerCase() === search.toLowerCase()) ||
+            (t.address && t.address.toLowerCase() === search.toLowerCase())
+        );
+        if (filteredAddressesByName && filteredAddressesByName.length > 0) {
+          return true;
+        }
+      }
+
+      // filter by did
+      if (dids && dids.length > 0) {
+        const filteredDids = dids.filter((did: any) => did.did && did.did.toLowerCase() === search.toLowerCase());
+        if (filteredDids && filteredDids.length > 0) {
+          return true;
+        }
+      }
+
+      if (domainnames && domainnames.length > 0) {
+        const filteredDomains = domainnames.filter(
+          (domain: any) => domain.domainname && domain.domainname.toLowerCase() === search.toLowerCase()
+        );
+        if (filteredDomains && filteredDomains.length > 0) {
+          return true;
+        }
+      }
+
+      // filter by name
+      if (name.toLowerCase().includes(search.toLowerCase())) {
+        return true;
+      }
+
+      // filter didn't match any criteria
+      return false;
+    });
+  }
+
+  function listOfContacts() {
+    if (addressBook !== undefined) {
+      if (filter === '') {
+        return addressBook.map((contact: IAddressContact) => <AddressBookMenuItem contact={contact} />);
+      }
+
+      const filtered = filterArray(addressBook, filter);
+
+      return filtered.map((contact: IAddressContact) => <AddressBookMenuItem contact={contact} />);
+    }
+    return <div>No Contacts</div>;
+  }
+
+  function handleCreateNewContact() {
+    navigate('/dashboard/addressbook/new');
+  }
+
+  function handleFilterChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setFilter(e.target.value);
+  }
+
+  return (
+    <div style={{ padding: '10px', minWidth: '390px', maxWidth: '500px' }}>
+      <Typography variant="h5">
+        <Trans>Addresses</Trans>
+      </Typography>
+      <Flex flexDirection="column" gap={2.5}>
+        <Flex flexDirection="column" gap={2.5}>
+          <ButtonLoading variant="contained" color="primary" onClick={handleCreateNewContact} disableElevation>
+            <Trans>New Contact</Trans>
+          </ButtonLoading>
+        </Flex>
+        <TextField
+          name="name"
+          variant="filled"
+          color="secondary"
+          fullWidth
+          disabled={false}
+          label={<Trans>Filter</Trans>}
+          data-testid="WalletCATSend-address"
+          onChange={handleFilterChanged}
+        />
+        <Flex flexDirection="column" gap={1.5}>
+          {listOfContacts()}
+        </Flex>
+      </Flex>
+    </div>
+  );
+}

--- a/packages/gui/src/components/addressbook/ContactAdd.tsx
+++ b/packages/gui/src/components/addressbook/ContactAdd.tsx
@@ -1,0 +1,121 @@
+import { ButtonLoading, Form, TextField, Card, TooltipIcon, Flex } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { Typography, Box } from '@mui/material';
+import React, { useContext, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+import { AddressBookContext } from './AddressBookProvider';
+import ContactAddressTable from './ContactAddressTable';
+import ContactDIDSTable from './ContactDIDSTable';
+import ContactDomainNamesTable from './ContactDomainNamesTable';
+
+export default function ContactAdd() {
+  const [, addContact] = useContext(AddressBookContext);
+  const [addresses, setAddresses] = useState([]);
+  const [dids, setDIDS] = useState([]);
+  const [domainNames, setDomainNames] = useState([]);
+  const [name, setName] = useState([]);
+  const navigate = useNavigate();
+
+  const methods = useForm<ContactAddData>({
+    name: '',
+    notes: '',
+    nftid: '',
+  });
+
+  async function handleSubmit(data: ContactAddData) {
+    if (addresses.length === 0) throw new Error('At least one Address must be provided to create contact');
+    if (addresses.name === 0) throw new Error('Name must be provided to create a contact');
+    addContact(data.name, addresses, dids, data.notes, data.nftid, domainNames);
+    navigate(`/dashboard/addressbook/`);
+  }
+
+  return (
+    <Flex flexDirection="column" gap={2.5}>
+      <Typography variant="h6">
+        <Trans>Create Contact</Trans>
+        &nbsp;
+        <TooltipIcon>
+          <Trans>
+            Creating a contact enables you to keep track of people who you know and store information such as their
+            DIDs, Profile NFT or Websites.
+          </Trans>
+        </TooltipIcon>
+      </Typography>
+      <Card>
+        <Form methods={methods} key={0} onSubmit={handleSubmit}>
+          <Flex gap={2} flexDirection="column">
+            <Card title={<Trans>Name</Trans>} titleVariant="h6" transparent>
+              <TextField
+                name="name"
+                variant="filled"
+                color="secondary"
+                fullWidth
+                disabled={false}
+                label={<Trans>Name</Trans>}
+                data-testid="WalletCATSend-address"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </Card>
+
+            <Card title={<Trans>NFT ID</Trans>} titleVariant="h6" transparent>
+              <TextField
+                name="nftid"
+                variant="filled"
+                color="secondary"
+                fullWidth
+                disabled={false}
+                label={<Trans>NFTID</Trans>}
+                data-testid="WalletCATSend-address"
+              />
+            </Card>
+            <Flex justifyContent="flex-end" gap={1}>
+              <ButtonLoading
+                variant="contained"
+                color="primary"
+                type="submit"
+                loading={false}
+                data-testid="WalletSend-send"
+              >
+                <Trans>Create</Trans>
+              </ButtonLoading>
+            </Flex>
+          </Flex>
+        </Form>
+      </Card>
+
+      <Box display="block">
+        <Flex flexDirection="column" gap={4}>
+          <Card title={<Trans>Addresses</Trans>} titleVariant="h6">
+            <ContactAddressTable addresses={addresses} setAddresses={setAddresses} />
+          </Card>
+        </Flex>
+      </Box>
+
+      <Box display="block">
+        <Flex flexDirection="column" gap={4}>
+          <Card title={<Trans>DIDS</Trans>} titleVariant="h6">
+            <ContactDIDSTable dids={dids} setDIDS={setDIDS} />
+          </Card>
+        </Flex>
+      </Box>
+
+      <Box display="block">
+        <Flex flexDirection="column" gap={4}>
+          <Card title={<Trans>Domain Names</Trans>} titleVariant="h6">
+            <ContactDomainNamesTable domainnames={domainNames} setDomainNames={setDomainNames} />
+          </Card>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+}
+
+type ContactAddData = {
+  name: string;
+  notes: string;
+  nftid: string;
+};

--- a/packages/gui/src/components/addressbook/ContactAddressTable.tsx
+++ b/packages/gui/src/components/addressbook/ContactAddressTable.tsx
@@ -1,0 +1,104 @@
+import { Form, Flex, ButtonLoading, TextField, Table } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { Remove } from '@mui/icons-material';
+import { Box, IconButton } from '@mui/material';
+import React, { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+
+function AddressesTable(props) {
+  const cols = useMemo(() => {
+    function removeAddress(data) {
+      props.addresses.splice(data.$uniqueId, 1);
+      props.setAddresses([...props.addresses]);
+    }
+
+    return [
+      {
+        // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+        field: (row: any) => <div>{row.name}</div>,
+        minWidth: '170px',
+        maxWidth: '170px',
+        title: <Trans>Name</Trans>,
+      },
+      {
+        // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+        field: (row: any) => <div>{row.address}</div>,
+        minWidth: '170px',
+        maxWidth: '170px',
+        title: <Trans>Address</Trans>,
+      },
+      {
+        // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+        field: (row: any) => (
+          <Box>
+            <IconButton onClick={() => removeAddress(row)}>
+              <Remove />
+            </IconButton>
+          </Box>
+        ),
+        minWidth: '170px',
+        maxWidth: '170px',
+        title: <Trans>Remove</Trans>,
+      },
+    ];
+  }, [props]);
+
+  return (
+    <Table
+      rows={props.addresses}
+      cols={cols}
+      rowsPerPageOptions={[5, 25, 100]}
+      rowsPerPage={25}
+      pages={5}
+      isLoading={false}
+    />
+  );
+}
+
+export default function ContactAddressTable(props) {
+  function handleSubmit(data: ContactAddressData) {
+    props.addresses.push({ name: data.name, address: data.address });
+    props.setAddresses([...props.addresses]);
+  }
+
+  const methods = useForm<ContactAddressData>({
+    name: '',
+    address: '',
+  });
+
+  return (
+    <div>
+      <Form name="addresses" methods={methods} key={2} onSubmit={handleSubmit}>
+        <Flex justifyContent="flex-stretch" fullWidth gap={1}>
+          <TextField
+            name="name"
+            variant="filled"
+            color="secondary"
+            fullWidth
+            disabled={false}
+            label={<Trans>Name</Trans>}
+            data-testid="WalletCATSend-name"
+          />
+          <TextField
+            name="address"
+            variant="filled"
+            color="secondary"
+            fullWidth
+            disabled={false}
+            label={<Trans>Address</Trans>}
+            data-testid="WalletCATSend-address"
+          />
+          <ButtonLoading variant="contained" color="primary" type="submit" loading={false} data-testid="WalletSend-add">
+            <Trans>Add</Trans>
+          </ButtonLoading>
+        </Flex>
+      </Form>
+      <AddressesTable addresses={props.addresses} setAddresses={props.setAddresses} />
+    </div>
+  );
+}
+
+type ContactAddressData = {
+  name: string;
+  address: string;
+};

--- a/packages/gui/src/components/addressbook/ContactDIDSTable.tsx
+++ b/packages/gui/src/components/addressbook/ContactDIDSTable.tsx
@@ -1,0 +1,83 @@
+import { Flex, ButtonLoading, Form, TextField, Table } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { Remove } from '@mui/icons-material';
+import { Box, IconButton } from '@mui/material';
+import React, { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+
+function DIDSTable(props) {
+  const cols = useMemo(() => {
+    function removeDID(data: any) {
+      props.dids.splice(data.$uniqueId, 1);
+      props.setDIDS([...props.dids]);
+    }
+    return [
+      {
+        // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+        field: (row: any) => <div>{row.did}</div>,
+        minWidth: '170px',
+        maxWidth: '170px',
+        title: <Trans>Status</Trans>,
+      },
+      {
+        // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+        field: (row: any) => (
+          <Box>
+            <IconButton onClick={() => removeDID(row)}>
+              <Remove />
+            </IconButton>
+          </Box>
+        ),
+        minWidth: '170px',
+        maxWidth: '170px',
+        title: <Trans>Remove</Trans>,
+      },
+    ];
+  }, [props]);
+
+  return (
+    <Table
+      rows={props.dids}
+      cols={cols}
+      rowsPerPageOptions={[5, 25, 100]}
+      rowsPerPage={25}
+      pages={5}
+      isLoading={false}
+    />
+  );
+}
+
+export default function ContactDIDSTable(props: any) {
+  const methods = useForm<DIDData>({
+    DID: '',
+  });
+
+  function handleSubmit(data: DIDData) {
+    props.dids.push({ did: data.DID });
+    props.setDIDS([...props.dids]);
+  }
+
+  return (
+    <Form name="addresses" methods={methods} key={2} onSubmit={handleSubmit}>
+      <Flex justifyContent="flex-stretch" fullWidth gap={1}>
+        <TextField
+          name="DID"
+          variant="filled"
+          color="secondary"
+          fullWidth
+          disabled={false}
+          label={<Trans>DID</Trans>}
+          data-testid="WalletCATSend-DID"
+        />
+        <ButtonLoading variant="contained" color="primary" type="submit" loading={false} data-testid="WalletSend-send">
+          <Trans>Add</Trans>
+        </ButtonLoading>
+      </Flex>
+      <DIDSTable dids={props.dids} setDIDS={props.setDIDS} />
+    </Form>
+  );
+}
+
+type DIDData = {
+  DID: string;
+};

--- a/packages/gui/src/components/addressbook/ContactDomainNamesTable.tsx
+++ b/packages/gui/src/components/addressbook/ContactDomainNamesTable.tsx
@@ -1,0 +1,84 @@
+import { Flex, ButtonLoading, Form, TextField, Table } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { Remove } from '@mui/icons-material';
+import { Box, IconButton } from '@mui/material';
+import React, { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+
+function DomainsTable(props) {
+  const cols = useMemo(() => {
+    function removeDomain(data: any) {
+      props.domainnames.splice(data.$uniqueId, 1);
+      props.setDomainNames([...props.domainnames]);
+    }
+
+    return [
+      {
+        // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+        field: (row: any) => <div>{row.domainname}</div>,
+        minWidth: '170px',
+        maxWidth: '170px',
+        title: <Trans>Domain</Trans>,
+      },
+      {
+        // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+        field: (row: any) => (
+          <Box>
+            <IconButton onClick={() => removeDomain(row)}>
+              <Remove />
+            </IconButton>
+          </Box>
+        ),
+        minWidth: '170px',
+        maxWidth: '170px',
+        title: <Trans>Remove</Trans>,
+      },
+    ];
+  }, [props]);
+
+  return (
+    <Table
+      rows={props.domainnames}
+      cols={cols}
+      rowsPerPageOptions={[5, 25, 100]}
+      rowsPerPage={25}
+      pages={5}
+      isLoading={false}
+    />
+  );
+}
+
+export default function ContactDomainNamesTable(props: any) {
+  const methods = useForm<DomainData>({
+    Domain: '',
+  });
+
+  function handleSubmit(data: DomainData) {
+    props.domainnames.push({ domainname: data.Domain });
+    props.setDomainNames([...props.domainnames]);
+  }
+
+  return (
+    <Form name="domainnames" methods={methods} key={2} onSubmit={handleSubmit}>
+      <Flex justifyContent="flex-stretch" fullWidth gap={1}>
+        <TextField
+          name="Domain"
+          variant="filled"
+          color="secondary"
+          fullWidth
+          disabled={false}
+          label={<Trans>Domain</Trans>}
+          data-testid="WalletCATSend-Domain"
+        />
+        <ButtonLoading variant="contained" color="primary" type="submit" loading={false} data-testid="WalletSend-send">
+          <Trans>Add</Trans>
+        </ButtonLoading>
+      </Flex>
+      <DomainsTable domainnames={props.domainnames} setDomainNames={props.setDomainNames} />
+    </Form>
+  );
+}
+
+type DomainData = {
+  Domain: string;
+};

--- a/packages/gui/src/components/addressbook/ContactEdit.tsx
+++ b/packages/gui/src/components/addressbook/ContactEdit.tsx
@@ -1,0 +1,80 @@
+import { useGetNFTInfoQuery } from '@chia-network/api-react';
+import { CopyToClipboard, CardHero, Flex } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { Save, Delete } from '@mui/icons-material';
+import { TextField, InputAdornment, IconButton, Typography } from '@mui/material';
+import React, { useContext } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+
+import { launcherIdFromNFTId } from '../../util/nfts';
+import NFTPreview from '../nfts/NFTPreview';
+import { AddressBookContext } from './AddressBookProvider';
+
+export default function ContactEdit() {
+  const { contactid } = useParams();
+  const navigate = useNavigate();
+  const [, , removeAddress, getContactContactId] = useContext(AddressBookContext);
+  const contact = getContactContactId(Number(contactid));
+
+  const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
+
+  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId });
+
+  function getImage() {
+    if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
+    return <img height={50} width={50} style={{ backgroundColor: 'grey', color: 'grey' }} />;
+  }
+
+  function handleRemove(contactId: number) {
+    removeAddress(contactId);
+    navigate(`/dashboard/addressbook/`);
+  }
+
+  return (
+    <div>
+      <CardHero variant="outlined" style={{ backgroundColor: 'blue' }}>
+        <Flex
+          flexDirection="column"
+          flexGrow={1}
+          alignItems="flex-end"
+          justifyContent="flex-end"
+          style={{ paddingBottom: '1em' }}
+        >
+          <Typography>
+            <IconButton onClick={() => handleRemove(Number(contact.contactid))}>
+              <Delete />
+            </IconButton>
+            <IconButton>
+              <Save />
+            </IconButton>
+          </Typography>
+        </Flex>
+      </CardHero>
+
+      <div style={{ width: '70%', margin: 'auto', marginTop: -40 }}>
+        {getImage()}
+        <h1>
+          <Trans>{contact.name}</Trans>
+        </h1>
+        <TextField label={<Trans>Name</Trans>} value={contact.name} variant="filled" fullWidth />
+        <TextField
+          label={<Trans>Address</Trans>}
+          value={contact.addresses[0]}
+          variant="filled"
+          inputProps={{
+            'data-testid': 'WalletReceiveAddress-address',
+            readOnly: true,
+          }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <CopyToClipboard value={contact.addresses[0]} data-testid="WalletReceiveAddress-address-copy" />
+              </InputAdornment>
+            ),
+          }}
+          fullWidth
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/gui/src/components/addressbook/ContactEdit.tsx
+++ b/packages/gui/src/components/addressbook/ContactEdit.tsx
@@ -1,4 +1,4 @@
-import { useGetNFTInfoQuery } from '@chia-network/api-react';
+// import { useGetNFTInfoQuery } from '@chia-network/api-react';
 import { CopyToClipboard, CardHero, Flex } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { Save, Delete } from '@mui/icons-material';
@@ -6,8 +6,8 @@ import { TextField, InputAdornment, IconButton, Typography } from '@mui/material
 import React, { useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import { launcherIdFromNFTId } from '../../util/nfts';
-import NFTPreview from '../nfts/NFTPreview';
+// import { launcherIdFromNFTId } from '../../util/nfts';
+// import NFTPreview from '../nfts/NFTPreview';
 import { AddressBookContext } from './AddressBookProvider';
 
 export default function ContactEdit() {
@@ -16,12 +16,13 @@ export default function ContactEdit() {
   const [, , removeAddress, getContactContactId] = useContext(AddressBookContext);
   const contact = getContactContactId(Number(contactid));
 
-  const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
+  // commented out - until this stops throwing an error when not a valid nft
+  // const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
 
-  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId });
+  // const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId });
 
   function getImage() {
-    if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
+    // if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
     return <img height={50} width={50} style={{ backgroundColor: 'grey', color: 'grey' }} />;
   }
 

--- a/packages/gui/src/components/addressbook/ContactSummary.tsx
+++ b/packages/gui/src/components/addressbook/ContactSummary.tsx
@@ -1,4 +1,4 @@
-import { useGetNFTInfoQuery } from '@chia-network/api-react';
+// import { useGetNFTInfoQuery } from '@chia-network/api-react';
 import { CopyToClipboard, CardHero, Flex, Card, Table } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { ModeEdit } from '@mui/icons-material';
@@ -6,8 +6,8 @@ import { IconButton, Typography } from '@mui/material';
 import React, { useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import { launcherIdFromNFTId } from '../../util/nfts';
-import NFTPreview from '../nfts/NFTPreview';
+// import { launcherIdFromNFTId } from '../../util/nfts';
+// import NFTPreview from '../nfts/NFTPreview';
 import { AddressBookContext } from './AddressBookProvider';
 
 export default function ContactSummary() {
@@ -16,9 +16,10 @@ export default function ContactSummary() {
   const [, , , getContactContactId] = useContext(AddressBookContext);
   const contact = getContactContactId(Number(contactid));
 
-  const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
+  // commented out - until this stops throwing an error when not a valid nft
+  // const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
 
-  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' });
+  // const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' });
 
   if (contactid === undefined || contact === undefined) return <div />;
 
@@ -27,7 +28,7 @@ export default function ContactSummary() {
   }
 
   function getImage() {
-    if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
+    // if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
     return <img height={50} width={50} style={{ backgroundColor: 'grey', color: 'grey' }} />;
   }
 

--- a/packages/gui/src/components/addressbook/ContactSummary.tsx
+++ b/packages/gui/src/components/addressbook/ContactSummary.tsx
@@ -1,0 +1,169 @@
+import { useGetNFTInfoQuery } from '@chia-network/api-react';
+import { CopyToClipboard, CardHero, Flex, Card, Table } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import { ModeEdit } from '@mui/icons-material';
+import { IconButton, Typography } from '@mui/material';
+import React, { useContext } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+
+import { launcherIdFromNFTId } from '../../util/nfts';
+import NFTPreview from '../nfts/NFTPreview';
+import { AddressBookContext } from './AddressBookProvider';
+
+export default function ContactSummary() {
+  const { contactid } = useParams();
+  const navigate = useNavigate();
+  const [, , , getContactContactId] = useContext(AddressBookContext);
+  const contact = getContactContactId(Number(contactid));
+
+  const launcherId = launcherIdFromNFTId(contact.nftid ?? '');
+
+  const { data: nft } = useGetNFTInfoQuery({ coinId: launcherId ?? '' });
+
+  if (contactid === undefined || contact === undefined) return <div />;
+
+  function handleEditContact(id: number) {
+    navigate(`/dashboard/addressbook/edit/${id}`);
+  }
+
+  function getImage() {
+    if (nft !== undefined) return <NFTPreview nft={nft} height={50} width={50} disableThumbnail />;
+    return <img height={50} width={50} style={{ backgroundColor: 'grey', color: 'grey' }} />;
+  }
+
+  const addressCols = [
+    {
+      // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+      field: (row: any) => <div>{row.name}</div>,
+      minWidth: '170px',
+      maxWidth: '170px',
+      title: <Trans>Name</Trans>,
+    },
+    {
+      // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+      field: (row: any) => <div>{row.address}</div>,
+      minWidth: '170px',
+      maxWidth: '170px',
+      title: <Trans>Address</Trans>,
+    },
+    {
+      // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+      field: (row: any) => (
+        <Flex alignItems="center" gap={1}>
+          <CopyToClipboard value={row.address} fontSize="small" />
+        </Flex>
+      ),
+      minWidth: '170px',
+      maxWidth: '170px',
+      title: <Trans>Action</Trans>,
+    },
+  ];
+
+  const didCols = [
+    {
+      // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+      field: (row: any) => <div>{row.did}</div>,
+      minWidth: '170px',
+      maxWidth: '170px',
+      title: <Trans>DID</Trans>,
+    },
+    {
+      // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+      field: (row: any) => (
+        <Flex alignItems="center" gap={1}>
+          <CopyToClipboard value={row.did} fontSize="small" />
+        </Flex>
+      ),
+      minWidth: '170px',
+      maxWidth: '170px',
+      title: <Trans>Action</Trans>,
+    },
+  ];
+
+  const domainCols = [
+    {
+      // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+      field: (row: any) => <div>{row.domainname}</div>,
+      minWidth: '170px',
+      maxWidth: '170px',
+      title: <Trans>DomainName</Trans>,
+    },
+    {
+      // eslint-disable-next-line react/no-unstable-nested-components -- The result is memoized. No performance issue
+      field: (row: any) => (
+        <Flex alignItems="center" gap={1}>
+          <CopyToClipboard value={row.domainname} fontSize="small" />
+        </Flex>
+      ),
+      minWidth: '170px',
+      maxWidth: '170px',
+      title: <Trans>Action</Trans>,
+    },
+  ];
+
+  return (
+    <div>
+      <CardHero variant="outlined" style={{ backgroundColor: 'blue' }}>
+        <Flex
+          flexDirection="column"
+          flexGrow={1}
+          alignItems="flex-end"
+          justifyContent="flex-end"
+          style={{ paddingBottom: '1em' }}
+        >
+          <Typography>
+            <IconButton onClick={() => handleEditContact(contactid)}>
+              <ModeEdit />
+            </IconButton>
+          </Typography>
+        </Flex>
+      </CardHero>
+
+      <div style={{ width: '95%', margin: 'auto', marginTop: -40 }}>
+        {getImage()}
+        <h1 style={{ display: 'Inline', marginLeft: '10px' }}>
+          <Trans>{contact.name}</Trans>
+        </h1>
+      </div>
+
+      <Flex flexDirection="column" gap={4}>
+        <Flex flexDirection="column" gap={4}>
+          <Card title={<Trans>Addresses</Trans>} titleVariant="h6">
+            <Table
+              rows={contact.addresses}
+              cols={addressCols}
+              rowsPerPageOptions={[5, 25, 100]}
+              rowsPerPage={25}
+              pages={5}
+              isLoading={false}
+            />
+          </Card>
+        </Flex>
+        <Flex flexDirection="column" gap={4}>
+          <Card title={<Trans>DIDS</Trans>} titleVariant="h6">
+            <Table
+              rows={contact.dids}
+              cols={didCols}
+              rowsPerPageOptions={[5, 25, 100]}
+              rowsPerPage={25}
+              pages={5}
+              isLoading={false}
+            />
+          </Card>
+        </Flex>
+        <Flex flexDirection="column" gap={4}>
+          <Card title={<Trans>Domains</Trans>} titleVariant="h6">
+            <Table
+              rows={contact.domainnames}
+              cols={domainCols}
+              rowsPerPageOptions={[5, 25, 100]}
+              rowsPerPage={25}
+              pages={5}
+              isLoading={false}
+            />
+          </Card>
+        </Flex>
+      </Flex>
+    </div>
+  );
+}

--- a/packages/gui/src/components/app/AppProviders.tsx
+++ b/packages/gui/src/components/app/AppProviders.tsx
@@ -21,6 +21,7 @@ import { Outlet } from 'react-router-dom';
 import WebSocket from 'ws';
 
 import { i18n, defaultLocale, locales } from '../../config/locales';
+import AddressBookProvider from '../addressbook/AddressBookProvider';
 import LRUsProvider from '../lrus/LRUsProvider';
 import NFTProvider from '../nfts/provider/NFTProvider';
 import NotificationsProvider from '../notification/NotificationsProvider';
@@ -99,11 +100,13 @@ export default function App(props: AppProps) {
               <NFTProvider>
                 <ModalDialogsProvider>
                   <Suspense fallback={<LayoutLoading />}>
-                    <WalletConnectProvider projectId={WalletConnectChiaProjectId}>
-                      <NotificationsProvider>
-                        <AppState>{outlet ? <Outlet /> : children}</AppState>
-                      </NotificationsProvider>
-                    </WalletConnectProvider>
+                    <AddressBookProvider>
+                      <WalletConnectProvider projectId={WalletConnectChiaProjectId}>
+                        <NotificationsProvider>
+                          <AppState>{outlet ? <Outlet /> : children}</AppState>
+                        </NotificationsProvider>
+                      </WalletConnectProvider>
+                    </AddressBookProvider>
                   </Suspense>
                   <ModalDialogs />
                 </ModalDialogsProvider>

--- a/packages/gui/src/components/app/AppRouter.tsx
+++ b/packages/gui/src/components/app/AppRouter.tsx
@@ -3,6 +3,7 @@ import { WalletAdd, WalletImport, Wallets } from '@chia-network/wallets';
 import React from 'react';
 import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 
+import AddressBook from '../addressbook/AddressBook';
 import Block from '../block/Block';
 import DashboardSideBar from '../dashboard/DashboardSideBar';
 import Farm from '../farm/Farm';
@@ -47,6 +48,7 @@ export default function AppRouter() {
               <Route path="dashboard/nfts/*" element={<NFTs />} />
               <Route path="dashboard/*" element={<Navigate to="wallets" />} />
               <Route path="dashboard/settings/*" element={<Settings />} />
+              <Route path="dashboard/addressbook/*" element={<AddressBook />} />
             </Route>
           ) : (
             <Route
@@ -68,6 +70,7 @@ export default function AppRouter() {
               <Route path="dashboard/plot/*" element={<Plot />} />
               <Route path="dashboard/farm/*" element={<Farm />} />
               <Route path="dashboard/pool/*" element={<Pool />} />
+              <Route path="dashboard/addressbook/*" element={<AddressBook />} />
             </Route>
           )}
         </Route>

--- a/packages/gui/src/components/dashboard/DashboardSideBar.tsx
+++ b/packages/gui/src/components/dashboard/DashboardSideBar.tsx
@@ -8,6 +8,7 @@ import {
   Offers as OffersIcon,
   Tokens as TokensIcon,
   Settings as SettingsIcon,
+  Settings as AddressBookIcon,
 } from '@chia-network/icons';
 import { Trans } from '@lingui/macro';
 import { Box } from '@mui/material';
@@ -62,6 +63,12 @@ export default function DashboardSideBar(props: DashboardSideBarProps) {
           icon={OffersIcon}
           title={<Trans>Offers</Trans>}
           data-testid="DashboardSideBar-offers"
+        />
+        <SideBarItem
+          to="/dashboard/addressbook"
+          icon={AddressBookIcon}
+          title={<Trans>Address Book</Trans>}
+          data-testid="DashboardSideBar-addressbook"
         />
 
         {!simple && (


### PR DESCRIPTION
This is a proposed version of an address book for the chia client that will enable contacts to be added, allow for users to have copy/paste addresses when sending transactions. It also shows a friendly name against a transaction if the transaction comes from a contact in your address book.

This PR is a PoC v2
- Creates contacts and stores them in local storage.
- Allows for Dids, Nft & domains to be associated with a contact.
- Added side menu item for an address book.

<img width="1440" alt="Screenshot 2023-04-21 at 14 52 48" src="https://user-images.githubusercontent.com/23059552/233685790-b0eadb88-fa80-411f-bd1c-b4dfc82e0fac.png">


Outstanding
-  Editing a contact
- Nft preview was causing failures when nftid was not a valid id, so it's commented out temporarily.
- Showing name in transaction history 

(will be re-added shortly).

CC:
@paninaro 