### PR TITLE
Removed compression level 0 from the cuda plot option

### DIFF
--- a/packages/api/src/constants/Plotters.ts
+++ b/packages/api/src/constants/Plotters.ts
@@ -164,7 +164,7 @@ export const bladebitCudaDefaults: PlotterDefaults = {
   bladebitWarmStart: false,
   bladebitDisableNUMA: false,
   bladebitNoCpuAffinity: false,
-  bladebitCompressionLevel: 0,
+  bladebitCompressionLevel: 1,
   bladebitDiskCache: undefined,
   bladebitDiskF1Threads: undefined,
   bladebitDiskFpThreads: undefined,

--- a/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
@@ -29,6 +29,7 @@ export default function PlotAddChooseSize(props: Props) {
 
   const plotterName = watch('plotterName');
   const plotSize = watch('plotSize');
+  const hybridDiskMode = watch('bladebitEnableHybridDiskMode', false);
   const overrideK = watch('overrideK');
   const compressionLevelStr = watch('bladebitCompressionLevel');
   const compressionLevel = compressionLevelStr ? +compressionLevelStr : undefined;
@@ -78,6 +79,8 @@ export default function PlotAddChooseSize(props: Props) {
     }
   }, [plotSize, overrideK, setValue, openDialog]);
 
+  const showC0 = !hybridDiskMode || plotterName !== PlotterName.BLADEBIT_CUDA;
+
   return (
     <CardStep
       step={step}
@@ -122,8 +125,8 @@ export default function PlotAddChooseSize(props: Props) {
               </InputLabel>
               <Select name="bladebitCompressionLevel" defaultValue={plotter.defaults.bladebitCompressionLevel}>
                 {
-                  /* Bladebit cuda currently doesn't support compression level 0 */
-                  plotterName !== PlotterName.BLADEBIT_CUDA && <MenuItem value={0}>0 - No compression</MenuItem>
+                  /* Bladebit cuda_plot with hybridDiskMode option currently doesn't support compression level 0 */
+                  showC0 && <MenuItem value={0}>0 - No compression</MenuItem>
                 }
                 <MenuItem value={1}>1</MenuItem>
                 <MenuItem value={2}>2</MenuItem>

--- a/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
@@ -121,7 +121,10 @@ export default function PlotAddChooseSize(props: Props) {
                 <Trans>Compression level</Trans>
               </InputLabel>
               <Select name="bladebitCompressionLevel" defaultValue={plotter.defaults.bladebitCompressionLevel}>
-                <MenuItem value={0}>0 - No compression</MenuItem>
+                {
+                  /* Bladebit cuda currently doesn't support compression level 0 */
+                  plotterName !== PlotterName.BLADEBIT_CUDA && <MenuItem value={0}>0 - No compression</MenuItem>
+                }
                 <MenuItem value={1}>1</MenuItem>
                 <MenuItem value={2}>2</MenuItem>
                 <MenuItem value={3}>3</MenuItem>


### PR DESCRIPTION
Bladebit 3.1 doesn't support to create a plot with compression level 0 using cudaplot.
This PRs will:
- set default compression level for cudaplot to `1` from `0`
- Hide compression level `0` from option if selecting `cuda_plot` with hybrid disk mode enabled.