### PR TITLE
Added compressed plot size texts

### DIFF
--- a/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
@@ -34,7 +34,9 @@ export default function PlotAddChooseSize(props: Props) {
   const compressionLevel = compressionLevelStr ? +compressionLevelStr : undefined;
   const isKLow = plotSize < MIN_MAINNET_K_SIZE;
 
-  const compressionAvailable = op.haveBladebitCompressionLevel && plotterName === PlotterName.BLADEBIT_CUDA;
+  const compressionAvailable =
+    op.haveBladebitCompressionLevel &&
+    (plotterName === PlotterName.BLADEBIT_CUDA || plotterName === PlotterName.BLADEBIT_RAM);
 
   const [allowedPlotSizes, setAllowedPlotSizes] = useState(
     getPlotSizeOptions(plotterName, compressionLevel).filter((option) => plotter.options.kSizes.includes(option.value))

--- a/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import styled from 'styled-components';
 
+import PlotterName from '../../../constants/PlotterName';
 import { getPlotSizeOptions } from '../../../constants/plotSizes';
 import Plotter from '../../../types/Plotter';
 
@@ -25,8 +26,6 @@ export default function PlotAddChooseSize(props: Props) {
   const openDialog = useOpenDialog();
 
   const op = plotter.options;
-  const isBladebit3OrNewer =
-    plotter.defaults.plotterName.startsWith('bladebit') && plotter.version && +plotter.version.split('.')[0] >= 3;
 
   const plotterName = watch('plotterName');
   const plotSize = watch('plotSize');
@@ -35,7 +34,7 @@ export default function PlotAddChooseSize(props: Props) {
   const compressionLevel = compressionLevelStr ? +compressionLevelStr : undefined;
   const isKLow = plotSize < MIN_MAINNET_K_SIZE;
 
-  const compressionAvailable = op.haveBladebitCompressionLevel && isBladebit3OrNewer;
+  const compressionAvailable = op.haveBladebitCompressionLevel && plotterName === PlotterName.BLADEBIT_CUDA;
 
   const [allowedPlotSizes, setAllowedPlotSizes] = useState(
     getPlotSizeOptions(plotterName, compressionLevel).filter((option) => plotter.options.kSizes.includes(option.value))

--- a/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
@@ -31,19 +31,23 @@ export default function PlotAddChooseSize(props: Props) {
   const plotterName = watch('plotterName');
   const plotSize = watch('plotSize');
   const overrideK = watch('overrideK');
+  const compressionLevelStr = watch('bladebitCompressionLevel');
+  const compressionLevel = compressionLevelStr ? +compressionLevelStr : undefined;
   const isKLow = plotSize < MIN_MAINNET_K_SIZE;
 
   const compressionAvailable = op.haveBladebitCompressionLevel && isBladebit3OrNewer;
 
   const [allowedPlotSizes, setAllowedPlotSizes] = useState(
-    getPlotSizeOptions(plotterName).filter((option) => plotter.options.kSizes.includes(option.value))
+    getPlotSizeOptions(plotterName, compressionLevel).filter((option) => plotter.options.kSizes.includes(option.value))
   );
 
   useEffect(() => {
     setAllowedPlotSizes(
-      getPlotSizeOptions(plotterName).filter((option) => plotter.options.kSizes.includes(option.value))
+      getPlotSizeOptions(plotterName, compressionLevel).filter((option) =>
+        plotter.options.kSizes.includes(option.value)
+      )
     );
-  }, [plotter.options.kSizes, plotterName]);
+  }, [plotter.options.kSizes, plotterName, compressionLevel]);
 
   useEffect(() => {
     async function getConfirmation() {

--- a/packages/gui/src/constants/plotSizes.ts
+++ b/packages/gui/src/constants/plotSizes.ts
@@ -7,6 +7,18 @@ type PlotSize = {
   defaultRam: number;
 };
 
+export const compressedSizes: Record<number, Record<number, string>> = {
+  0: { 32: '101.4GiB', 33: '208.8GiB', 34: '429.9GiB', 35: '884.1GiB' },
+  1: { 32: '87.5GiB', 33: '179.6GiB', 34: '368.2GiB', 35: '754.3GiB' },
+  2: { 32: '86.0GiB', 33: '176.6GiB', 34: '362.1GiB', 35: '742.2GiB' },
+  3: { 32: '84.5GiB', 33: '173.4GiB', 34: '355.9GiB', 35: '729.7GiB' },
+  4: { 32: '82.9GiB', 33: '170.2GiB', 34: '349.4GiB', 35: '716.8GiB' },
+  5: { 32: '81.3GiB', 33: '167.0GiB', 34: '343.0GiB', 35: '704.0GiB' },
+  6: { 32: '79.6GiB', 33: '163.8GiB', 34: '336.6GiB', 35: '691.1GiB' },
+  7: { 32: '78.0GiB', 33: '160.6GiB', 34: '330.2GiB', 35: '678.3GiB' },
+  9: { 32: '75.2GiB', 33: '154.1GiB', 34: '315.5GiB', 35: '645.8GiB' },
+};
+
 export function getEffectivePlotSize(kSize: 25 | 32 | 33 | 34 | 35) {
   const sizeInBytes = (2 * kSize + 1) * 2 ** (kSize - 1);
   if (kSize < 32) {
@@ -43,9 +55,23 @@ export const plottingInfo: Record<PlotterName, PlotSize[]> = {
   ],
 };
 
-export function getPlotSizeOptions(plotterName: PlotterName) {
-  return plottingInfo[plotterName].map((item) => ({
-    value: item.value,
-    label: `k=${item.value} (Effective plot size: ${item.effectivePlotSize}, Temporary space: ${item.workspace})`,
-  }));
+export function getPlotSizeOptions(plotterName: PlotterName, compressionLevel?: number) {
+  return plottingInfo[plotterName].map((item) => {
+    const kSize = item.value;
+    if (
+      typeof compressionLevel !== 'number' ||
+      !compressedSizes[compressionLevel] ||
+      !compressedSizes[compressionLevel][kSize]
+    ) {
+      return {
+        value: kSize,
+        label: `k=${kSize} (Effective plot size: ${item.effectivePlotSize}, Temporary space: ${item.workspace})`,
+      };
+    }
+    const compressedSize = compressedSizes[compressionLevel][kSize];
+    return {
+      value: kSize,
+      label: `k=${kSize} (Effective plot size: ${item.effectivePlotSize}, Compressed plot size: ${compressedSize})`,
+    };
+  });
 }


### PR DESCRIPTION
Source: https://docs.chia.net/k-sizes/

![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/a8ee8b9e-6916-49f8-be72-a7d3e1de1622)

Also this PR hides compress option for bladebit_disk.