### PR TITLE
Include RCAT in build buildOfferRequest CAT types array

### DIFF
--- a/packages/gui/src/components/offers/NFTOfferEditor.tsx
+++ b/packages/gui/src/components/offers/NFTOfferEditor.tsx
@@ -490,7 +490,9 @@ type NFTBuildOfferRequestParams = {
 
 function buildOfferRequest(params: NFTBuildOfferRequestParams) {
   const { exchangeType, nft, nftLauncherId, tokenWalletInfo, tokenAmount, fee } = params;
-  const baseMojoAmount: BigNumber = [WalletType.CAT, WalletType.CRCAT].includes(tokenWalletInfo.walletType)
+  const baseMojoAmount: BigNumber = [WalletType.CAT, WalletType.RCAT, WalletType.CRCAT].includes(
+    tokenWalletInfo.walletType,
+  )
     ? catToMojo(tokenAmount)
     : chiaToMojo(tokenAmount);
   const mojoAmount = exchangeType === NFTOfferExchangeType.NFTForToken ? baseMojoAmount : baseMojoAmount.negated();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small conditional change that only affects how `RCAT` wallet amounts are converted to mojos when creating NFT offers.
> 
> **Overview**
> Ensures `WalletType.RCAT` is treated like other CAT-style wallets when building NFT offer requests, using `catToMojo` (instead of `chiaToMojo`) for amount conversion in `buildOfferRequest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ea134fa33aef419b95770230460d0235c6537f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->