### PR TITLE
Fixed an issue where chia services could not run in the background

### DIFF
--- a/packages/gui/src/util/chiaEnvironment.js
+++ b/packages/gui/src/util/chiaEnvironment.js
@@ -90,13 +90,20 @@ const chiaInit = () => {
 const startChiaDaemon = () => {
   pyProc = null;
 
+  let procOption;
+  if (process.platform !== 'win32') {
+    procOption = {
+      detached: true,
+      windowsHide: true,
+    };
+  }
+
   const chiaExec = getExecutablePath(PY_CHIA_EXEC);
   console.info('Running python executable: ');
   console.info(`Script: ${chiaExec} ${CHIA_START_ARGS.join(' ')}`);
 
   try {
-    const Process = childProcess.spawn;
-    pyProc = new Process(chiaExec, CHIA_START_ARGS);
+    pyProc = childProcess.spawn(chiaExec, CHIA_START_ARGS, procOption);
   } catch (e) {
     console.error('Running python executable: Error: ');
     console.error(e);


### PR DESCRIPTION
Fixed https://github.com/Chia-Network/chia-blockchain-gui/issues/2483

## Test
|OS|Version|Issue exists?|Fix confirmed by this PR?|
|---|-------|------|----------|
|MacOS|14.6.1|OK with d92ed1db65b5dbd2231f09aec5ecd759c49fa74d but confirmed the issue with `main`|Fixed for both source/package install|
|Windows|10|OK|Issue does not exist|
|Ubuntu|24.04|OK with d92ed1db65b5dbd2231f09aec5ecd759c49fa74d but confirmed the issue with `main`|Fixed for both source/package install|
|Fedora|40|OK with d92ed1db65b5dbd2231f09aec5ecd759c49fa74d but confirmed the issue with `main`|Fixed for both source/package install|

It seems some of the changes since `2.4.3` (https://github.com/Chia-Network/chia-blockchain-gui/compare/d92ed1db65b5dbd2231f09aec5ecd759c49fa74d...main) triggered this issue.
