### PR TITLE
Downgrade electron to 25.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10991,24 +10991,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/electron": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
-      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
-      }
-    },
     "node_modules/electron-devtools-assembler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/electron-devtools-assembler/-/electron-devtools-assembler-1.2.0.tgz",
@@ -11103,12 +11085,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "18.17.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.7.tgz",
-      "integrity": "sha512-WJj/p/cIg6zUsxv1n2leZHpvn8hr9TYuLQxAZxZcK/7+5t5ukmJGelOLGOy3L1MLhAO/sapTJGd1V7kvoIuzUg==",
-      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -24432,7 +24408,7 @@
         "babel-plugin-macros": "3.1.0",
         "babel-plugin-styled-components": "2.1.4",
         "babel-plugin-transform-imports": "2.0.0",
-        "electron": "26.2.1",
+        "electron": "25.9.0",
         "jest": "29.6.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -24466,6 +24442,30 @@
         "react-router": "^6.15.0",
         "react-router-dom": "^6.15.0",
         "styled-components": "^6.0.7"
+      }
+    },
+    "packages/core/node_modules/@types/node": {
+      "version": "18.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
+      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
+      "dev": true
+    },
+    "packages/core/node_modules/electron": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.9.0.tgz",
+      "integrity": "sha512-wgscxf2ORHL/8mAQfy7l9rVDG//wrG9RUQndG508kCCMHRq9deFyZ4psOMzySheBRSfGMcFoRFYSlkAeZr8cFg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^18.11.18",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
       }
     },
     "packages/gui": {
@@ -24573,7 +24573,7 @@
         "cross-env": "7.0.3",
         "css-loader": "6.8.1",
         "date-and-time": "2.4.3",
-        "electron": "26.2.1",
+        "electron": "25.9.0",
         "electron-devtools-assembler": "1.2.0",
         "electron-playwright-helpers": "^1.6.0",
         "electron-winstaller": "5.1.0",
@@ -24596,6 +24596,30 @@
       "optionalDependencies": {
         "playwright": "1.37.1"
       }
+    },
+    "packages/gui/node_modules/electron": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.9.0.tgz",
+      "integrity": "sha512-wgscxf2ORHL/8mAQfy7l9rVDG//wrG9RUQndG508kCCMHRq9deFyZ4psOMzySheBRSfGMcFoRFYSlkAeZr8cFg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^18.11.18",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "packages/gui/node_modules/electron/node_modules/@types/node": {
+      "version": "18.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
+      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
+      "dev": true
     },
     "packages/gui/node_modules/ws": {
       "version": "8.4.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,7 +93,7 @@
     "babel-plugin-macros": "3.1.0",
     "babel-plugin-styled-components": "2.1.4",
     "babel-plugin-transform-imports": "2.0.0",
-    "electron": "26.2.1",
+    "electron": "25.9.0",
     "jest": "29.6.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -245,7 +245,7 @@
     "cross-env": "7.0.3",
     "date-and-time": "2.4.3",
     "css-loader": "6.8.1",
-    "electron": "26.2.1",
+    "electron": "25.9.0",
     "electron-devtools-assembler": "1.2.0",
     "electron-playwright-helpers": "^1.6.0",
     "electron-winstaller": "5.1.0",


### PR DESCRIPTION
Trying to fix this blank screen issue: https://github.com/Chia-Network/chia-blockchain/issues/16538

I reproduced the above issue on my Ubuntu 22.04 machine.
I opened devTool on my white-screened electron but devTool said it is disconeccted.
I suspect that this is electron specific issue.

The most suspicious and relevant issue: https://github.com/electron/electron/issues/39515

I tried several electron versions whether it reproduces the blank screen issue.
25.4.0 -> Success
25.9.0 (released 2 days ago) -> Success
26.0.0 -> Failed
26.2.1 (GUI currently use) -> Failed
26.3.0 (released 2 days ago) -> Failed
