### PR TITLE
Hide clawback TXs while wallet is syncing

### DIFF
--- a/packages/wallets/src/components/ClawbackClaimTransactionDialog.tsx
+++ b/packages/wallets/src/components/ClawbackClaimTransactionDialog.tsx
@@ -83,11 +83,12 @@ export default function ClawbackClaimTransactionDialog(props: Props) {
     pollingInterval: 10_000,
   });
   const isSyncing = isWalletSyncLoading || !!walletState?.syncing;
+  const isSynced = !isSyncing && walletState?.synced;
 
   const { isSubmitting } = methods.formState;
 
   // The fee from EstimatedFee is a string
-  const canSubmit = !isSyncing && !isSubmitting && !isGetAutoClaimLoading && feeValue !== '';
+  const canSubmit = isSynced && !isSubmitting && !isGetAutoClaimLoading && feeValue !== '';
 
   function handleClose() {
     methods.reset();
@@ -195,7 +196,7 @@ export default function ClawbackClaimTransactionDialog(props: Props) {
                 </Alert>
               )}
 
-              {isSyncing && (
+              {!isSynced && (
                 <Alert severity="info" sx={{ marginBottom: 3 }}>
                   <Trans>Wallet needs to be synced for claiming clawback transactions</Trans>
                 </Alert>

--- a/packages/wallets/src/components/WalletHistory.tsx
+++ b/packages/wallets/src/components/WalletHistory.tsx
@@ -286,6 +286,7 @@ export default function WalletHistory(props: Props) {
 
   const isLoading = isWalletTransactionsLoading || isWalletLoading;
   const isSyncing = isWalletSyncLoading || !walletState || !!walletState?.syncing;
+  const isSynced = !isSyncing && walletState?.synced;
 
   const [clawbackClaimTransactionDialogProps, setClawbackClaimTransactionDialogProps] = React.useState<{
     coinId: string;
@@ -446,16 +447,17 @@ export default function WalletHistory(props: Props) {
   );
 
   const ExtraRowsAfterHeader = useMemo(
-    () => (
-      <WalletHistoryPending
-        walletId={walletId}
-        cols={cols}
-        metadata={metadata}
-        expandedField={expandedField}
-        expandedCellShift={1}
-      />
-    ),
-    [cols, expandedField, metadata, walletId]
+    () =>
+      isSynced && (
+        <WalletHistoryPending
+          walletId={walletId}
+          cols={cols}
+          metadata={metadata}
+          expandedField={expandedField}
+          expandedCellShift={1}
+        />
+      ),
+    [cols, expandedField, metadata, walletId, isSynced]
   );
 
   return (


### PR DESCRIPTION
I liked the Jeff's idea of hiding clawback TX while syncing.

I did it but it was still flickering. So I switched from isSyncing to isSynced and now it behaves much better, without flickering back&forth.