### PR TITLE
The label of `last block won` is now `Never` when there are no blocks…

### DIFF
--- a/packages/gui/src/components/farm/card/FarmingRewardsHistoryCards.tsx
+++ b/packages/gui/src/components/farm/card/FarmingRewardsHistoryCards.tsx
@@ -94,6 +94,9 @@ function FarmingRewardsHistoryCards() {
     if (!data || isLoading) {
       return <CardSimple title={<Trans>Last block won</Trans>} value="-" loading={isLoading} error={error} />;
     }
+    if (data.lastTimeFarmed === 0) {
+      return <CardSimple title={<Trans>Last block won</Trans>} value="Never" loading={isLoading} error={error} />;
+    }
 
     const time = moment(data.lastTimeFarmed * 1000);
     const cardValue = (


### PR DESCRIPTION
… farmed yet

### Before
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/091f25a1-ff95-4622-9652-78dad5742f7e)

### After
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/0046635c-df28-4d77-907e-97eb6b477275)
