### PR TITLE
Use main branch in crowdin for translations

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -59,7 +59,7 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
-          crowdin_branch_name: ${{ github.ref_name }} # The "branch" (folder) in crowdin to source from. Match the branch name in GH
+          crowdin_branch_name: main
           localization_branch_name: ${{ env.localization_branch_name }}
           create_pull_request: true
           pull_request_title: 'New Crowdin Translations'


### PR DESCRIPTION
release branches (the only other supported branches for this workflow) should include all changes from main anyways, and main will contain their changes because of checkpoints