### PR TITLE
Fix addVCProofs WalletConnect call

### DIFF
--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -879,7 +879,7 @@ const walletConnectCommands: WalletConnectCommand[] = [
     params: [
       {
         name: WalletConnectCommandParamName.PROOFS,
-        type: 'string',
+        type: 'object',
         label: <Trans>Proofs Object (Key Value Pairs)</Trans>,
       },
     ],


### PR DESCRIPTION
### Purpose:

Bugfix of addVCProofs WalletConnect call. Currently it doesn't work because an error is thrown.

### Current Behavior:

- When calling addVCProofs using the HTTP RPC it parses the proofs into a Python dictionary which gets passed into a VCProofs class.
- When calling addVCProofs using WalletConnect it parses the proofs into a string which throws an error when passed into a VCProofs class.


### New Behavior:

- When calling addVCProofs using the HTTP RPC it parses the proofs into a Python dictionary which gets passed into a VCProofs class.
- When calling addVCProofs using WalletConnect it parses the proofs into a Python dictionary which gets passed into a VCProofs class.

