### PR TITLE
Fix address entry when entered directly instead of using the selection

### DIFF
--- a/packages/wallets/src/components/AddressBookAutocomplete.tsx
+++ b/packages/wallets/src/components/AddressBookAutocomplete.tsx
@@ -65,6 +65,7 @@ export default function AddressBookAutocomplete(props: Props) {
             label={<Trans>Address or Contact</Trans>}
             required={required}
             onBlur={onBlur}
+            onChange={(_e) => handleChange(_e.target.value)}
             {...rest}
             {...params}
           />


### PR DESCRIPTION
Entering an address via typing/pasting was broken by the removal of the `autoSelect` prop. That prop was removed to prevent automatic selection on blur if the user didn't actually make a selection. This fix updates the TextField's props to include an onChange handler that is invoked when typing/pasting.