### PR TITLE
Allow extra_conditions in make_offer

### DIFF
--- a/packages/api/src/services/WalletService.test.ts
+++ b/packages/api/src/services/WalletService.test.ts
@@ -686,7 +686,7 @@ describe('WalletService', () => {
     const expected = [
       new Message({
         command: 'create_offer_for_ids',
-        data: { driver_dict: driverDict, ...restArgs },
+        data: { driver_dict: driverDict, extra_conditions: undefined, coin_ids: undefined, ...restArgs },
         destination: 'chia_wallet',
         origin: 'test_origin' as ServiceNameValue,
       }),

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -262,6 +262,7 @@ export default class Wallet extends Service {
     disableJSONFormatting?: boolean;
     maxTime?: number;
     extraConditions?: any[];
+    coinIds?: string[];
   }) {
     const { disableJSONFormatting, driverDict, ...restArgs } = args;
     return this.command<{ offer: string; tradeRecord: TradeRecord }>(

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -261,6 +261,7 @@ export default class Wallet extends Service {
     validateOnly?: boolean;
     disableJSONFormatting?: boolean;
     maxTime?: number;
+    extraConditions?: any[];
   }) {
     const { disableJSONFormatting, driverDict, ...restArgs } = args;
     return this.command<{ offer: string; tradeRecord: TradeRecord }>(

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -281,7 +281,7 @@ export default class Wallet extends Service {
     return this.command<{ id: string; valid: boolean }>('check_offer_validity', args);
   }
 
-  async takeOffer(args: { offer: string; fee: number | string }) {
+  async takeOffer(args: { offer: string; fee: number | string; extraConditions?: any[] }) {
     return this.command<{ tradeRecord: TradeRecord }>('take_offer', args);
   }
 

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -264,10 +264,10 @@ export default class Wallet extends Service {
     extraConditions?: any[];
     coinIds?: string[];
   }) {
-    const { disableJSONFormatting, driverDict, ...restArgs } = args;
+    const { disableJSONFormatting, driverDict, extraConditions, coinIds, ...restArgs } = args;
     return this.command<{ offer: string; tradeRecord: TradeRecord }>(
       'create_offer_for_ids',
-      { driver_dict: driverDict, ...restArgs },
+      { driver_dict: driverDict, extra_conditions: extraConditions, coin_ids: coinIds, ...restArgs },
       false,
       undefined,
       disableJSONFormatting,

--- a/packages/gui/src/@types/WalletConnectCommandParamName.ts
+++ b/packages/gui/src/@types/WalletConnectCommandParamName.ts
@@ -22,6 +22,7 @@ enum WalletConnectCommandParamName {
   EDITION_TOTAL = 'editionTotal',
   END = 'end',
   END_HEIGHT = 'endHeight',
+  EXTRA_CONDITIONS = 'extraConditions',
   FEE = 'fee',
   FINGERPRINT = 'fingerprint',
   FINGERPRINTS = 'fingerprints',

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -529,6 +529,13 @@ const walletConnectCommands: WalletConnectCommand[] = [
         type: 'BigNumber',
         displayComponent: (value) => <MojoToChia value={value} />,
       },
+      {
+        name: WalletConnectCommandParamName.EXTRA_CONDITIONS,
+        label: <Trans>Extra Conditions</Trans>,
+        isOptional: true,
+        type: 'object',
+        displayComponent: (value) => <>{JSON.stringify(value)}</>,
+      },
     ],
   },
   {

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -464,6 +464,13 @@ const walletConnectCommands: WalletConnectCommand[] = [
         type: 'BigNumber',
         displayComponent: (value) => <MojoToChia value={value} />,
       },
+      {
+        name: WalletConnectCommandParamName.EXTRA_CONDITIONS,
+        label: <Trans>Extra Conditions</Trans>,
+        isOptional: true,
+        type: 'object',
+        displayComponent: (value) => <>{JSON.stringify(value)}</>,
+      },
     ],
   },
   {

--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -471,6 +471,13 @@ const walletConnectCommands: WalletConnectCommand[] = [
         type: 'object',
         displayComponent: (value) => <>{JSON.stringify(value)}</>,
       },
+      {
+        name: WalletConnectCommandParamName.COIN_IDS,
+        label: <Trans>Coin IDs</Trans>,
+        isOptional: true,
+        type: 'object',
+        displayComponent: (value) => <>{JSON.stringify(value)}</>,
+      },
     ],
   },
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches offer creation/take request payloads; incorrect parameter mapping or backend incompatibility could break offer flows, though changes are additive and optional.
> 
> **Overview**
> Extends wallet offer APIs to support passing additional constraints: `WalletService.createOfferForIds` now accepts optional `extraConditions` and `coinIds` and forwards them as `extra_conditions`/`coin_ids`, and `WalletService.takeOffer` now accepts optional `extraConditions`.
> 
> Updates WalletConnect command metadata to expose these new optional parameters in the GUI for `createOfferForIds` (both `extraConditions` and `coinIds`) and `takeOffer` (`extraConditions`), and adjusts the related unit test expectation for `create_offer_for_ids`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db19bc26605e0d9bafa5156ad3c569c0aae3ff96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->