### PR TITLE
Ensure enough bottom padding is available in the token list

### DIFF
--- a/packages/wallets/src/components/WalletsSidebar.tsx
+++ b/packages/wallets/src/components/WalletsSidebar.tsx
@@ -47,7 +47,7 @@ const StyledItemsContainer = styled(ScrollbarFlex)`
 
 const StyledItemsContent = styled(Box)`
   padding-left: ${({ theme }: { theme: Theme }) => theme.spacing(3)};
-  padding-bottom: ${({ theme }: { theme: Theme }) => theme.spacing(1)};
+  padding-bottom: ${({ theme }: { theme: Theme }) => theme.spacing(7)};
   margin-right: ${({ theme }: { theme: Theme }) => theme.spacing(2)};
   min-height: ${({ theme }: { theme: Theme }) => theme.spacing(5)};
   overflow: hidden;


### PR DESCRIPTION
When the "Manage Token List" drawer tab overlaps the token listing, the last token listed would be partially clipped by the drawer tab. This fix ensures there's enough bottom padding on the token list to allow the full token entry to be displayed.