### PR TITLE
change cache algorithm

### DIFF
--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -225,7 +225,7 @@ export default class CacheManager extends EventEmitter {
       throw new Error(`Invalid URL: ${url}`);
     }
 
-    const urlHash = crypto.createHash('md5').update(url).digest('hex');
+    const urlHash = crypto.createHash('sha256').update(url).digest('hex');
     const fileName = `${urlHash}${FILE_SUFFIX}`;
     return path.join(this.cacheDirectory, fileName);
   }


### PR DESCRIPTION
change cache algorithm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local cache key change only; worst case is redundant re-downloads, with no auth or remote data impact.
> 
> **Overview**
> **Cache file naming** now derives disk paths from **SHA-256** instead of **MD5** when hashing the remote URL in `getCacheFilePath`.
> 
> That is a one-line change in how `${urlHash}${FILE_SUFFIX}` is computed; download, eviction, and IPC behavior are unchanged. **Existing cache files keep their old MD5-based names**, so after upgrade the same URLs miss the old entries and **downloads run again** until the new files are written—there is no migration or dual lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7bfb9700ee6fdb814f2df9a0dae0b773cfa49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->