### PR TITLE
fix cat_spend to use 'inner_address' instead of 'address'

### DIFF
--- a/packages/api/src/wallets/CAT.ts
+++ b/packages/api/src/wallets/CAT.ts
@@ -50,11 +50,17 @@ export default class CATWallet extends Wallet {
     }>('cat_set_name', args);
   }
 
-  async spend(args: { walletId: number; innerAddress: string; amount: string; fee: string; memos?: string[] }) {
+  async spend(args: { walletId: number; address: string; amount: string; fee: string; memos?: string[] }) {
+    const { address, ...updatedArgs } = args;
+    // cat_spend expects 'inner_address' instead of 'address'
+    if (!(updatedArgs as any).innerAddress) {
+      (updatedArgs as any).innerAddress = address;
+    }
+
     return this.command<{
       transaction: Transaction;
       transactionId: string;
-    }>('cat_spend', args);
+    }>('cat_spend', updatedArgs);
   }
 
   async getCatList() {


### PR DESCRIPTION
This affected both sending a CAT from WalletCATSend as well as WalletConnect.

The reason I left the interface as-is is to prevent changing the WalletConnect interface. If we were to rename the address key to `innerAddress` in the RTK query, the callers would need to be updated (no big deal), but this would break existing WalletConnect Dapps that expect to use `address`