### PR TITLE
Cosmetic fixes for the Harvester settings screen

### DIFF
--- a/packages/gui/src/components/settings/SettingsHarvester.tsx
+++ b/packages/gui/src/components/settings/SettingsHarvester.tsx
@@ -6,10 +6,10 @@ import {
   useStartServiceMutation,
   useStopServiceMutation,
 } from '@chia-network/api-react';
-import { ButtonLoading, Flex, SettingsSection, SettingsTitle, SettingsText } from '@chia-network/core';
+import { ButtonLoading, Flex, SettingsHR, SettingsSection, SettingsTitle, SettingsText } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { Warning as WarningIcon } from '@mui/icons-material';
-import { Alert, Divider, FormControlLabel, Grid, Switch, TextField, Snackbar } from '@mui/material';
+import { Alert, FormControlLabel, Grid, Switch, TextField, Snackbar } from '@mui/material';
 import React from 'react';
 
 const messageAnchorOrigin = { vertical: 'bottom' as const, horizontal: 'center' as const };
@@ -388,9 +388,13 @@ export default function SettingsHarvester() {
       )}
 
       <Grid item xs={12} sm={12} lg={12}>
-        <Divider textAlign="left">
+        <SettingsHR />
+      </Grid>
+
+      <Grid item xs={12} sm={12} lg={12}>
+        <SettingsSection>
           <Trans>Plot</Trans>
-        </Divider>
+        </SettingsSection>
       </Grid>
 
       <Grid container gap={3}>
@@ -429,9 +433,13 @@ export default function SettingsHarvester() {
         </Grid>
 
         <Grid item xs={12} sm={12} lg={12}>
-          <Divider textAlign="left">
+          <SettingsHR />
+        </Grid>
+
+        <Grid item xs={12} sm={12} lg={12}>
+          <SettingsSection>
             <Trans>Compressed plot support</Trans>
-          </Divider>
+          </SettingsSection>
         </Grid>
 
         <Grid container>


### PR DESCRIPTION
Removed the dividers and used SettingsHR and SettingsSection components

![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/339312/6cc2079b-5146-4065-864d-d417ac91e71d)
