### PR TITLE
fix WC transferNFT params -- use nftCoinIDs array

### DIFF
--- a/packages/gui/src/@types/WalletConnectCommandParamName.ts
+++ b/packages/gui/src/@types/WalletConnectCommandParamName.ts
@@ -30,7 +30,6 @@ enum WalletConnectCommandParamName {
   NEW_ADDRESS = 'newAddress',
   NEW_PROOF_HASH = 'newProofHash',
   NEW_PUZHASH = 'newPuzhash',
-  NFT_COIN_ID = 'nftCoinId',
   NFT_COIN_IDS = 'nftCoinIds',
   NFT_LAUNCHER_ID = 'nftLauncherId',
   NUM = 'num',

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -665,14 +665,9 @@ const walletConnectCommands: WalletConnectCommand[] = [
         type: 'number',
       },
       {
-        name: WalletConnectCommandParamName.NFT_COIN_ID,
-        label: <Trans>NFT Coin Id</Trans>,
-        type: 'string',
-      },
-      {
-        name: WalletConnectCommandParamName.LAUNCHER_ID,
-        label: <Trans>Launcher Id</Trans>,
-        type: 'string',
+        name: WalletConnectCommandParamName.NFT_COIN_IDS,
+        label: <Trans>NFT Coin Ids</Trans>,
+        type: 'object',
       },
       {
         name: WalletConnectCommandParamName.TARGET_ADDRESS,


### PR DESCRIPTION
Replaces `NFT_COIN_ID` with `NFT_COIN_IDS` string array to match transferNft RPC hook.
Removes unused `LAUNCHER_ID` from transferNFT.
Removes unused `NFT_COIN_ID` from available params.
