### PR TITLE
Fix a couple path traversal test cases for getFileExtension

### DIFF
--- a/packages/gui/src/util/getFileExtension.test.ts
+++ b/packages/gui/src/util/getFileExtension.test.ts
@@ -47,8 +47,8 @@ describe('getFileExtension', () => {
     expect(getFileExtension('https://example.com/../secret.txt')).toBe('txt');
     expect(getFileExtension('https://example.com/folder/../file.pdf')).toBe('pdf');
     expect(getFileExtension('https://example.com/./file.jpg')).toBe('jpg');
-    expect(getFileExtension('https://example.com/test\secret.txt')).toBe('txt');
-    expect(getFileExtension('https://example.com/test\..\secret.txt')).toBe('txt');
+    expect(getFileExtension('https://example.com/test\\secret.txt')).toBe('txt');
+    expect(getFileExtension('https://example.com/test\\..\\secret.txt')).toBe('txt');
     expect(getFileExtension('https://example.com/test/secret.t.xt')).toBe('xt');
     expect(getFileExtension('https://example.com/test/secret.t./xt')).toBeUndefined();
     expect(getFileExtension('https://example.com/test/secret.t/./xt')).toBeUndefined();


### PR DESCRIPTION
This will target main once the 3b65c4f checkpoint lands.