### PR TITLE
Added `--skip-keyring` option to `chia start daemon` command

### DIFF
--- a/packages/gui/src/util/chiaEnvironment.js
+++ b/packages/gui/src/util/chiaEnvironment.js
@@ -9,10 +9,10 @@ const path = require('path');
 const PY_MAC_DIST_FOLDER = '../../../app.asar.unpacked/daemon';
 const PY_WIN_DIST_FOLDER = '../../../app.asar.unpacked/daemon';
 const PY_DIST_EXECUTABLE = 'chia';
-const PY_DIST_EXEC_ARGS = Object.freeze(['start', 'daemon']);
+const PY_DIST_EXEC_ARGS = Object.freeze(['start', 'daemon', '--skip-keyring']);
 
 const PY_DEV_EXECUTABLE = `../../../venv/${process.platform === 'win32' ? 'Scripts/chia.exe' : 'bin/chia'}`;
-const PY_DEV_EXEC_ARGS = Object.freeze(['start', 'daemon']);
+const PY_DEV_EXEC_ARGS = Object.freeze(['start', 'daemon', '--skip-keyring']);
 
 let pyProc = null;
 let haveCert = null;


### PR DESCRIPTION
Fixding the issue https://github.com/Chia-Network/chia-blockchain/issues/17848
Detail is described in https://github.com/Chia-Network/chia-blockchain/pull/17857