### PR TITLE
Upgraded ws to 8.17.1 and solved some issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27322,9 +27322,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -27716,9 +27716,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -28410,7 +28410,7 @@
         "unique-names-generator": "4.6.0",
         "validator": "13.11.0",
         "victory": "^36.6.11",
-        "ws": "8.4.2"
+        "ws": "8.17.1"
       },
       "devDependencies": {
         "@babel/core": "7.22.10",
@@ -28606,14 +28606,16 @@
       }
     },
     "packages/gui/node_modules/ws": {
-      "version": "8.4.2",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -96,7 +96,7 @@
     "unique-names-generator": "4.6.0",
     "validator": "13.11.0",
     "victory": "^36.6.11",
-    "ws": "8.4.2"
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@babel/core": "7.22.10",

--- a/packages/gui/webpack.react.babel.ts
+++ b/packages/gui/webpack.react.babel.ts
@@ -100,6 +100,10 @@ export default {
       '@mui/styled-engine': '@mui/styled-engine-sc',
       crypto: 'crypto-browserify',
       stream: 'stream-browserify',
+      // Use `ws` package for nodejs instead of `ws` package for browsers
+      // Without this alias, webpack will bundle `ws` package for browsers
+      // See https://github.com/Chia-Network/chia-blockchain-gui/pull/2413#issuecomment-2181012908
+      ws: require.resolve('ws'),
     },
   },
   optimization: {


### PR DESCRIPTION
This PR replaces https://github.com/Chia-Network/chia-blockchain-gui/pull/2413

Why need replacing? Because
1. with the above dependabot PR, the version of `packages/gui/node_modules/ws` remains `8.14.1` in `package-lock.json` and vulnerability still opens.
2. `ws@8.17.1` doesn't work with `packages/gui` since it added a conditonal exports to its own `package.json` like below.
```
// See https://www.npmjs.com/package/ws/v/8.17.1?activeTab=code
"exports": {
  ".": {
    ...,
    "browser": "./browser.js"
  }
}
```
When building code with `webpack`, it treats electron-renderer code (mostly React components) as browser code by the above exports entry.
This is the problem, since the content of `ws/browser.js` is
```typescript
'use strict';

module.exports = function () {
  throw new Error(
    'ws does not work in the browser. Browser clients must use the native ' +
      'WebSocket object'
  );
};
```
So when you try to instantiate `WebSocket`, it immediately throws.

## Solutions to the above issues
1. Remove `ws` from `packages/gui` by `npm un ws -w @chia-network/gui` then re-add `ws` by `npm i ws -w @chia-network/gui`. After the re-installation, run `npm audit fix` to upgrade `ws` to vuln-free version.
2. Add the below entry to `packages/gui/webpack.react.babel.ts`
```
exports.module = {
  ...,
  resolve: {
    alias: {
      ws: require.resolve('ws'), // This will be `.../node_modules/ws/index.js`
    },
  },
  ...
};
```