### PR TITLE
Check wallet preferences and rpc request to ungate allowUnsynced

### DIFF
--- a/packages/api-react/src/utils/withAllowUnsynced.ts
+++ b/packages/api-react/src/utils/withAllowUnsynced.ts
@@ -1,11 +1,17 @@
 import { selectWalletRpcPreferences } from '../slices/walletRpcPreferences';
 import type { RootState } from '../store';
 
-/** Merge `allowUnsynced: true` when the user enabled it in settings (chia-blockchain PR #20805). */
+/**
+ * Merge `allowUnsynced: true` only when BOTH the user preference AND the
+ * per-call RPC arg opt in.  This lets individual endpoints gate unsynced
+ * access even when the global preference is on (chia-blockchain PR #20805).
+ */
 export default function withAllowUnsynced<T extends object>(state: unknown, args: T): T & { allowUnsynced?: boolean } {
-  const { allowUnsynced } = selectWalletRpcPreferences(state as RootState);
-  if (allowUnsynced) {
+  const { allowUnsynced: preferenceEnabled } = selectWalletRpcPreferences(state as RootState);
+  const argsEnabled = 'allowUnsynced' in args && (args as Record<string, unknown>).allowUnsynced;
+
+  if (preferenceEnabled && argsEnabled) {
     return { ...args, allowUnsynced: true };
   }
-  return args;
+  return { ...args, allowUnsynced: false };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `allowUnsynced` is set on wallet RPC requests, which can alter behavior of endpoints that previously inherited the global preference and may affect calls expecting the field to be omitted.
> 
> **Overview**
> Updates `withAllowUnsynced` so `allowUnsynced: true` is only merged when **both** the stored wallet RPC preference is enabled *and* the specific RPC call’s args opt in via `allowUnsynced`.
> 
> When either condition is not met, the helper now explicitly returns `allowUnsynced: false` instead of leaving args unchanged, letting individual endpoints block unsynced access even if the global setting is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519b19e9349846bd4d8cab7d4f8a12695de39ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->