### PR TITLE
Add a tooltip for USDSC (Stably USDS Classic) in the token listing

### DIFF
--- a/packages/wallets/src/components/WalletIcon.tsx
+++ b/packages/wallets/src/components/WalletIcon.tsx
@@ -1,8 +1,8 @@
 import { WalletType, type Wallet } from '@chia-network/api';
 import { useGetCatListQuery } from '@chia-network/api-react';
-import { useCurrencyCode } from '@chia-network/core';
+import { Flex, TooltipIcon, useCurrencyCode } from '@chia-network/core';
 import { CrCat } from '@chia-network/icons';
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import { Typography, type TypographyProps } from '@mui/material';
 import React from 'react';
 import styled from 'styled-components';
@@ -10,6 +10,12 @@ import styled from 'styled-components';
 const StyledSymbol = styled(Typography)`
   font-size: 1rem;
 `;
+
+const STABLY_USDSC_ASSET_ID = '6d95dae356e32a71db5ddcb42224754a02524c615c5fc35f568c2af04774e589';
+
+const AssetIdTooltipMapping = {
+  [STABLY_USDSC_ASSET_ID]: t`Classic version of Stably USDS as held by Prime Trust`,
+};
 
 export type WalletIconProps = TypographyProps & {
   wallet: Wallet;
@@ -40,9 +46,13 @@ export default function WalletIcon(props: WalletIconProps) {
   if (!isLoading && [WalletType.CAT, WalletType.CRCAT].includes(wallet.type)) {
     const token = catList.find((tokenItem) => tokenItem.assetId === wallet.meta?.assetId);
     if (token) {
+      const tooltipText = AssetIdTooltipMapping[token.assetId];
       return (
         <StyledSymbol color={color} {...rest}>
-          {token.symbol}
+          <Flex flexDirection="row" alignItems="center" gap={1}>
+            {token.symbol}
+            {tooltipText && <TooltipIcon>{tooltipText}</TooltipIcon>}
+          </Flex>
         </StyledSymbol>
       );
     }


### PR DESCRIPTION
The token card for Stably USDS Classic now includes a tooltip indicating that the token is the USDSC asset.

Note that this will not rename existing USDS wallets that have been previously added to the wallet DB. As shown below, if the token has not been previously added, adding the token will result in the following:

![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/339312/6ecebcdb-236f-4399-9d57-a4b9509978b2)

If the token has been previously added (and therefore already has a name), the following is displayed. It is, of course, possible to manually rename the token.
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/339312/fafefc14-1853-45d1-ad48-11c4b14ea615)

The `USDSC` symbol rename is dependent on this PR: https://github.com/Chia-Network/chia-blockchain/pull/16295