### PR TITLE
Updated harvester setting page

### DIFF
--- a/packages/gui/src/components/settings/SettingsHarvester.tsx
+++ b/packages/gui/src/components/settings/SettingsHarvester.tsx
@@ -289,7 +289,8 @@ export default function SettingsHarvester() {
   }, [configUpdateRequests, data, isLoading]);
 
   const restartButton = React.useMemo(() => {
-    if (!isRestartRequired) {
+    // Show restart button when restarting harvester
+    if (!isRestartRequired && !(isStarting || isStopping || isUpdating)) {
       return null;
     }
     return (
@@ -315,7 +316,7 @@ export default function SettingsHarvester() {
         </Grid>
       </Grid>
     );
-  }, [data, isLoading, onClickRestartHarvester, isProcessing, isRestartRequired]);
+  }, [data, isLoading, onClickRestartHarvester, isProcessing, isRestartRequired, isStarting, isStopping, isUpdating]);
 
   return (
     <Grid container style={{ maxWidth: '624px' }} gap={3}>


### PR DESCRIPTION
## Change note
Added "Enable compressed plot support" switch.
After this switch is turned on, `parallel_decompressor_count` is set to `1`.
When it is turned off,  `parallel_decompressor_count` is set to `0` and hide other options for plot compression.

### When "Enable compressed plot support" is turned on
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/714bbe8c-84e1-475b-8137-c97832979c58)

### When "Enable compressed plot support" is turned off
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/a8ca15a9-4062-40d8-be85-42833ca31915)
