### PR TITLE
Run `chia init` on the first run

### DIFF
--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -30,8 +30,8 @@ import packageJson from '../../package.json';
 import AppIcon from '../assets/img/chia64x64.png';
 import About from '../components/about/About';
 import { i18n } from '../config/locales';
-import chiaEnvironment from '../util/chiaEnvironment';
-import loadConfig from '../util/loadConfig';
+import chiaEnvironment, { chiaInit } from '../util/chiaEnvironment';
+import loadConfig, { checkConfigFileExists } from '../util/loadConfig';
 import manageDaemonLifetime from '../util/manageDaemonLifetime';
 import { setUserDataDir } from '../util/userData';
 
@@ -71,6 +71,12 @@ let mainWindow: BrowserWindow | null = null;
 
 let currentDownloadRequest: any;
 let abortDownloadingFiles: boolean = false;
+
+// When there is no config file, it is assumed to be the first run.
+// At that time, the config file is created here by `chia init`.
+if (!checkConfigFileExists()) {
+  chiaInit();
+}
 
 // Set the userData directory to its location within CHIA_ROOT/gui
 setUserDataDir();

--- a/packages/gui/src/util/chiaEnvironment.js
+++ b/packages/gui/src/util/chiaEnvironment.js
@@ -62,6 +62,31 @@ const getChiaVersion = () => {
   return version;
 };
 
+const chiaInit = () => {
+  if (guessPackaged()) {
+    const executablePath = getExecutablePath(PY_DIST_EXECUTABLE);
+    console.info(`Executing: ${executablePath} init`);
+
+    try {
+      const output = childProcess.execFileSync(executablePath, ['init']);
+      console.info(output.toString());
+    } catch (e) {
+      console.error('Error: ');
+      console.error(e);
+    }
+  } else {
+    console.info(`Executing: ${PY_DEV_EXECUTABLE} init`);
+
+    try {
+      const output = childProcess.execFileSync(PY_DEV_EXECUTABLE, ['init']);
+      console.info(output.toString());
+    } catch (e) {
+      console.error('Error: ');
+      console.error(e);
+    }
+  }
+};
+
 const startChiaDaemon = () => {
   pyProc = null;
 
@@ -142,6 +167,7 @@ const startChiaDaemon = () => {
 };
 
 module.exports = {
+  chiaInit,
   startChiaDaemon,
   getChiaVersion,
   guessPackaged,

--- a/packages/gui/src/util/loadConfig.ts
+++ b/packages/gui/src/util/loadConfig.ts
@@ -14,6 +14,11 @@ export function getConfigRootDir(net = 'mainnet'): string {
   return 'CHIA_ROOT' in process.env ? untildify(process.env.CHIA_ROOT) : path.join(homedir, '.chia', net);
 }
 
+export function checkConfigFileExists(net?: string): boolean {
+  const configRootDir = getConfigRootDir(net);
+  return fs.existsSync(path.resolve(configRootDir, 'config/config.yaml'));
+}
+
 export function readConfigFile(net?: string): string {
   const configRootDir = getConfigRootDir(net);
 


### PR DESCRIPTION
From `2.3.0`, the GUI launches `daemon` by `chia start daemon --skip-keyring` instead of `chia run_daemon --wait-for-unlock`.
On the first GUI run, there is no `CHIA_ROOT` directory and config files.
`chia run_daemon` always tries to run `chia init` on start up while `chia start daemon` doesn't.
So, on the first run without `CHIA_ROOT` directory, the new `2.3.0` GUI can never read `CHIA_ROOT/config/config.yaml` because it won't be created.

This PR let the GUI search for the `CHIA_ROOT/config/config.yaml` and if it doesn't exist it invokes `chia init`.

# Test
Tested against Ubuntu 22.04 (x64) in cases
(1) with no `$CHIA_ROOT/config/config.yaml` created yet
(2) with `$CHIA_ROOT/config/config.yaml` created

The test succeeded. Before this PR, with `2.3.0` and with no `config.yaml` created, the GUI never proceed from loading screen.
After applying this PR, the GUI proceeds to run.