### PR TITLE
Add min-release-age to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+min-release-age=1


### PR DESCRIPTION
See https://chia-network.atlassian.net/browse/SEC-1019 and #security_chat for context

## Summary
- Adds `min-release-age=1` to `.npmrc`, telling npm to only resolve package versions published more than 1 day ago
- Lightweight supply-chain-attack mitigation: malicious packages are typically flagged and removed within hours, so a 1-day quarantine avoids installing freshly-published compromised versions

## Test plan
- [ ] `npm install` still works correctly
- [ ] `npm ci` still works correctly

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change that only affects npm dependency resolution by avoiding newly published versions; potential impact is install failures if a required package is <1 day old.
> 
> **Overview**
> Adds `min-release-age=1` to `.npmrc` so npm will only resolve dependency versions published at least one day ago, reducing exposure to freshly published malicious packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2788a286cf40cbf1fea6ac8891d9416f798fad6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->