### PR TITLE
Updated `inline-style-prefixer` to remove `fast-loops`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13665,12 +13665,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-loops": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
-      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==",
-      "license": "MIT"
-    },
     "node_modules/fast-redact": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
@@ -15443,13 +15437,12 @@
       }
     },
     "node_modules/inline-style-prefixer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.0.tgz",
-      "integrity": "sha512-I7GEdScunP1dQ6IM2mQWh6v0mOYdYmH3Bp31UecKdrcUgcURTcctSe1IECdUznSHKSmsHtjrT3CwCPI1pyxfUQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
       "license": "MIT",
       "dependencies": {
-        "css-in-js-utils": "^3.1.0",
-        "fast-loops": "^1.1.3"
+        "css-in-js-utils": "^3.1.0"
       }
     },
     "node_modules/inquirer": {


### PR DESCRIPTION
This PR replaces https://github.com/Chia-Network/chia-blockchain-gui/pull/2421

`fast-loops@1.1.3` has vulnerability and needs to be updated to `1.1.4`.
But I found that by updating `inline-style-prefixer` to `7.0.1`, `fast-loops` is no longer a dependency and will be removed from `package-lock.json`

## Steps to reproduce the new `package-lock.json`
Updating indirect npm dependencies requires a bit tricky procedure. I'll show you the way here.
```bash
npm i inline-style-prefixer # Install the latest inline-style-prefixer. This also removed fast-loops from lock file
npm un inline-style-prefixer # Removes the npm from direct dependency in lock file
```