### PR TITLE
Fix refetching plots after new plot is finished plotting

### DIFF
--- a/packages/gui/src/components/plot/PlotPlotting.tsx
+++ b/packages/gui/src/components/plot/PlotPlotting.tsx
@@ -1,8 +1,8 @@
-import { useGetThrottlePlotQueueQuery, useRefreshPlotsMutation } from '@chia-network/api-react';
+import { useGetThrottlePlotQueueQuery } from '@chia-network/api-react';
 import { Card, Table } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { TableRow } from '@mui/material';
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
 import PlotQueueActions from './queue/PlotQueueActions';
@@ -34,18 +34,8 @@ const cols = [
 
 export default function PlotPlotting() {
   const { isLoading, queue } = useGetThrottlePlotQueueQuery();
-  const [refreshPlots] = useRefreshPlotsMutation();
 
   const nonFinished = useMemo(() => queue?.filter((item) => item.state !== 'FINISHED'), [queue]);
-  const finished = useMemo(() => queue?.filter((item) => item.state === 'FINISHED'), [queue]);
-
-  const finishedLength = finished?.length || 0;
-
-  useEffect(() => {
-    if (finishedLength > 0) {
-      refreshPlots().unwrap();
-    }
-  }, [finishedLength, refreshPlots]);
 
   if (isLoading || !nonFinished?.length) {
     return null;

--- a/packages/gui/src/components/plot/PlotPlotting.tsx
+++ b/packages/gui/src/components/plot/PlotPlotting.tsx
@@ -1,8 +1,8 @@
-import { useGetThrottlePlotQueueQuery } from '@chia-network/api-react';
+import { useGetThrottlePlotQueueQuery, useRefreshPlotsMutation } from '@chia-network/api-react';
 import { Card, Table } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { TableRow } from '@mui/material';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 
 import PlotQueueActions from './queue/PlotQueueActions';
@@ -34,8 +34,18 @@ const cols = [
 
 export default function PlotPlotting() {
   const { isLoading, queue } = useGetThrottlePlotQueueQuery();
+  const [refreshPlots] = useRefreshPlotsMutation();
 
   const nonFinished = useMemo(() => queue?.filter((item) => item.state !== 'FINISHED'), [queue]);
+  const finished = useMemo(() => queue?.filter((item) => item.state === 'FINISHED'), [queue]);
+
+  const finishedLength = finished?.length || 0;
+
+  useEffect(() => {
+    if (finishedLength > 0) {
+      refreshPlots().unwrap();
+    }
+  }, [finishedLength, refreshPlots]);
 
   if (isLoading || !nonFinished?.length) {
     return null;


### PR DESCRIPTION
fixes: https://github.com/Chia-Network/chia-blockchain-gui/issues/1728

What other solutions were considered:

1. Have the logic of clearing cache directly in the api-react
-> spend hours on it, could not make it work. Queries should not clear caches, mutations should...

2. Have the logic of clearing cache in useGetThrottlePlotQueueQuery
-> might be a better place, but this is obvious for the developer that some cache cleaning is happening. I can move it to useGetThrottlePlotQueueQuery if someone thinks its a better place.

Thank you