### PR TITLE
Fixed add plot page

### DIFF
--- a/packages/gui/src/components/plot/add/PlotAddChooseKeys.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseKeys.tsx
@@ -1,8 +1,8 @@
 import { toBech32m } from '@chia-network/api';
 import { useGetKeysForPlottingQuery } from '@chia-network/api-react';
-import { CardStep, TextField, Button } from '@chia-network/core';
+import { CardStep, TextField, Button, Checkbox } from '@chia-network/core';
 import { Trans, t } from '@lingui/macro';
-import { Grid, FormControl, Typography, Switch, FormControlLabel, ButtonGroup } from '@mui/material';
+import { Grid, FormControl, Typography, FormControlLabel, ButtonGroup } from '@mui/material';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -150,8 +150,7 @@ export default function PlotAddChooseKeys(props: Props) {
       </Typography>
       <FormControl variant="filled" fullWidth>
         <FormControlLabel
-          name="useManualKeySetup"
-          control={<Switch checked={manualSetup} onChange={onChangeSetupKeys} />}
+          control={<Checkbox name="useManualKeySetup" checked={manualSetup} onChange={onChangeSetupKeys} />}
           label={<Trans>Set up keys manually</Trans>}
         />
       </FormControl>

--- a/packages/gui/src/components/plot/add/PlotAddForm.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddForm.tsx
@@ -89,7 +89,7 @@ export default function PlotAddForm(props: Props) {
     defaultValues: defaultsForPlotter(PlotterName.BLADEBIT_DISK),
   });
 
-  const { watch, setValue, reset } = methods;
+  const { watch, setValue, reset, getValues } = methods;
   const plotterName = watch('plotterName') as PlotterName;
   const plotSize = watch('plotSize');
 
@@ -105,7 +105,14 @@ export default function PlotAddForm(props: Props) {
 
   const handlePlotterChanged = (newPlotterName: PlotterName) => {
     const defaults = defaultsForPlotter(newPlotterName);
-    reset(defaults);
+    const formValues = getValues();
+    reset({
+      ...defaults,
+      farmerPublicKey: formValues.farmerPublicKey,
+      p2SingletonPuzzleHash: formValues.p2SingletonPuzzleHash,
+      plotNFTContractAddr: formValues.plotNFTContractAddr,
+      poolPublicKey: formValues.poolPublicKey,
+    });
   };
 
   const handleSubmit: SubmitHandler<FormData> = async (data) => {

--- a/packages/gui/src/components/plot/add/PlotAddForm.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddForm.tsx
@@ -189,9 +189,17 @@ export default function PlotAddForm(props: Props) {
 
       if (useManualKeySetup) {
         if (farmerPublicKey) {
+          if (farmerPublicKey.length !== 96) {
+            await showError(new Error(t`Farmer public key is invalid`));
+            return;
+          }
           plotAddConfig.farmerPublicKey = farmerPublicKey;
         }
         if (poolPublicKey && !selectedP2SingletonPuzzleHash) {
+          if (poolPublicKey.length !== 96) {
+            await showError(new Error(t`Pool public key is invalid`));
+            return;
+          }
           plotAddConfig.poolPublicKey = poolPublicKey;
         }
       }


### PR DESCRIPTION
- Fixed an issue where farmer public key is emptified after changing plotter
- Fixed an issue where manual key setup didn't work even if the checkbox is on
- Shows error when farmer/pool public key is invalid when they are manually entered
- Add current logged-in farmer/pool pk hints to manual key inputs