### PR TITLE
fix loading of some audio NFTs

### DIFF
--- a/packages/gui/src/components/nfts/NFTProperties.tsx
+++ b/packages/gui/src/components/nfts/NFTProperties.tsx
@@ -38,7 +38,7 @@ export function NFTProperty(props: NFTPropertyProps) {
   const theme = useTheme();
   // eslint-disable-next-line @typescript-eslint/naming-convention -- Comes from API like this
   const { name, trait_type, value: rawValue } = attribute;
-  if (typeof rawValue === 'object') {
+  if (typeof rawValue === 'object' || typeof rawValue === 'undefined') {
     return null;
   }
   const value = rawValue.toString();


### PR DESCRIPTION
On behalf of @dkackman:
For an audio NFT (or at least the one indicated in the #1786)

rawValue on line 44 of \chia-blockchain-gui\packages\gui\src\components\nfts\NFTProperties.tsx can be undefined. Added a simple check alongside where typeof object is checked and return null. Haven't seen downstream consequences and the nft detail page now opens without error.

value on that line could also be set to an empty string or other default but I don't know enough about the code to know what is the best approach so deiced an early bail out, since it already is in there, was safest.