### PR TITLE
Wallet Connect - Correctly update fees when removing them in the GUI

### DIFF
--- a/packages/gui/src/components/walletConnect/WalletConnectCreateOfferPreview.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectCreateOfferPreview.tsx
@@ -34,13 +34,11 @@ export default function WalletConnectCreateOfferPreview(props: WalletConnectOffe
     if (offerBuilderDataResult) {
       // use new fee value
       const feeChia = offerBuilderDataResult.offered.fee?.[0]?.amount;
-      if (feeChia) {
-        const feeMojos = feeChia ? chiaToMojo(feeChia).toFixed() : '0';
-        onChange({
-          ...values,
-          fee: feeMojos,
-        });
-      }
+      const feeMojos = feeChia ? chiaToMojo(feeChia).toFixed() : undefined;
+      onChange({
+        ...values,
+        fee: feeMojos,
+      });
     }
   }
 

--- a/packages/gui/src/components/walletConnect/WalletConnectOfferPreview.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectOfferPreview.tsx
@@ -23,13 +23,11 @@ export default function WalletConnectOfferPreview(props: WalletConnectOfferPrevi
     if (offerBuilderData) {
       // use new fee value
       const feeChia = offerBuilderData.offered.fee?.[0]?.amount;
-      if (feeChia) {
-        const feeMojos = feeChia ? chiaToMojo(feeChia).toFixed() : '0';
-        onChange({
-          ...values,
-          fee: feeMojos,
-        });
-      }
+      const feeMojos = feeChia ? chiaToMojo(feeChia).toFixed() : undefined;
+      onChange({
+        ...values,
+        fee: feeMojos,
+      });
     }
   }
 


### PR DESCRIPTION
Previously, removing a fee by clicking the "-" (minus) button in the GUI would retain the previous fee value. This commit fixes this behavior to ensure that removing a fee results in a zero fee value.