### PR TITLE
Walletconnect create offer fee

### DIFF
--- a/packages/gui/src/components/offers2/OfferBuilderFeeSection.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderFeeSection.tsx
@@ -41,10 +41,10 @@ export default function OfferBuilderFeeSection(props: OfferBuilderFeeSectionProp
   function handleRemove(index: number) {
     remove(index);
   }
-
   const canAdd =
-    (!fields.length && state === undefined && !viewer) || // If in builder mode, or in viewer mode when offer hasn't been accepted
-    (viewer && imported && !offering); // If in viewer mode when offer has not been accepted and showing the requesting side
+    !fields.length && // If there is not already a fee field
+    ((state === undefined && !viewer) || // If in builder mode, or in viewer mode when offer hasn't been accepted
+      (viewer && imported && offering)); // If in viewer mode when offer has not been accepted and showing the offering side
   const disableReadOnly = offering && viewer && imported;
   const expanded = !!fields.length; // Fee section is expanded if there is a field value set. Could be ''.
 

--- a/packages/gui/src/components/offers2/utils/createDefaultValues.ts
+++ b/packages/gui/src/components/offers2/utils/createDefaultValues.ts
@@ -35,7 +35,7 @@ export default function createDefaultValues(params: CreateDefaultValuesParams | 
       nfts,
       xch: walletType === WalletType.STANDARD_WALLET ? [{ amount: '' }] : [],
       tokens: [WalletType.CAT, WalletType.CRCAT].includes(walletType) && assetId ? [{ assetId, amount: '' }] : [],
-      fee: [],
+      fee: [{ amount: '' }],
     },
     requested: {
       ...clonedEmptyDefaultValues.requested,

--- a/packages/gui/src/components/offers2/utils/createDefaultValues.ts
+++ b/packages/gui/src/components/offers2/utils/createDefaultValues.ts
@@ -35,7 +35,6 @@ export default function createDefaultValues(params: CreateDefaultValuesParams | 
       nfts,
       xch: walletType === WalletType.STANDARD_WALLET ? [{ amount: '' }] : [],
       tokens: [WalletType.CAT, WalletType.CRCAT].includes(walletType) && assetId ? [{ assetId, amount: '' }] : [],
-      fee: [{ amount: '' }],
     },
     requested: {
       ...clonedEmptyDefaultValues.requested,

--- a/packages/gui/src/components/offers2/utils/createDefaultValues.ts
+++ b/packages/gui/src/components/offers2/utils/createDefaultValues.ts
@@ -35,6 +35,7 @@ export default function createDefaultValues(params: CreateDefaultValuesParams | 
       nfts,
       xch: walletType === WalletType.STANDARD_WALLET ? [{ amount: '' }] : [],
       tokens: [WalletType.CAT, WalletType.CRCAT].includes(walletType) && assetId ? [{ assetId, amount: '' }] : [],
+      fee: [],
     },
     requested: {
       ...clonedEmptyDefaultValues.requested,

--- a/packages/gui/src/components/walletConnect/WalletConnectCreateOfferPreview.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectCreateOfferPreview.tsx
@@ -1,5 +1,6 @@
-import { Button, Flex, Loading, useOpenDialog } from '@chia-network/core';
+import { Button, Flex, Loading, useOpenDialog, chiaToMojo } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
+import BigNumber from 'bignumber.js';
 import React, { useMemo } from 'react';
 
 import OfferBuilderData from '../../@types/OfferBuilderData';
@@ -7,20 +8,68 @@ import useAssetIdName from '../../hooks/useAssetIdName';
 import createOfferForIdsToOfferBuilderData from '../../util/createOfferForIdsToOfferBuilderData';
 import OfferBuilderViewerDialog from '../offers2/OfferBuilderViewerDialog';
 
-export default function WalletConnectCreateOfferPreview({ value }: { value: Record<string, number> }) {
+export type WalletConnectOfferPreviewProps = {
+  value: Record<string, number>;
+  values: Record<string, any>;
+  onChange: (values: Record<string, any>) => void;
+};
+
+function parseFee(value: any) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) {
+      return '';
+    }
+
+    return value.toString();
+  }
+
+  if (value instanceof BigNumber) {
+    if (value.isNaN()) {
+      return '';
+    }
+
+    return value.toFixed();
+  }
+
+  return value;
+}
+
+export default function WalletConnectCreateOfferPreview(props: WalletConnectOfferPreviewProps) {
+  const { value, values, onChange } = props;
   const { lookupByWalletId, isLoading: isLoadingAssetIdNames } = useAssetIdName();
   const openDialog = useOpenDialog();
+
+  const fee = parseFee(values.fee);
 
   const offerBuilderData: OfferBuilderData | undefined = useMemo(() => {
     if (isLoadingAssetIdNames) {
       return undefined;
     }
 
-    return createOfferForIdsToOfferBuilderData(value, lookupByWalletId);
-  }, [value, lookupByWalletId, isLoadingAssetIdNames]);
+    return createOfferForIdsToOfferBuilderData(value, lookupByWalletId, fee);
+  }, [value, lookupByWalletId, isLoadingAssetIdNames, fee]);
 
   async function handleShowPreview() {
-    await openDialog(<OfferBuilderViewerDialog offerBuilderData={offerBuilderData} />);
+    const offerBuilderDataResult = await openDialog(<OfferBuilderViewerDialog offerBuilderData={offerBuilderData} />);
+    if (offerBuilderDataResult) {
+      // use new fee value
+      const feeChia = offerBuilderDataResult.offered.fee?.[0]?.amount;
+      if (feeChia) {
+        const feeMojos = feeChia ? chiaToMojo(feeChia).toFixed() : '0';
+        onChange({
+          ...values,
+          fee: feeMojos,
+        });
+      }
+    }
   }
 
   return (

--- a/packages/gui/src/components/walletConnect/WalletConnectCreateOfferPreview.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectCreateOfferPreview.tsx
@@ -1,11 +1,11 @@
 import { Button, Flex, Loading, useOpenDialog, chiaToMojo } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
-import BigNumber from 'bignumber.js';
 import React, { useMemo } from 'react';
 
 import OfferBuilderData from '../../@types/OfferBuilderData';
 import useAssetIdName from '../../hooks/useAssetIdName';
 import createOfferForIdsToOfferBuilderData from '../../util/createOfferForIdsToOfferBuilderData';
+import parseFee from '../../util/parseFee';
 import OfferBuilderViewerDialog from '../offers2/OfferBuilderViewerDialog';
 
 export type WalletConnectOfferPreviewProps = {
@@ -13,34 +13,6 @@ export type WalletConnectOfferPreviewProps = {
   values: Record<string, any>;
   onChange: (values: Record<string, any>) => void;
 };
-
-function parseFee(value: any) {
-  if (value === null || value === undefined) {
-    return '';
-  }
-
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (typeof value === 'number') {
-    if (Number.isNaN(value)) {
-      return '';
-    }
-
-    return value.toString();
-  }
-
-  if (value instanceof BigNumber) {
-    if (value.isNaN()) {
-      return '';
-    }
-
-    return value.toFixed();
-  }
-
-  return value;
-}
 
 export default function WalletConnectCreateOfferPreview(props: WalletConnectOfferPreviewProps) {
   const { value, values, onChange } = props;

--- a/packages/gui/src/components/walletConnect/WalletConnectOfferPreview.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectOfferPreview.tsx
@@ -1,9 +1,9 @@
 import { Button, Flex, useOpenDialog, chiaToMojo } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { Typography } from '@mui/material';
-import BigNumber from 'bignumber.js';
 import React from 'react';
 
+import parseFee from '../../util/parseFee';
 import OfferBuilderViewerDialog from '../offers2/OfferBuilderViewerDialog';
 
 export type WalletConnectOfferPreviewProps = {
@@ -11,34 +11,6 @@ export type WalletConnectOfferPreviewProps = {
   values: Record<string, any>;
   onChange: (values: Record<string, any>) => void;
 };
-
-function parseFee(value: any) {
-  if (value === null || value === undefined) {
-    return '';
-  }
-
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (typeof value === 'number') {
-    if (Number.isNaN(value)) {
-      return '';
-    }
-
-    return value.toString();
-  }
-
-  if (value instanceof BigNumber) {
-    if (value.isNaN()) {
-      return '';
-    }
-
-    return value.toFixed();
-  }
-
-  return value;
-}
 
 export default function WalletConnectOfferPreview(props: WalletConnectOfferPreviewProps) {
   const { value: offer, values, onChange } = props;

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -367,6 +367,12 @@ const walletConnectCommands: WalletConnectCommand[] = [
         isOptional: true,
         type: 'boolean',
       },
+      {
+        name: WalletConnectCommandParamName.FEE,
+        label: <Trans>Fee</Trans>,
+        type: 'BigNumber',
+        displayComponent: (value) => <MojoToChia value={value} />,
+      },
     ],
   },
   {

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -370,6 +370,7 @@ const walletConnectCommands: WalletConnectCommand[] = [
       {
         name: WalletConnectCommandParamName.FEE,
         label: <Trans>Fee</Trans>,
+        isOptional: true,
         type: 'BigNumber',
         displayComponent: (value) => <MojoToChia value={value} />,
       },

--- a/packages/gui/src/util/createOfferForIdsToOfferBuilderData.ts
+++ b/packages/gui/src/util/createOfferForIdsToOfferBuilderData.ts
@@ -8,7 +8,8 @@ import { AssetIdMapEntry } from '../hooks/useAssetIdName';
 
 export default function createOfferForIdsToOfferBuilderData(
   walletIdsAndAmounts: Record<string, number>,
-  lookupByWalletId: (walletId: string) => AssetIdMapEntry | undefined
+  lookupByWalletId: (walletId: string) => AssetIdMapEntry | undefined,
+  fee?: string
 ): OfferBuilderData {
   const offerBuilderData: OfferBuilderData = createDefaultValues();
   Object.entries(walletIdsAndAmounts).forEach(([walletOrAssetId, amount]) => {
@@ -42,6 +43,10 @@ export default function createOfferForIdsToOfferBuilderData(
       console.error(e);
     }
   });
+
+  if (fee) {
+    offerBuilderData.offered.fee.push({ amount: mojoToChia(fee).toFixed() });
+  }
 
   return offerBuilderData;
 }

--- a/packages/gui/src/util/createOfferForIdsToOfferBuilderData.ts
+++ b/packages/gui/src/util/createOfferForIdsToOfferBuilderData.ts
@@ -45,7 +45,7 @@ export default function createOfferForIdsToOfferBuilderData(
   });
 
   if (fee) {
-    offerBuilderData.offered.fee.push({ amount: mojoToChia(fee).toFixed() });
+    offerBuilderData.offered.fee = [{ amount: mojoToChia(fee).toFixed() }];
   }
 
   return offerBuilderData;

--- a/packages/gui/src/util/parseFee.ts
+++ b/packages/gui/src/util/parseFee.ts
@@ -1,0 +1,29 @@
+import BigNumber from 'bignumber.js';
+
+export default function parseFee(value: any) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) {
+      return '';
+    }
+
+    return value.toString();
+  }
+
+  if (value instanceof BigNumber) {
+    if (value.isNaN()) {
+      return '';
+    }
+
+    return value.toFixed();
+  }
+
+  return value;
+}

--- a/packages/gui/src/util/parsefee.test.ts
+++ b/packages/gui/src/util/parsefee.test.ts
@@ -1,0 +1,24 @@
+import BigNumber from 'bignumber.js';
+
+import parseFee from './parseFee';
+
+describe('parseFee', () => {
+  it('should return empty string if value is null', () => {
+    expect(parseFee(null)).toEqual('');
+  });
+  it('should return empty string if value is undefined', () => {
+    expect(parseFee(undefined)).toEqual('');
+  });
+  it('should return value if value is a string', () => {
+    expect(parseFee('123')).toEqual('123');
+  });
+  it('should return value if value is a number', () => {
+    expect(parseFee(123)).toEqual('123');
+  });
+  it('should return value if value is a BigNumber', () => {
+    expect(parseFee(new BigNumber(123))).toEqual('123');
+  });
+  it('should return empty string if value is NaN', () => {
+    expect(parseFee(NaN)).toEqual('');
+  });
+});


### PR DESCRIPTION
- Added the ability to add a fee when calling Wallet Connect `createOfferForIds`.
- The fee is optional.
- If the fee is not given, the user still has the ability to add a fee in the created offer.

## Todo
- [x] Add and adapt unit tests
