### PR TITLE
Remove autoSelect behavior so that a row isn't selected on blur

### DIFF
--- a/packages/wallets/src/components/AddressBookAutocomplete.tsx
+++ b/packages/wallets/src/components/AddressBookAutocomplete.tsx
@@ -55,7 +55,6 @@ export default function AddressBookAutocomplete(props: Props) {
     <FormControl variant="filled" fullWidth>
       <MaterialAutocomplete
         autoComplete
-        autoSelect
         blurOnSelect
         options={options}
         onChange={(_e, newValue) => handleChange(newValue)}


### PR DESCRIPTION
When selecting an address book contact using the AddressBookAutocomplete component, a row would be selected on blur despite not making an explicit selection. This change removes the autoSelect prop which is responsible for implementing this behavior.