### PR TITLE
when on testnet, point the faucet link to the new `testnet11-faucet.chia.net`

### DIFF
--- a/packages/gui/src/components/plotNFT/select/PlotNFTSelectFaucet.tsx
+++ b/packages/gui/src/components/plotNFT/select/PlotNFTSelectFaucet.tsx
@@ -17,7 +17,7 @@ export default function PlotNFTSelectFaucet(props: Props) {
 
   const handleClick = React.useCallback(() => {
     if (currencyCode === 'TXCH') {
-      openExternal('https://testnet10-faucet.chia.net/');
+      openExternal('https://testnet11-faucet.chia.net/');
     } else {
       openExternal('https://faucet.chia.net/');
     }

--- a/packages/gui/src/components/settings/ProfileAdd.tsx
+++ b/packages/gui/src/components/settings/ProfileAdd.tsx
@@ -68,7 +68,7 @@ export default function ProfileAdd() {
   const canCreateProfile = (balance?.spendableBalance ?? 0) > 0;
 
   function handleClick() {
-    const url = `https://${isTestnet ? 'testnet10-faucet.chia.net' : 'faucet.chia.net'}/?address=${currentAddress}`;
+    const url = `https://${isTestnet ? 'testnet11-faucet.chia.net' : 'faucet.chia.net'}/?address=${currentAddress}`;
     openExternal(url);
   }
 


### PR DESCRIPTION
The previous one (testnet10-faucet) has been decomissioned. In an ideal world this link would be disabled or have a helpful error message if the user happens to be on some other testnet, other than testnet11