### PR TITLE
Fixed an issue where plotNFT was not created after changing plotter

### DIFF
--- a/packages/gui/src/components/plot/add/PlotAddForm.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddForm.tsx
@@ -113,6 +113,7 @@ export default function PlotAddForm(props: Props) {
       p2SingletonPuzzleHash: formValues.p2SingletonPuzzleHash,
       plotNFTContractAddr: formValues.plotNFTContractAddr,
       poolPublicKey: formValues.poolPublicKey,
+      createNFT: formValues.createNFT,
     });
   };
 


### PR DESCRIPTION
There is currently a bug where creating plotNFT is silently canceled after changing plotter.
The root cause is when changing plotter, form values are reset to plotter's default values.
Since the default value of create-nft request is `false`, even if filling plotNFT form, changing plotter reset the flag for creating plotNFT as `false`.

![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/04357839-963a-4773-8546-1d2a1b33fdc2)

![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/cf908486-5aa2-42ee-bbb0-d1305f529d27)
