### PR TITLE
Fixed add plot directory button

### DIFF
--- a/packages/gui/src/components/plot/PlotAddDirectoryDialog.tsx
+++ b/packages/gui/src/components/plot/PlotAddDirectoryDialog.tsx
@@ -7,6 +7,7 @@ import { useShowError, Button, Loading } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { Folder as FolderIcon, Delete as DeleteIcon } from '@mui/icons-material';
 import {
+  Alert,
   Avatar,
   Box,
   Dialog,
@@ -19,6 +20,7 @@ import {
   ListItemAvatar,
   ListItemSecondaryAction,
   ListItemText,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import React from 'react';
@@ -85,6 +87,13 @@ export default function PlotAddDirectoryDialog(props: Props) {
             plotting screen.
           </Trans>
         </Typography>
+        {directories && directories.length > 0 && (
+          <Alert severity="info">
+            <Trans>
+              Clicking a delete icon only removes a directory from this list and never deletes the directory itself
+            </Trans>
+          </Alert>
+        )}
         <Box display="flex">
           {isLoading ? (
             <Loading center />
@@ -99,9 +108,11 @@ export default function PlotAddDirectoryDialog(props: Props) {
                   </ListItemAvatar>
                   <ListItemText primary={dir} />
                   <ListItemSecondaryAction>
-                    <IconButton edge="end" aria-label="delete" onClick={() => removePlotDir(dir)}>
-                      <DeleteIcon color="info" />
-                    </IconButton>
+                    <Tooltip title={<Trans>Remove from the list</Trans>}>
+                      <IconButton edge="end" aria-label="delete" onClick={() => removePlotDir(dir)}>
+                        <DeleteIcon color="info" />
+                      </IconButton>
+                    </Tooltip>
                   </ListItemSecondaryAction>
                 </ListItem>
               ))}

--- a/packages/gui/src/components/plot/overview/PlotOverviewPlots.tsx
+++ b/packages/gui/src/components/plot/overview/PlotOverviewPlots.tsx
@@ -1,7 +1,7 @@
-import { useRefreshPlotsMutation } from '@chia-network/api-react';
+import { useRefreshPlotsMutation, useGetPlotDirectoriesQuery } from '@chia-network/api-react';
 import { Button, Flex, useOpenDialog, MenuItem, More } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
-import { Add, Refresh } from '@mui/icons-material';
+import { Folder, Refresh } from '@mui/icons-material';
 import { ListItemIcon, Typography } from '@mui/material';
 import React from 'react';
 import { useNavigate } from 'react-router';
@@ -15,6 +15,7 @@ import PlotOverviewCards from './PlotOverviewCards';
 export default function PlotOverviewPlots() {
   const navigate = useNavigate();
   const openDialog = useOpenDialog();
+  const { data: directories, isLoading } = useGetPlotDirectoriesQuery();
   const [refreshPlots] = useRefreshPlotsMutation();
 
   function handleAddPlot() {
@@ -44,10 +45,14 @@ export default function PlotOverviewPlots() {
             <More>
               <MenuItem onClick={handleAddPlotDirectory} close>
                 <ListItemIcon>
-                  <Add fontSize="small" color="info" />
+                  <Folder fontSize="small" color="info" />
                 </ListItemIcon>
                 <Typography variant="inherit" noWrap>
-                  <Trans>Add Plot Directory</Trans>
+                  {isLoading || directories.length === 0 ? (
+                    <Trans>Add Plot Directory</Trans>
+                  ) : (
+                    <Trans>Manage Plot Directories</Trans>
+                  )}
                 </Typography>
               </MenuItem>
               <MenuItem onClick={handleRefreshPlots} close>


### PR DESCRIPTION
Fix this issue: https://github.com/Chia-Network/chia-blockchain-gui/issues/67

Changed icon and caption
(Before this PR, it is always `Add Plot Directory` even if an user want to remove plot directory from this menu)
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/d1b37fa7-27dd-4d4c-a555-c57aa1525f5a)

Added info level alert and tooltip
![image](https://github.com/Chia-Network/chia-blockchain-gui/assets/84098616/f4ca737c-2d39-494f-ba99-b4f59b04858e)
