### PR TITLE
add translations to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 **/coverage
 .coverage
 .nyc_output
+
+# Things having to do with differences between CI and local builds, e.g. translations
+*.po


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`, with no runtime or logic changes; risk is limited to potentially hiding intentionally-committed `.po` files.
> 
> **Overview**
> Adds `*.po` to `.gitignore` so gettext translation source files generated/used for CI vs local builds are no longer tracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e4c879e79aa4cf4bc0f3085401a1ce200f53af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->