### PR TITLE
use tmpdir value for tmpdir2 if not specified to fix madmax plotting

### DIFF
--- a/packages/gui/src/components/plot/add/PlotAddForm.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddForm.tsx
@@ -111,7 +111,15 @@ export default function PlotAddForm(props: Props) {
   const handleSubmit: SubmitHandler<FormData> = async (data) => {
     try {
       setLoading(true);
-      const { p2SingletonPuzzleHash, delay, createNFT, ...rest } = data;
+      const {
+        p2SingletonPuzzleHash,
+        delay,
+        createNFT,
+        plotterName: formPlotterName,
+        workspaceLocation,
+        workspaceLocation2,
+        ...rest
+      } = data;
       const { farmerPublicKey, poolPublicKey, plotNFTContractAddr } = rest;
 
       let selectedP2SingletonPuzzleHash = p2SingletonPuzzleHash;
@@ -150,6 +158,9 @@ export default function PlotAddForm(props: Props) {
       const plotAddConfig = {
         ...rest,
         delay: delay * 60,
+        plotterName: formPlotterName,
+        workspaceLocation,
+        workspaceLocation2: formPlotterName === 'madmax' ? workspaceLocation2 || workspaceLocation : workspaceLocation2,
       };
 
       if (!selectedP2SingletonPuzzleHash && plotNFTContractAddr) {


### PR DESCRIPTION
Plotting with madmax broke at some point due to tmpdir2 being specified as an empty string when plotting from the GUI. This patch will use the tmpdir value for tmpdir2 if plotting with madmax, and tmpdir2 isn't specified.