### PR TITLE
Extend heightInfo for WalletConnect

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -553,7 +553,6 @@ export const walletApi = apiWithTag.injectEndpoints({
     getTimestampForHeight: query(build, WalletService, 'getTimestampForHeight'),
 
     getHeightInfo: query(build, WalletService, 'getHeightInfo', {
-      transformResponse: (response) => response.height,
       onCacheEntryAdded: onCacheEntryAddedInvalidate(baseQuery, api, [
         {
           command: 'onSyncChanged',

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -214,7 +214,7 @@ export default class Wallet extends Service {
     return this.command<{
       height: number;
       isTransactionBlock: boolean | null;
-      latestTransactionBlockHeight: number | null;
+      prevTransactionBlockHeight: number | null;
     }>('get_height_info');
   }
 

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -211,7 +211,11 @@ export default class Wallet extends Service {
   }
 
   async getHeightInfo() {
-    return this.command<{ height: number }>('get_height_info');
+    return this.command<{
+      height: number;
+      isTransactionBlock: boolean | null;
+      latestTransactionBlockHeight: number | null;
+    }>('get_height_info');
   }
 
   async getNetworkInfo() {

--- a/packages/core/src/screens/SelectKey/WalletStatusHeight.tsx
+++ b/packages/core/src/screens/SelectKey/WalletStatusHeight.tsx
@@ -4,12 +4,13 @@ import React from 'react';
 import FormatLargeNumber from '../../components/FormatLargeNumber';
 
 export default function WalletStatusHeight() {
-  const { data: height, isLoading } = useGetHeightInfoQuery(
+  const { data: heightData, isLoading } = useGetHeightInfoQuery(
     {},
     {
       pollingInterval: 10_000,
     },
   );
+  const height = heightData?.height;
 
   if (isLoading) {
     return null;

--- a/packages/gui/src/components/offers/OfferManager.tsx
+++ b/packages/gui/src/components/offers/OfferManager.tsx
@@ -105,9 +105,10 @@ function OfferList(props: OfferListProps) {
 
   const isWalletSynced = useIsWalletSynced();
 
-  const { data: height, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
+  const { data: heightData, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
     pollingInterval: 3000,
   });
+  const height = heightData?.height;
   const { data: lastBlockTimeStampData, isLoading: isGetTimestampForHeightLoading } = useGetTimestampForHeightQuery(
     { height: height || 0 },
     { skip: !height },

--- a/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
+++ b/packages/gui/src/components/offers2/CreateOfferBuilder.tsx
@@ -76,9 +76,10 @@ export default function CreateOfferBuilder(props: CreateOfferBuilderProps) {
 
   const [suppressShareOnCreate] = useSuppressShareOnCreate();
 
-  const { data: height, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
+  const { data: heightData, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
     pollingInterval: 3000,
   });
+  const height = heightData?.height;
   const { data: lastBlockTimeStampData, isLoading: isGetTimestampForHeightLoading } = useGetTimestampForHeightQuery(
     { height: height || 0 },
     { skip: !height },

--- a/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderViewer.tsx
@@ -114,9 +114,10 @@ function OfferBuilderViewer(props: OfferBuilderViewerProps, ref: any) {
   let expirationTime = null;
   let isExpired = false;
 
-  const { data: height, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
+  const { data: heightData, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
     pollingInterval: 3000,
   });
+  const height = heightData?.height;
   const { data: lastBlockTimeStampData, isLoading: isGetTimestampForHeightLoading } = useGetTimestampForHeightQuery(
     { height: height || 0 },
     { skip: !height },

--- a/packages/wallets/src/components/WalletHistoryClawbackChip.tsx
+++ b/packages/wallets/src/components/WalletHistoryClawbackChip.tsx
@@ -19,9 +19,10 @@ export default function WalletHistoryClawbackChip(props: Props) {
   const { data: autoClaimData, isLoading: isGetAutoClaimLoading } = useGetAutoClaimQuery();
   const isAutoClaimEnabled = !isGetAutoClaimLoading && autoClaimData?.enabled;
 
-  const { data: height, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
+  const { data: heightData, isLoading: isGetHeightInfoLoading } = useGetHeightInfoQuery(undefined, {
     pollingInterval: 3000,
   });
+  const height = heightData?.height;
 
   const { data: lastBlockTimeStampData, isLoading: isGetTimestampForHeightLoading } = useGetTimestampForHeightQuery({
     height: height || 0,

--- a/packages/wallets/src/components/WalletStatusHeight.tsx
+++ b/packages/wallets/src/components/WalletStatusHeight.tsx
@@ -3,12 +3,13 @@ import { FormatLargeNumber } from '@chia-network/core';
 import React from 'react';
 
 export default function WalletStatusHeight() {
-  const { data: height, isLoading } = useGetHeightInfoQuery(
+  const { data: heightData, isLoading } = useGetHeightInfoQuery(
     {},
     {
       pollingInterval: 10_000,
     },
   );
+  const height = heightData?.height;
 
   if (isLoading) {
     return null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are type/shape updates to the `getHeightInfo` API response and straightforward UI call-site adjustments, with no auth or stateful logic changes beyond parsing the new response object.
> 
> **Overview**
> Extends the wallet RPC wrapper `WalletService.getHeightInfo()` to return additional chain metadata (`isTransactionBlock` and `prevTransactionBlockHeight`) alongside `height`.
> 
> Updates the RTK Query endpoint `getHeightInfo` to stop transforming the response down to a raw height number, and adjusts all UI consumers to read `heightData?.height` instead of treating `data` as a number (including wallet status height displays, offer expiration timing, and clawback timing UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b85b1a9e3fc3d7002a1c0ef82f446ffedd3eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->