### PR TITLE
Allow failure on the commit/push step, to account for the case where …

### DIFF
--- a/.github/workflows/extract-strings.yml
+++ b/.github/workflows/extract-strings.yml
@@ -43,6 +43,7 @@ jobs:
           npm run locale:extract
 
       - name: Commit changes back to the repo
+        continue-on-error: true
         run: |
           git add '**/messages.po'
           git commit -m "Extract latest strings for translation"


### PR DESCRIPTION
…no new strings were defined