### PR TITLE
[CHIA-4266] Add get_full_node_peer_count to WC

### DIFF
--- a/packages/api-react/src/services/index.ts
+++ b/packages/api-react/src/services/index.ts
@@ -168,6 +168,7 @@ export const {
   useGetHeightInfoQuery,
   useGetPuzzleAndSolutionMutation,
   useGetNetworkInfoQuery,
+  useGetFullNodePeerCountQuery,
   useGetSyncStatusQuery,
   useGetWalletConnectionsQuery,
   useGetAllOffersQuery,

--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -623,6 +623,8 @@ export const walletApi = apiWithTag.injectEndpoints({
 
     getNetworkInfo: query(build, WalletService, 'getNetworkInfo'),
 
+    getFullNodePeerCount: query(build, WalletService, 'getFullNodePeerCount'),
+
     getSyncStatus: query(build, WalletService, 'getSyncStatus', {
       onCacheEntryAdded: onCacheEntryAddedInvalidate(baseQuery, api, [
         {
@@ -1630,6 +1632,7 @@ export const {
   useGetHeightInfoQuery,
   useGetPuzzleAndSolutionMutation,
   useGetNetworkInfoQuery,
+  useGetFullNodePeerCountQuery,
   useGetSyncStatusQuery,
   useGetWalletConnectionsQuery,
   useGetAllOffersQuery,

--- a/packages/api/src/services/WalletService.test.ts
+++ b/packages/api/src/services/WalletService.test.ts
@@ -608,6 +608,21 @@ describe('WalletService', () => {
     expect(client.send).toHaveBeenCalledWith(...expected);
   });
 
+  it('calls get_full_node_peer_count', async () => {
+    const expected = [
+      new Message({
+        command: 'get_full_node_peer_count',
+        destination: 'chia_wallet',
+        origin: 'test_origin' as ServiceNameValue,
+      }),
+      undefined,
+      undefined,
+    ];
+
+    await service.getFullNodePeerCount();
+    expect(client.send).toHaveBeenCalledWith(...expected);
+  });
+
   it('calls get_sync_status', async () => {
     const expected = [
       new Message({

--- a/packages/api/src/services/WalletService.ts
+++ b/packages/api/src/services/WalletService.ts
@@ -305,6 +305,10 @@ export default class Wallet extends Service {
     return this.command<{ networkName: string; networkPrefix: string }>('get_network_info');
   }
 
+  async getFullNodePeerCount() {
+    return this.command<{ peerCount: number }>('get_full_node_peer_count');
+  }
+
   async getSyncStatus() {
     return this.command<{
       genesisInitialized: boolean;

--- a/packages/gui/src/electron/commands/Commands.test.ts
+++ b/packages/gui/src/electron/commands/Commands.test.ts
@@ -25,4 +25,15 @@ describe('Commands', () => {
       });
     });
   });
+
+  describe('chia_getFullNodePeerCount transform', () => {
+    it('unwraps the daemon response to the peer count', () => {
+      const transform = Commands['chia_wallet.get_full_node_peer_count'].dapp?.find(
+        ({ command }) => command === 'chia_getFullNodePeerCount',
+      )?.transform;
+
+      expect(transform).toBeDefined();
+      expect(transform?.({ peer_count: 8, success: true })).toBe(8);
+    });
+  });
 });

--- a/packages/gui/src/electron/commands/Commands.ts
+++ b/packages/gui/src/electron/commands/Commands.ts
@@ -1879,6 +1879,24 @@ export const Commands: Record<string, CommandSchema> = {
     ],
   },
 
+  'chia_wallet.get_full_node_peer_count': {
+    title: () => i18n._(/* i18n */ { id: 'Get Full Node Peer Count' }),
+    message: () =>
+      i18n._(/* i18n */ { id: 'Requests the number of full node peers currently connected to the wallet' }),
+    confirmLabel: () => i18n._(/* i18n */ { id: 'Proceed' }),
+    params: [],
+    dapp: [
+      {
+        command: 'chia_getFullNodePeerCount',
+        title: () => i18n._(/* i18n */ { id: 'Get Full Node Peer Count' }),
+        message: () =>
+          i18n._(/* i18n */ { id: 'Requests the number of full node peers currently connected to the wallet' }),
+        transform: (data) => data.peer_count,
+        allowConfirmationBypass: true,
+      },
+    ],
+  },
+
   'chia_wallet.get_height_info': {
     title: () => i18n._(/* i18n */ { id: 'Get Height Info' }),
     message: () =>

--- a/packages/gui/src/electron/commands/isAllowedCommand.ts
+++ b/packages/gui/src/electron/commands/isAllowedCommand.ts
@@ -33,6 +33,7 @@ const ALLOWED_COMMANDS_SET = new Set<keyof typeof Commands>([
   'chia_wallet.get_logged_in_fingerprint',
   'chia_wallet.get_notifications',
   'chia_wallet.get_sync_status',
+  'chia_wallet.get_full_node_peer_count',
   'chia_wallet.get_wallets',
   'chia_wallet.get_coin_records_by_names',
   'chia_wallet.select_coins',

--- a/packages/gui/src/electron/commands/isDappAllowedCommand.ts
+++ b/packages/gui/src/electron/commands/isDappAllowedCommand.ts
@@ -5,6 +5,7 @@ const DAPP_ALLOWED_COMMANDS = new Set<keyof typeof Commands>([
   'chia_wallet.get_wallets',
   'chia_wallet.get_next_address',
   'chia_wallet.get_sync_status',
+  'chia_wallet.get_full_node_peer_count',
   'chia_wallet.get_coin_records_by_names',
   'chia_wallet.select_coins',
   'chia_wallet.get_height_info',


### PR DESCRIPTION
This PR exposes the new wallet RPC API function from [here](https://github.com/Chia-Network/chia-blockchain/pull/20962) to the WalletConnect functionality where it will be incredibly helpful for applications.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only status query with no transaction or key handling; follows the same pattern as `get_sync_status`.
> 
> **Overview**
> Adds end-to-end support for the wallet RPC **`get_full_node_peer_count`**, so apps can read how many full-node peers the wallet is connected to (aligned with chia-blockchain).
> 
> **API layer:** `WalletService.getFullNodePeerCount()` and an RTK Query endpoint with **`useGetFullNodePeerCountQuery`**.
> 
> **WalletConnect / dapps:** New **`chia_getFullNodePeerCount`** command; the dapp response is reduced to the numeric **`peer_count`** (not the full RPC payload). The command is on the renderer allowlist and the dapp no-confirmation allowlist, with tests for the RPC wiring and the transform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 534bc0c267ed23563ba7da6c05392f3d9c498376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->