### PR TITLE
[CHIA-3992] Hide whats new button if no associated blog post is released

### DIFF
--- a/packages/core/src/hooks/useGetLatestVersionFromWebsite.ts
+++ b/packages/core/src/hooks/useGetLatestVersionFromWebsite.ts
@@ -46,6 +46,16 @@ export default function useGetLatestVersionFromWebsite(): UseGetLatestVersionFro
       return;
     }
 
+    async function validateBlogUrl(blogUrlPath: string): Promise<boolean> {
+      try {
+        const fullBlogUrl = new URL(blogUrlPath, 'https://www.chia.net/').toString();
+        const blogResponse = await fetch(fullBlogUrl, { method: 'HEAD' });
+        return blogResponse.ok;
+      } catch {
+        return false;
+      }
+    }
+
     async function fetchLatestVersion() {
       try {
         const response = await fetch(latestVersionURL as string, {
@@ -59,11 +69,19 @@ export default function useGetLatestVersionFromWebsite(): UseGetLatestVersionFro
         const data = await response.json();
         const { version, downloadPageUrl, releaseNotesUrl, blogUrl } = data;
 
+        let validatedBlogUrl: string | null = blogUrl ?? null;
+        if (blogUrl) {
+          const blogExists = await validateBlogUrl(blogUrl);
+          if (!blogExists) {
+            validatedBlogUrl = null;
+          }
+        }
+
         setTimeout(() => {
           setLatestVersion(version);
           setDownloadPath(downloadPageUrl);
           setReleaseNotesPath(releaseNotesUrl);
-          setBlogPath(blogUrl);
+          setBlogPath(validatedBlogUrl);
           setIsLoading(false);
         }, 1000); /* we need the delay, otherwise dialog will close too fast */
       } catch (e) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, isolated change that adds one extra network `HEAD` request during update checks; minimal impact beyond potential transient network/CORS failures resulting in the blog link being hidden.
> 
> **Overview**
> The update-check hook now *validates* the `blogUrl` returned by `latest.json` by issuing a `HEAD` request to the resolved `chia.net` URL.
> 
> If the blog URL is missing or returns a non-OK response, the hook sets `blogUrl` to `undefined`, causing the UI to omit the **What's New** link/button for that release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3ab04f914cdda87984227941aebf0d99dc0af88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->