### PR TITLE
increased number of max event listeners for api services

### DIFF
--- a/packages/api/src/services/Service.ts
+++ b/packages/api/src/services/Service.ts
@@ -28,6 +28,8 @@ export default abstract class Service extends EventEmitter {
     this.name = name;
     this.origin = origin ?? client.origin;
 
+    this.setMaxListeners(100);
+
     client.on('message', this.handleMessage);
 
     this.#readyPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
increased number of max event listeners for api services (from 10 => 100)

fixed:
[1] (node:23884) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 state_changed listeners added to [Wallet]. Use emitter.setMaxListeners() to increase limit
