### PR TITLE
Skip fee estimator RPC call in wallet mode

### DIFF
--- a/packages/core/src/components/EstimatedFee/EstimatedFee.tsx
+++ b/packages/core/src/components/EstimatedFee/EstimatedFee.tsx
@@ -13,8 +13,10 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
 import Color from '../../constants/Color';
+import Mode from '../../constants/Mode';
 import useCurrencyCode from '../../hooks/useCurrencyCode';
 import useLocale from '../../hooks/useLocale';
+import useMode from '../../hooks/useMode';
 import mojoToChiaLocaleString from '../../utils/mojoToChiaLocaleString';
 import Fee from '../Fee';
 import Flex from '../Flex';
@@ -175,6 +177,7 @@ type FeeProps = {
 
 export default function EstimatedFee(props: FeeProps) {
   const { name, txType, required, ...rest } = props;
+  const [mode] = useMode();
   const { setValue } = useFormContext();
   const [requestId, setRequestId] = useState<string | undefined>(undefined);
   const [startTime, setStartTime] = useState<number | undefined>(undefined);
@@ -182,6 +185,7 @@ export default function EstimatedFee(props: FeeProps) {
     { targetTimes: TARGET_TIMES, spendType: txType },
     {
       pollingInterval: REFRESH_SECONDS * 1000, // in milliseconds
+      skip: mode === Mode.WALLET,
     }
   );
   const { data: ests, isLoading, isSuccess, requestId: feeEstimateRequestId, startedTimeStamp } = result;


### PR DESCRIPTION
Previously it didn't matter whether the full_node process was running or not -- calling useGetFeeEstimateQuery would simply return undefined if the RPC failed because the service wasn't running.

More recently, the service start/stop code was modified such that calling an RPC hook against a service that wasn't running would cause that service to be launched.

This change uses RTK's `skip: <boolean>` option to leave the hook intact (necessary by React's convention to not conditionally call hooks) while signaling that the underlying RPC should not be called when in wallet mode.