### PR TITLE
fix callers of RTK mutations to pass params properly

### DIFF
--- a/packages/gui/src/components/farm/FarmCloseConnection.tsx
+++ b/packages/gui/src/components/farm/FarmCloseConnection.tsx
@@ -10,7 +10,7 @@ export default function FarmCloseConnection(props: Props): JSX.Element {
   const [closeFarmerConnection] = useCloseFarmerConnectionMutation();
 
   async function handleClose() {
-    await closeFarmerConnection(nodeId).unwrap();
+    await closeFarmerConnection({ nodeId }).unwrap();
   }
 
   return children({

--- a/packages/gui/src/components/nfts/NFTBurnDialog.tsx
+++ b/packages/gui/src/components/nfts/NFTBurnDialog.tsx
@@ -100,7 +100,6 @@ export default function NFTBurnDialog(props: NFTPreviewDialogProps) {
       await transferNFT({
         walletId: nfts[0].walletId,
         nftCoinIds: nfts.map((nft: NFTInfo) => nft.nftCoinId),
-        launcherId: nfts[0].launcherId,
         targetAddress: destination,
         fee: feeInMojos,
       }).unwrap();

--- a/packages/gui/src/components/nfts/NFTContextualActions.tsx
+++ b/packages/gui/src/components/nfts/NFTContextualActions.tsx
@@ -246,7 +246,6 @@ function NFTCancelUnconfirmedTransactionContextualAction(props: NFTCancelUnconfi
     try {
       await setNFTStatus({
         walletId: selectedNft?.walletId,
-        nftLauncherId: removeHexPrefix(selectedNft?.launcherId),
         nftCoinId: removeHexPrefix(selectedNft?.nftCoinId ?? ''),
         inTransaction: false,
       }).unwrap();

--- a/packages/gui/src/components/nfts/NFTMoveToProfileDialog.tsx
+++ b/packages/gui/src/components/nfts/NFTMoveToProfileDialog.tsx
@@ -167,7 +167,6 @@ export function NFTMoveToProfileAction(props: NFTMoveToProfileActionProps) {
       try {
         const { error, data: response } = await setNFTDID({
           walletId: nfts[0].walletId,
-          nftLauncherId: removeHexPrefix(nfts[0].launcherId),
           nftCoinIds: nfts.map((nft) => removeHexPrefix(nft.nftCoinId)),
           did: destinationDID,
           fee: feeInMojos,

--- a/packages/gui/src/components/nfts/NFTTransferAction.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferAction.tsx
@@ -108,7 +108,6 @@ export default function NFTTransferAction(props: NFTTransferActionProps) {
         await transferNFT({
           walletId: nfts[0].walletId,
           nftCoinIds: nfts.map((nft: NFTInfo) => nft.nftCoinId),
-          launcherId: nfts[0].launcherId,
           targetAddress: destinationLocal,
           fee: feeInMojos,
         }).unwrap();

--- a/packages/gui/src/components/offers/NFTOfferEditor.tsx
+++ b/packages/gui/src/components/offers/NFTOfferEditor.tsx
@@ -660,8 +660,8 @@ export default function NFTOfferEditor(props: NFTOfferEditorProps) {
 
     try {
       const response = await createOfferForIds({
-        walletIdsAndAmounts: offer,
-        feeInMojos,
+        offer,
+        fee: feeInMojos,
         driverDict,
         validateOnly: false,
         disableJSONFormatting: true,

--- a/packages/gui/src/components/offers/NFTOfferViewer.tsx
+++ b/packages/gui/src/components/offers/NFTOfferViewer.tsx
@@ -407,7 +407,7 @@ function NFTOfferDetails(props: NFTOfferDetailsProps) {
     let valid = false;
 
     try {
-      const response = await checkOfferValidity(offerData).unwrap();
+      const response = await checkOfferValidity({ offer: offerData }).unwrap();
 
       valid = response.data?.valid === true;
     } catch (e) {

--- a/packages/gui/src/components/offers/OfferEditor.tsx
+++ b/packages/gui/src/components/offers/OfferEditor.tsx
@@ -121,8 +121,9 @@ function OfferEditor(props: OfferEditorProps) {
 
     try {
       const response = await createOfferForIds({
-        walletIdsAndAmounts: offer,
-        feeInMojos,
+        offer,
+        fee: feeInMojos,
+        driverDict: {},
         validateOnly: false,
       }).unwrap();
 

--- a/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
@@ -82,7 +82,7 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
       setIsValid(undefined);
       setIsValidating(true);
 
-      const response = await checkOfferValidity(offerData).unwrap();
+      const response = await checkOfferValidity({ offer: offerData }).unwrap();
       setIsValid(response.valid === true);
     } catch (e) {
       setIsValid(false);

--- a/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
@@ -65,7 +65,7 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
   const offerBuilderRef = useRef<{ submit: () => void; getValues: () => OfferBuilderData } | undefined>(undefined);
 
   const [checkOfferValidity] = useCheckOfferValidityMutation();
-  const [isValidating, setIsValidating] = useState<boolean>(offerData !== undefined);
+  const [isValidating, setIsValidating] = useState<boolean>();
   const [isValid, setIsValid] = useState<boolean | undefined>();
   const isWalletSynced = useIsWalletSynced();
   const openDialog = useOpenDialog();

--- a/packages/wallets/src/components/WalletHistory.tsx
+++ b/packages/wallets/src/components/WalletHistory.tsx
@@ -69,7 +69,7 @@ async function handleRowClick(
 ) {
   if (row.tradeId) {
     try {
-      const { data: response } = await getOfferRecord(row.tradeId);
+      const { data: response } = await getOfferRecord({ offerId: row.tradeId });
       const {
         tradeRecord: { summary },
         success,


### PR DESCRIPTION
The recent refactoring of the RTK queries/mutations missed some updates in the callers of these mutations. Mostly these didn't affect production code, but clicking on an offer txn in WalletHistory was broken as a result of this.