### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           # Use node version from '.nvmrc' instead of hardcoding here
           node-version-file: ".nvmrc"

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -30,7 +30,7 @@ jobs:
         uses: Chia-Network/actions/git-mark-workspace-safe@main
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: "${{ inputs.pr_target || github.ref_name }}"
 
@@ -56,7 +56,7 @@ jobs:
           passphrase: ${{ secrets.CHIA_AUTOMATION_PRIVATE_GPG_PASSPHRASE }}
 
       - name: crowdin action
-        uses: crowdin/github-action@v2.4.0
+        uses: crowdin/github-action@v2.16.2
         with:
           upload_sources: false
           upload_translations: false

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -16,7 +16,7 @@ jobs:
     container: node:24
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Vault Login
         uses: Chia-Network/actions/vault/login@main
@@ -34,7 +34,7 @@ jobs:
             secret/data/crowdin project-id-blockchain-gui | CROWDIN_PROJECT_ID;
 
       - name: crowdin action
-        uses: crowdin/github-action@v2.4.0
+        uses: crowdin/github-action@v2.16.2
         with:
           upload_sources: true
           upload_translations: false

--- a/.github/workflows/extract-strings.yml
+++ b/.github/workflows/extract-strings.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.REPO_COMMIT }}
 
       - name: Setup Node 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only changes that update action versions; main risk is workflow breakage due to upstream behavior changes in the newer action releases.
> 
> **Overview**
> Updates CI workflows to use newer GitHub Actions versions, bumping `actions/checkout` and `actions/setup-node` from `v4` to `v6`.
> 
> Upgrades the Crowdin integration in both pull/push translation workflows from `crowdin/github-action@v2.4.0` to `v2.16.2` to keep localization automation current.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce3ead6020680248afaba54f8183da214eb0e7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->