### PR TITLE
Support CAIP-25 style session proposal handling

### DIFF
--- a/packages/gui/src/util/walletConnect.ts
+++ b/packages/gui/src/util/walletConnect.ts
@@ -44,7 +44,13 @@ export async function processSessionProposal(
           icons?: string[];
         };
       };
-      requiredNamespaces: {
+      requiredNamespaces?: {
+        chia: {
+          chains: string[];
+          methods: string[];
+        };
+      };
+      optionalNamespaces?: {
         chia: {
           chains: string[];
           methods: string[];
@@ -64,6 +70,7 @@ export async function processSessionProposal(
         pairingTopic,
         proposer: { metadata: proposerMetadata },
         requiredNamespaces,
+        optionalNamespaces,
       },
     } = event;
 
@@ -71,12 +78,14 @@ export async function processSessionProposal(
       throw new Error('Pairing topic not found');
     }
 
-    const requiredNamespace = requiredNamespaces.chia;
-    if (!requiredNamespace) {
-      throw new Error('Missing required chia namespace');
+    const requiredNamespace = requiredNamespaces?.chia;
+    const optionalNamespace = optionalNamespaces?.chia;
+    const chiaNamespace = requiredNamespace || optionalNamespace; // Use optionalNamespaces if requiredNamespaces is not present
+    if (!chiaNamespace) {
+      throw new Error('Missing both required/optional chia namespace');
     }
 
-    const { chains, methods } = requiredNamespace;
+    const { chains, methods } = chiaNamespace;
     const chain = chains.find((item) => ['chia:testnet', 'chia:mainnet'].includes(item));
     if (!chain) {
       throw new Error('Chain not supported');


### PR DESCRIPTION
https://specs.walletconnect.com/2.0/specs/clients/sign/session-proposal
https://reown.com/blog/caip-25-implementation-guidance-migrating-to-empty-undefined-required-namespaces

## Summary
### Why this change
WalletConnect is migrating to align with the CAIP-25 standard, which treats all namespace requests as optional for better UX.

### What's changing
#### Old pattern
dApps use `requiredNamespaces` (must support or connection fails)
#### New pattern
dApps use `optionalNamespaces` only, leaving `requiredNamespaces` empty/undefined

This allows wallets to approve connections even when they don't support all requested chains

This PR still supports `requiredNamespaces`, because many dApps haven't migrated yet, so we need backward compatibility.