### PR TITLE
Moved expand icon button to the head of each rows for wallet transaction history

### DIFF
--- a/packages/wallets/src/components/WalletHistory.tsx
+++ b/packages/wallets/src/components/WalletHistory.tsx
@@ -99,6 +99,14 @@ async function handleRowClick(
 
 const getCols = (type: WalletType, isSyncing, getOfferRecord, navigate, location) => [
   {
+    width: '70px',
+    field: (row: Row, metadata, isExpanded, toggleExpand) => (
+      <IconButton aria-label="expand row" size="small" onClick={() => toggleExpand(row)}>
+        {isExpanded ? <ExpandLessIcon color="info" /> : <ExpandMoreIcon color="info" />}
+      </IconButton>
+    ),
+  },
+  {
     field: (row: Row, metadata) => {
       const isOutgoing = getIsOutgoingTransaction(row);
 
@@ -234,15 +242,6 @@ const getCols = (type: WalletType, isSyncing, getOfferRecord, navigate, location
       </>
     ),
     title: <Trans>Fee</Trans>,
-  },
-
-  {
-    width: '70px',
-    field: (row: Row, metadata, isExpanded, toggleExpand) => (
-      <IconButton aria-label="expand row" size="small" onClick={() => toggleExpand(row)}>
-        {isExpanded ? <ExpandLessIcon color="info" /> : <ExpandMoreIcon color="info" />}
-      </IconButton>
-    ),
   },
 ];
 


### PR DESCRIPTION
This PR fixes https://github.com/Chia-Network/chia-blockchain-gui/issues/2550

![image](https://github.com/user-attachments/assets/5829aa6a-44f1-4e77-a3e6-6a18fd84bd81)
