### PR TITLE
Hide compression option if bladebit version < 3

### DIFF
--- a/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddChooseSize.tsx
@@ -37,7 +37,9 @@ export default function PlotAddChooseSize(props: Props) {
 
   const compressionAvailable =
     op.haveBladebitCompressionLevel &&
-    (plotterName === PlotterName.BLADEBIT_CUDA || plotterName === PlotterName.BLADEBIT_RAM);
+    (plotterName === PlotterName.BLADEBIT_CUDA || plotterName === PlotterName.BLADEBIT_RAM) &&
+    plotter.version &&
+    +plotter.version.split('.')[0] >= 3;
 
   const [allowedPlotSizes, setAllowedPlotSizes] = useState(
     getPlotSizeOptions(plotterName, compressionLevel).filter((option) => plotter.options.kSizes.includes(option.value))

--- a/packages/gui/src/components/plot/add/PlotAddForm.tsx
+++ b/packages/gui/src/components/plot/add/PlotAddForm.tsx
@@ -85,6 +85,15 @@ export default function PlotAddForm(props: Props) {
       maxRam,
     };
 
+    if (
+      (plotterName === PlotterName.BLADEBIT_RAM ||
+        plotterName === PlotterName.BLADEBIT_DISK ||
+        plotterName === PlotterName.BLADEBIT_CUDA) &&
+      +plotters[plotterName].version.split('.')[0] < 3 // Bladebit < 3.0.0 does not support plot compression
+    ) {
+      defaults.bladebitCompressionLevel = undefined;
+    }
+
     return defaults;
   };
 


### PR DESCRIPTION
For MacOS, the max version of bladebit available is currently `2.0.1` which doesn't support plot compression.
However, the GUI shows compression level option when a user on MacOS chooses bladebit 2.0.1 ramplot.
This PR hides the option if available bladebit version is less than 3.0.0.