### PR TITLE
Fixed an issue where a component using `useThrottleQuery()` always crashed

### DIFF
--- a/packages/api-react/src/hooks/useThrottleQuery.ts
+++ b/packages/api-react/src/hooks/useThrottleQuery.ts
@@ -38,7 +38,7 @@ export default function useThrottleQuery(
 
       processUpdate();
 
-      return null;
+      return state;
     },
   });
 


### PR DESCRIPTION
# How to reproduce
Just click `Plot` tab button on the sidebar.

The root cause seems to be this: https://github.com/reduxjs/redux-toolkit/issues/3650
This issue appeared after updating `@reduxjs/toolkit` to `1.9.5`
`selectFromResult` must return an object while the previous code returned `undefined`.