### PR TITLE
adds the WalletConnect command getNFTWalletsWithDIDs to return a listing of NFT wallets that have an associated DID that the user possesses

### DIFF
--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -696,6 +696,12 @@ const walletConnectCommands: WalletConnectCommand[] = [
       },
     ],
   },
+  {
+    command: 'getNFTWalletsWithDIDs',
+    label: <Trans>Get NFT Wallets with DIDs</Trans>,
+    service: ServiceName.WALLET,
+    bypassConfirm: true,
+  },
 ];
 
 export default walletConnectCommands;


### PR DESCRIPTION
Without this, it's not possible to get an accurate listing of DIDs owned by the user from WalletConnect