### PR TITLE
Make <enter> key submit wc connect form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10760,12 +10760,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -30840,7 +30840,7 @@
         "@rehooks/local-storage": "2.4.4",
         "@walletconnect/sign-client": "2.23.9",
         "@walletconnect/utils": "2.23.9",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "bech32": "2.0.0",
         "bignumber.js": "9.1.1",
         "buffer": "6.0.3",
@@ -30857,6 +30857,7 @@
         "is-plain-object": "5.0.0",
         "isomorphic-fetch": "3.0.0",
         "js-yaml": "4.1.1",
+        "json-bigint": "1.0.0",
         "lodash": "4.18.1",
         "match-sorter": "6.3.4",
         "moment": "2.30.1",
@@ -30904,6 +30905,7 @@
         "@types/big.js": "6.2.0",
         "@types/jest": "29.5.3",
         "@types/js-yaml": "4.0.5",
+        "@types/json-bigint": "1.0.4",
         "@types/lodash": "4.14.202",
         "@types/node": "20.5.2",
         "@types/react": "18.2.20",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typescript": "5.7.3"
   },
   "overrides": {
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "follow-redirects": "1.16.0",
     "lodash": "4.18.1",
     "@noble/hashes": "1.8.0",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -54,7 +54,7 @@
     "@rehooks/local-storage": "2.4.4",
     "@walletconnect/sign-client": "2.23.9",
     "@walletconnect/utils": "2.23.9",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "bech32": "2.0.0",
     "bignumber.js": "9.1.1",
     "buffer": "6.0.3",

--- a/packages/gui/src/components/walletConnect/WalletConnectAddConnectionDialog.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectAddConnectionDialog.tsx
@@ -80,7 +80,19 @@ export default function WalletConnectAddConnectionDialog(props: WalletConnectAdd
                   <Trans>Paste the address from WalletConnect below.</Trans>
                 </Typography>
               </Box>
-              <TextField name="uri" label={<Trans>Paste link</Trans>} multiline required autoFocus />
+              <TextField
+                name="uri"
+                label={<Trans>Paste link</Trans>}
+                multiline
+                required
+                autoFocus
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    methods.handleSubmit(handleSubmit)();
+                  }
+                }}
+              />
             </Flex>
           </Flex>
         </DialogContent>

--- a/packages/gui/src/components/walletConnect/WalletConnectAddConnectionDialog.tsx
+++ b/packages/gui/src/components/walletConnect/WalletConnectAddConnectionDialog.tsx
@@ -33,6 +33,8 @@ export default function WalletConnectAddConnectionDialog(props: WalletConnectAdd
   }
 
   async function handleSubmit(values: FormData) {
+    if (methods.formState.isSubmitting) return;
+
     const { uri } = values;
     if (!uri) {
       throw new Error(t`Please enter a URI`);
@@ -83,13 +85,12 @@ export default function WalletConnectAddConnectionDialog(props: WalletConnectAdd
               <TextField
                 name="uri"
                 label={<Trans>Paste link</Trans>}
-                multiline
                 required
                 autoFocus
                 onKeyDown={(e: React.KeyboardEvent) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
+                  if (e.key === 'Enter' && canSubmit) {
                     e.preventDefault();
-                    methods.handleSubmit(handleSubmit)();
+                    (e.target as HTMLElement).closest('form')?.requestSubmit();
                   }
                 }}
               />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to upgrading `axios` (and its `follow-redirects` dependency) which can subtly affect HTTP behavior, plus a small UX change in a WalletConnect dialog. The form changes are localized but touch submission flow and double-submit prevention.
> 
> **Overview**
> Improves the WalletConnect “Add connection” dialog so pressing `Enter` in the URI field triggers form submission, and adds a guard to prevent duplicate submits while `react-hook-form` is already submitting.
> 
> Updates dependencies by bumping `axios` to `1.16.0` via root overrides (and lockfile), and records new `json-bigint` / `@types/json-bigint` entries in the GUI dependency set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315032015a0326b0f49563201f1bfd4d8aa0a1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->