### PR TITLE
Don't show NFT collection options on the request side of the offer builder

### DIFF
--- a/packages/gui/src/components/nfts/NFTAutocomplete.tsx
+++ b/packages/gui/src/components/nfts/NFTAutocomplete.tsx
@@ -17,6 +17,7 @@ import NFTTitle from './NFTTitle';
 export type NFTAutocompleteProps = {
   name: string;
   defaultValue?: string;
+  includeNFTCollection?: boolean;
   label?: ReactNode;
   variant?: 'standard' | 'outlined' | 'filled';
   rules?: any;
@@ -27,7 +28,18 @@ export type NFTAutocompleteProps = {
 };
 
 export default function NFTAutocomplete(props: NFTAutocompleteProps) {
-  const { name, defaultValue, label, rules, variant, color, required, fullWidth, InputProps = {} } = props;
+  const {
+    name,
+    defaultValue,
+    includeNFTCollection = false,
+    label,
+    rules,
+    variant,
+    color,
+    required,
+    fullWidth,
+    InputProps = {},
+  } = props;
   const [inputValue, setInputValue] = useState('');
 
   const [searchText, setSearchText] = useState('');
@@ -128,14 +140,16 @@ export default function NFTAutocomplete(props: NFTAutocompleteProps) {
     [firstOption, selectedNFT]
   );
 
+  const options = includeNFTCollection ? nfts : [];
+
   return (
     <Autocomplete
       renderOption={renderOption}
-      options={nfts}
+      options={options}
       value={value}
       onChange={handleChange}
       onClose={handleClose}
-      filterOptions={(options) => options} // disable filtering we are using our own
+      filterOptions={(localOptions) => localOptions} // disable filtering we are using our own
       loading={isLoading}
       inputValue={inputValue}
       onInputChange={handleInputValueChange}

--- a/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderNFT.tsx
@@ -48,7 +48,13 @@ export default function OfferBuilderNFT(props: OfferBuilderNFTProps) {
   return (
     <Flex flexDirection="column" gap={2}>
       <Flex flexDirection="column" gap={1}>
-        <OfferBuilderValue name={fieldName} type="text" label={<Trans>NFT ID</Trans>} onRemove={onRemove} />
+        <OfferBuilderValue
+          name={fieldName}
+          type="text"
+          label={<Trans>NFT ID</Trans>}
+          offering={offering}
+          onRemove={onRemove}
+        />
         {(minterDID || minterDIDName) && (
           <Flex flexDirection="column" gap={1}>
             <Typography variant="body1" color="textSecondary">

--- a/packages/gui/src/components/offers2/OfferBuilderNFTSection.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderNFTSection.tsx
@@ -55,6 +55,7 @@ export default function OfferBuilderNFTSection(props: OfferBuilderNFTSectionProp
             provenance={showProvenance}
             showRoyalties={showRoyalties}
             onRemove={() => handleRemove(index)}
+            offering={offering}
           />
         ))}
       </Flex>

--- a/packages/gui/src/components/offers2/OfferBuilderValue.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderValue.tsx
@@ -31,6 +31,7 @@ export type OfferBuilderValueProps = {
   caption?: ReactNode;
   type?: 'text' | 'amount' | 'fee' | 'token';
   isLoading?: boolean;
+  offering?: boolean;
   onRemove?: () => void;
   symbol?: string;
   showAmountInMojos?: boolean;
@@ -48,6 +49,7 @@ export default function OfferBuilderValue(props: OfferBuilderValueProps) {
     label,
     onRemove,
     isLoading = false,
+    offering = false,
     type = 'text',
     symbol,
     showAmountInMojos,
@@ -159,7 +161,15 @@ export default function OfferBuilderValue(props: OfferBuilderValueProps) {
                 <Fee variant="filled" color="secondary" label={label} name={name} fullWidth />
               )
             ) : type === 'text' ? (
-              <NFTAutocomplete variant="filled" color="secondary" label={label} name={name} required fullWidth />
+              <NFTAutocomplete
+                variant="filled"
+                color="secondary"
+                label={label}
+                name={name}
+                includeNFTCollection={offering}
+                required
+                fullWidth
+              />
             ) : type === 'token' ? (
               <OfferBuilderTokenSelector
                 variant="filled"


### PR DESCRIPTION
Addresses https://github.com/Chia-Network/chia-blockchain-gui/issues/2181

When using Offer Builder to construct an offer, the NFT request column will no longer provide autocomplete options from the user's own NFT collection. The offer column will continue to populate the NFT autocomplete options as before.