### PR TITLE
Added texts for effective size

### DIFF
--- a/packages/gui/src/components/harvest/HarvesterDetail.tsx
+++ b/packages/gui/src/components/harvest/HarvesterDetail.tsx
@@ -1,5 +1,5 @@
 import { HarvesterInfo, LatencyData } from '@chia-network/api';
-import { Flex, FormatBytes, Tooltip } from '@chia-network/core';
+import { Flex, FormatBytes, Tooltip, TooltipIcon } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { Box, Paper, Typography, LinearProgress, Chip } from '@mui/material';
 import BigNumber from 'bignumber.js';
@@ -154,7 +154,15 @@ function HarvesterLatencyGraph(props: HarvesterLatencyGraphProps) {
                 <tr>
                   <td colSpan={2}>
                     <Typography variant="body2" color="textSecondary">
-                      <Trans>Effective Space</Trans>
+                      <Flex alignItems="center" gap={1}>
+                        <Trans>Effective Space</Trans>
+                        <TooltipIcon>
+                          <Trans>
+                            This is a sum of effective plot sizes currently harvesting. An effective plot size is a
+                            theoretical value which is derived only by kSize.
+                          </Trans>
+                        </TooltipIcon>
+                      </Flex>
                     </Typography>
                   </td>
                 </tr>

--- a/packages/gui/src/components/harvest/HarvesterOverview.tsx
+++ b/packages/gui/src/components/harvest/HarvesterOverview.tsx
@@ -164,6 +164,12 @@ export default function HarvesterOverview() {
               valueColor="primary"
               title={<Trans>Total farm size effective</Trans>}
               value={<FormatBytes value={totalFarmSizeEffective} precision={3} effectiveSize />}
+              tooltip={
+                <Trans>
+                  This is a sum of effective plot sizes currently farming. An effective plot size is a theoretical value
+                  which is derived only by kSize
+                </Trans>
+              }
             />
           </Grid>
           <Grid xs={12} sm={6} md={4} item>


### PR DESCRIPTION
Added tooltips describing effective farm size / space.

![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/fcca088c-a1b7-47cd-a9d5-2e225dcde420)

![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/2d062a7f-dc42-4531-8e94-83933ef9fe72)
