### PR TITLE
Fix crash when previewing an offer created using WalletConnect

### DIFF
--- a/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
@@ -83,7 +83,7 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
 
   const showInvalid = !isValidating && isValid === false;
 
-  const validTimeList = isMyOffer ? myOfferValidTimes : offerSummary.validTimes;
+  const validTimeList = isMyOffer ? myOfferValidTimes : offerSummary?.validTimes;
 
   const hasExpiration =
     validTimeList?.maxTime !== null && validTimeList?.maxTime !== undefined && validTimeList?.maxTime !== 0;


### PR DESCRIPTION
When using the WalletConnect `createOfferForIds` command and clicking the 'Show Offer Details' button, OfferBuilderViewer would raise an exception due to a missing `validTimes` value.

This fix addresses the crash by making the offerSummary.validTimes optional. Additional work needs to be done to support passing in `maxTime` to specify an expiring offer's duration but that's out of scope for this fix.