### PR TITLE
use public k8s runners

### DIFF
--- a/.github/workflows/sync-crowdin.yml
+++ b/.github/workflows/sync-crowdin.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   synchronize-with-crowdin:
-    runs-on: [k8s-internal]
+    runs-on: [k8s-public]
     container: python:3.9.7
     steps:
       - name: Checkout


### PR DESCRIPTION
Use public runners for this workflow