### PR TITLE
Don't bypass stateful DID call `findLostDID`

### DIFF
--- a/packages/gui/src/constants/WalletConnectCommands.tsx
+++ b/packages/gui/src/constants/WalletConnectCommands.tsx
@@ -1794,7 +1794,6 @@ const walletConnectCommands: WalletConnectCommand[] = [
     command: 'findLostDID',
     label: <Trans>Find Lost DID</Trans>,
     service: ServiceName.WALLET,
-    bypassConfirm: true,
     params: [
       {
         name: WalletConnectCommandParamName.COIN_ID,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/UX behavior change that only affects whether the `findLostDID` WalletConnect command prompts for user confirmation before executing.
> 
> **Overview**
> Removes `bypassConfirm: true` from the WalletConnect `findLostDID` command, so this stateful DID recovery call now requires an explicit user confirmation prompt before execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73243af023cc452f7bf7f3c36beb51caf586a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->