### PR TITLE
replace isURL usage with isValidURL

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -70,6 +70,7 @@
         "@types/react": "17.0.38",
         "@types/react-dom": "17.0.11",
         "@types/react-router-dom": "5.3.2",
+        "@types/validator": "13.7.17",
         "@vitejs/plugin-react": "2.1.0",
         "babel-plugin-macros": "3.1.0",
         "babel-plugin-styled-components": "2.0.2",
@@ -4493,6 +4494,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -14932,6 +14939,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/validator": {
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -34,7 +34,8 @@
         "react-use-timeout": "1.0.0",
         "sortablejs": "1.15.0",
         "stacktrace-gps": "3.0.4",
-        "stacktrace-js": "2.0.2"
+        "stacktrace-js": "2.0.2",
+        "validator": "13.9.0"
       },
       "devDependencies": {
         "@babel/core": "7.21.0",
@@ -11514,6 +11515,14 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vite": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.1.tgz",
@@ -20056,6 +20065,11 @@
         "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^1.6.0"
       }
+    },
+    "validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "vite": {
       "version": "3.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,8 @@
     "react-use-timeout": "1.0.0",
     "sortablejs": "1.15.0",
     "stacktrace-gps": "3.0.4",
-    "stacktrace-js": "2.0.2"
+    "stacktrace-js": "2.0.2",
+    "validator": "13.9.0"
   },
   "devDependencies": {
     "@babel/core": "7.21.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,6 +87,7 @@
     "@types/react": "17.0.38",
     "@types/react-dom": "17.0.11",
     "@types/react-router-dom": "5.3.2",
+    "@types/validator": "13.7.17",
     "@vitejs/plugin-react": "2.1.0",
     "babel-plugin-macros": "3.1.0",
     "babel-plugin-styled-components": "2.0.2",

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,3 +17,4 @@ export { default as sleep } from './sleep';
 export { default as useColorModeValue } from './useColorModeValue';
 export { default as validAddress } from './validAddress';
 export { default as LRU, lruCreate } from './lru';
+export { default as isValidURL } from './isValidURL';

--- a/packages/core/src/utils/isValidURL.test.ts
+++ b/packages/core/src/utils/isValidURL.test.ts
@@ -1,0 +1,61 @@
+import isValidURL from './isValidURL';
+
+describe('isValidURL', () => {
+  test('returns true for a valid URL', () => {
+    const url = 'https://example.com';
+    expect(isValidURL(url)).toBe(true);
+  });
+
+  test('returns true for a valid URL with an encoded space', () => {
+    const url = 'https://example.com/foo%20bar';
+    expect(isValidURL(url)).toBe(true);
+  });
+
+  test('returns true for a valid URL with an unencoded space', () => {
+    const url = 'https://example.com/foo bar';
+    expect(isValidURL(url)).toBe(true);
+  });
+
+  test('returns false for an invalid URL', () => {
+    const url = 'not a valid URL';
+    expect(isValidURL(url)).toBe(false);
+  });
+
+  test('returns false for an invalid URL that throws when decoded', () => {
+    const url = 'https://example.com/%2';
+    expect(isValidURL(url)).toBe(false);
+  });
+
+  test('returns false for a URL with an invalid hostname', () => {
+    const url = 'https://example';
+    expect(isValidURL(url)).toBe(false);
+  });
+
+  test('returns false for a URL with an invalid port', () => {
+    const url = 'https://example.com:abc';
+    expect(isValidURL(url)).toBe(false);
+  });
+
+  test('returns true for a valid URL with options', () => {
+    const url = 'https://example.com';
+    const options = {
+      protocols: ['https'],
+      require_tld: true,
+      require_protocol: true,
+      require_host: true,
+      require_valid_protocol: true,
+      allow_underscores: false,
+      allow_trailing_dot: false,
+      allow_protocol_relative_urls: false,
+    };
+    expect(isValidURL(url, options)).toBe(true);
+  });
+
+  test('returns false for a URL with an invalid protocol', () => {
+    const url = 'https://example.com';
+    const options = {
+      protocols: ['ftp'],
+    };
+    expect(isValidURL(url, options)).toBe(false);
+  });
+});

--- a/packages/core/src/utils/isValidURL.test.ts
+++ b/packages/core/src/utils/isValidURL.test.ts
@@ -21,11 +21,6 @@ describe('isValidURL', () => {
     expect(isValidURL(url)).toBe(false);
   });
 
-  test('returns false for an invalid URL that throws when decoded', () => {
-    const url = 'https://example.com/%2';
-    expect(isValidURL(url)).toBe(false);
-  });
-
   test('returns false for a URL with an invalid hostname', () => {
     const url = 'https://example';
     expect(isValidURL(url)).toBe(false);
@@ -57,5 +52,19 @@ describe('isValidURL', () => {
       protocols: ['ftp'],
     };
     expect(isValidURL(url, options)).toBe(false);
+  });
+
+  test('returns false if decoding fails and URL is invalid', () => {
+    // mock decodeURI to throw an error
+    const { decodeURI } = global;
+    global.decodeURI = () => {
+      throw new Error('mock error');
+    };
+
+    const url = 'https://example.com/foo bar';
+    expect(isValidURL(url)).toBe(false);
+
+    // restore decodeURI
+    global.decodeURI = decodeURI;
   });
 });

--- a/packages/core/src/utils/isValidURL.ts
+++ b/packages/core/src/utils/isValidURL.ts
@@ -12,13 +12,10 @@ function isValidURL(url: string, options?: IsURLOptions): boolean {
     normalizedURL = decodeURI(url) === url ? encodeURI(url) : url;
   } catch (e) {
     // URL wasn't properly encoded
+    return isURL(url, options);
   }
 
-  if (normalizedURL) {
-    return isURL(normalizedURL, options);
-  }
-
-  return false;
+  return isURL(normalizedURL, options);
 }
 
 export default isValidURL;

--- a/packages/core/src/utils/isValidURL.ts
+++ b/packages/core/src/utils/isValidURL.ts
@@ -1,0 +1,24 @@
+import isURL from 'validator/lib/isURL';
+import type { IsURLOptions } from 'validator/lib/isURL';
+
+function isValidURL(url: string, options?: IsURLOptions): boolean {
+  let normalizedURL;
+
+  try {
+    // isURL returns false for URLs with unencoded spaces. We can't use
+    // encodeURI if the URL is already encoded, so we attempt to decode
+    // the URL first and then encode it if it wasn't already encoded.
+
+    normalizedURL = decodeURI(url) === url ? encodeURI(url) : url;
+  } catch (e) {
+    // URL wasn't properly encoded
+  }
+
+  if (normalizedURL) {
+    return isURL(normalizedURL, options);
+  }
+
+  return false;
+}
+
+export default isValidURL;

--- a/packages/gui/package-lock.json
+++ b/packages/gui/package-lock.json
@@ -61,7 +61,7 @@
         "stream-browserify": "3.0.0",
         "styled-components": "5.3.3",
         "unique-names-generator": "4.6.0",
-        "validator": "13.7.0",
+        "validator": "13.9.0",
         "victory": "^36.6.6",
         "ws": "8.4.2"
       },
@@ -15439,8 +15439,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "license": "MIT",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -26250,7 +26251,9 @@
       }
     },
     "validator": {
-      "version": "13.7.0"
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/packages/gui/package-lock.json
+++ b/packages/gui/package-lock.json
@@ -89,7 +89,7 @@
         "@types/react-router-dom": "5.3.2",
         "@types/seedrandom": "3.0.1",
         "@types/styled-components": "5.1.20",
-        "@types/validator": "13.7.1",
+        "@types/validator": "13.7.17",
         "@walletconnect/types": "2.6.0",
         "@welldone-software/why-did-you-render": "7.0.1",
         "babel-core": "7.0.0-bridge.0",
@@ -4892,9 +4892,10 @@
       }
     },
     "node_modules/@types/validator": {
-      "version": "13.7.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -19273,7 +19274,9 @@
       }
     },
     "@types/validator": {
-      "version": "13.7.1",
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
       "dev": true
     },
     "@types/ws": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -229,7 +229,7 @@
     "@types/react-router-dom": "5.3.2",
     "@types/seedrandom": "3.0.1",
     "@types/styled-components": "5.1.20",
-    "@types/validator": "13.7.1",
+    "@types/validator": "13.7.17",
     "@walletconnect/types": "2.6.0",
     "@welldone-software/why-did-you-render": "7.0.1",
     "babel-core": "7.0.0-bridge.0",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -201,7 +201,7 @@
     "stream-browserify": "3.0.0",
     "styled-components": "5.3.3",
     "unique-names-generator": "4.6.0",
-    "validator": "13.7.0",
+    "validator": "13.9.0",
     "victory": "^36.6.6",
     "ws": "8.4.2"
   },

--- a/packages/gui/src/components/nfts/NFTContextualActions.tsx
+++ b/packages/gui/src/components/nfts/NFTContextualActions.tsx
@@ -2,7 +2,7 @@
 
 import type { NFTInfo } from '@chia-network/api';
 import { useSetNFTStatusMutation, useLocalStorage } from '@chia-network/api-react';
-import { AlertDialog, DropdownActions, MenuItem, useOpenDialog } from '@chia-network/core';
+import { AlertDialog, DropdownActions, MenuItem, useOpenDialog, isValidURL } from '@chia-network/core';
 import {
   Burn as BurnIcon,
   LinkSmall as LinkSmallIcon,
@@ -24,7 +24,6 @@ import { ListItemIcon, Typography } from '@mui/material';
 import React, { useMemo, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useCopyToClipboard } from 'react-use';
-import isURL from 'validator/lib/isURL';
 
 import useBurnAddress from '../../hooks/useBurnAddress';
 import useHiddenNFTs from '../../hooks/useHiddenNFTs';
@@ -297,7 +296,7 @@ function NFTOpenInBrowserContextualAction(props: NFTOpenInBrowserContextualActio
       return false;
     }
 
-    return isURL(dataUrl);
+    return isValidURL(dataUrl);
   }, [dataUrl]);
   const disabled = !haveDataUrl || !isUrlValid;
 

--- a/packages/gui/src/components/nfts/NFTHashStatus.tsx
+++ b/packages/gui/src/components/nfts/NFTHashStatus.tsx
@@ -1,11 +1,10 @@
-import { Tooltip } from '@chia-network/core';
+import { Tooltip, isValidURL } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import { Chip, Typography } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import React, { useMemo } from 'react';
-import isURL from 'validator/lib/isURL';
 
 import useNFT from '../../hooks/useNFT';
 import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
@@ -39,7 +38,7 @@ export default function NFTHashStatus(props: NFTHashStatusProps) {
     }
 
     if (nftPreview.uri) {
-      return isURL(nftPreview.uri);
+      return isValidURL(nftPreview.uri);
     }
 
     return false;

--- a/packages/gui/src/components/offers2/OffersProvider.tsx
+++ b/packages/gui/src/components/offers2/OffersProvider.tsx
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
 
 import { useGetOfferSummaryMutation, useCheckOfferValidityMutation } from '@chia-network/api-react';
+import { isValidURL } from '@chia-network/core';
 import debug from 'debug';
 import React, { useState, createContext, useMemo, useCallback, type ReactNode } from 'react';
-import isURL from 'validator/lib/isURL';
 
 import type Offer from '../../@types/Offer';
 import type OfferOnDemand from '../../@types/OfferOnDemand';
@@ -71,7 +71,7 @@ export default function OffersProvider(props: OffersProviderProps) {
   // immutable function
   const prepareOfferData = useCallback(
     async (urlOrOfferData: string) => {
-      if (!isURL(urlOrOfferData)) {
+      if (!isValidURL(urlOrOfferData)) {
         return urlOrOfferData;
       }
 

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -305,8 +305,15 @@ export default class CacheManager extends EventEmitter {
 
     const process = async (): Promise<CacheInfo> => {
       try {
-        if (!isURL(url)) {
-          throw new Error(`Invalid URL: ${url}`);
+        // From isValidURL.ts
+        // isURL returns false for URLs with unencoded spaces. We can't use
+        // encodeURI if the URL is already encoded, so we attempt to decode
+        // the URL first and then encode it if it wasn't already encoded.
+
+        const normalizedURL = decodeURI(url) === url ? encodeURI(url) : url;
+
+        if (!isURL(normalizedURL)) {
+          throw new Error(`Invalid URL: ${normalizedURL}`);
         }
 
         const cacheInfo = await this.getCacheInfoByURL(url);

--- a/packages/gui/src/hooks/usePoolInfo.ts
+++ b/packages/gui/src/hooks/usePoolInfo.ts
@@ -1,6 +1,6 @@
+import { isValidURL } from '@chia-network/core';
 import { t } from '@lingui/macro';
 import { useAsync } from 'react-use';
-import isURL from 'validator/es/lib/isURL';
 
 import type PoolInfo from '../types/PoolInfo';
 import getPoolInfo from '../util/getPoolInfo';
@@ -33,7 +33,7 @@ export default function usePoolInfo(poolUrl?: string): {
     }
 
     const normalizedUrl = normalizeUrl(poolUrl);
-    const isValidUrl = isURL(normalizedUrl, isUrlOptions);
+    const isValidUrl = isValidURL(normalizedUrl, isUrlOptions);
 
     if (!isValidUrl) {
       if (isMainnet && !normalizedUrl.startsWith('https:')) {

--- a/packages/gui/src/util/fetchOffer.ts
+++ b/packages/gui/src/util/fetchOffer.ts
@@ -1,5 +1,5 @@
 import { store, walletApi } from '@chia-network/api-react';
-import isURL from 'validator/lib/isURL';
+import { isValidURL } from '@chia-network/core';
 
 import OfferServices from '../constants/OfferServices';
 import offerToOfferBuilderData from './offerToOfferBuilderData';
@@ -12,7 +12,7 @@ type FetchOfferParams = {
 };
 
 export default async function fetchOffer({ offerUrl, getContent, getHeaders }: FetchOfferParams) {
-  if (!offerUrl || !isURL(offerUrl)) {
+  if (!offerUrl || !isValidURL(offerUrl)) {
     throw new Error(`URL is not valid: ${offerUrl}`);
   }
 

--- a/packages/wallets/package-lock.json
+++ b/packages/wallets/package-lock.json
@@ -59,6 +59,7 @@
         "@types/react": "17.0.38",
         "@types/react-dom": "17.0.11",
         "@types/react-router-dom": "5.3.2",
+        "@types/validator": "13.7.17",
         "babel-plugin-macros": "3.1.0",
         "babel-plugin-styled-components": "2.0.2",
         "babel-plugin-transform-imports": "2.0.0",
@@ -4030,6 +4031,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -13719,6 +13726,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/validator": {
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/packages/wallets/package-lock.json
+++ b/packages/wallets/package-lock.json
@@ -28,7 +28,7 @@
         "react-use": "17.3.2",
         "react-use-timeout": "1.0.0",
         "use-dark-mode": "2.3.1",
-        "validator": "13.7.0",
+        "validator": "13.9.0",
         "victory": "36.6.6"
       },
       "devDependencies": {
@@ -10199,9 +10199,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -18313,9 +18313,9 @@
       }
     },
     "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "victory": {
       "version": "36.6.6",

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -44,7 +44,7 @@
     "react-use": "17.3.2",
     "react-use-timeout": "1.0.0",
     "use-dark-mode": "2.3.1",
-    "validator": "13.7.0",
+    "validator": "13.9.0",
     "victory": "36.6.6"
   },
   "devDependencies": {

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -76,6 +76,7 @@
     "@types/react": "17.0.38",
     "@types/react-dom": "17.0.11",
     "@types/react-router-dom": "5.3.2",
+    "@types/validator": "13.7.17",
     "babel-plugin-macros": "3.1.0",
     "babel-plugin-styled-components": "2.0.2",
     "babel-plugin-transform-imports": "2.0.0",


### PR DESCRIPTION
Some NFTs have content URLs containing unencoded spaces. While most of the code handles this without any trouble, the isURL function from the validator library will return false, causing these NFTs to fail to load.

This change introduces an `isValidURL` function that will encode URLs if necessary and then return the result of `isURL(encodedURL)`.

Tested with NFTs that have encoded and unencoded spaces.