### PR TITLE
Prevent the Enter key from submitting the form when text input has focus

### DIFF
--- a/packages/gui/src/components/signVerify/SignMessage.tsx
+++ b/packages/gui/src/components/signVerify/SignMessage.tsx
@@ -149,6 +149,13 @@ export default function SignMessage(props: SignMessageProps) {
     await handleSign();
   }
 
+  const preventEnterKeySubmission = (e: React.KeyboardEvent<HTMLFormElement>) => {
+    const { target } = e;
+    if (e.key === 'Enter' && target instanceof HTMLInputElement) {
+      e.preventDefault();
+    }
+  };
+
   const buttons: { type: SignMessageEntityType; label: ReactNode }[] = [
     { type: SignMessageEntityType.WalletAddress, label: <Trans>Wallet Address</Trans> },
     { type: SignMessageEntityType.NFT, label: <Trans>NFT</Trans> },
@@ -156,7 +163,7 @@ export default function SignMessage(props: SignMessageProps) {
   ];
 
   return (
-    <Form methods={methods} onSubmit={handleSubmit}>
+    <Form methods={methods} onSubmit={handleSubmit} onKeyDown={preventEnterKeySubmission}>
       <Flex flexDirection="column" gap={3}>
         <Card>
           <Flex flexDirection="column" gap={1}>

--- a/packages/gui/src/components/signVerify/SigningEntityNFT.tsx
+++ b/packages/gui/src/components/signVerify/SigningEntityNFT.tsx
@@ -65,6 +65,7 @@ export default function SigningEntityNFT(props: SigningEntityNFTProps) {
         label={<Trans>NFT ID</Trans>}
         variant="filled"
         name={entityFormName}
+        includeNFTCollection
         InputProps={{
           endAdornment: (
             <InputAdornment position="end">


### PR DESCRIPTION
- Prevent the Enter key from submitting the form when text input has focus
- Include our NFT collection in option list for signing