### PR TITLE
Fixed effective plot size values

### DIFF
--- a/packages/gui/src/constants/plotSizes.ts
+++ b/packages/gui/src/constants/plotSizes.ts
@@ -19,12 +19,17 @@ export const compressedSizes: Record<number, Record<number, string>> = {
   9: { 32: '75.2GiB', 33: '154.1GiB', 34: '315.5GiB', 35: '645.8GiB' },
 };
 
+export const UI_CONSTANT_FACTOR = 0.78;
+
 export function getEffectivePlotSize(kSize: 25 | 32 | 33 | 34 | 35) {
   const sizeInBytes = (2 * kSize + 1) * 2 ** (kSize - 1);
+  let size;
   if (kSize < 32) {
-    return `${sizeInBytes / 1024 / 1024}MiBe`;
+    size = (sizeInBytes / 1024 / 1024) * UI_CONSTANT_FACTOR;
+    return `${Math.floor(size * 10) / 10}MiBe`;
   }
-  return `${sizeInBytes / 1024 / 1024 / 1024}GiBe`;
+  size = (sizeInBytes / 1024 / 1024 / 1024) * UI_CONSTANT_FACTOR;
+  return `${Math.floor(size * 10) / 10}GiBe`;
 }
 
 export const plottingInfo: Record<PlotterName, PlotSize[]> = {


### PR DESCRIPTION
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/d74bd1c6-be3f-4399-ad3f-1cb6ccafdbdc)

The effective plot size is a function of `kSize`.
```
Effective Plot Size = (2 * k + 1) * (2 ** (k - 1)) * UI_CONSTANT_FACTOR
```
where `UI_CONSTANT_FACTOR = 0.78` currently