### PR TITLE
[CHIA-4389] Enabled to choose port to run GUI

### DIFF
--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -895,7 +895,7 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
 
     const startUrl =
       process.env.NODE_ENV === 'development'
-        ? `http://localhost:${process.env.PORT || 3000}`
+        ? `http://localhost:${Number(process.env.CHIA_GUI_PORT) || 3000}`
         : url.format({
             pathname: path.join(__dirname, '/../renderer/index.html'),
             protocol: 'file:',

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -895,7 +895,7 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
 
     const startUrl =
       process.env.NODE_ENV === 'development'
-        ? 'http://localhost:3000'
+        ? `http://localhost:${process.env.PORT || 3000}`
         : url.format({
             pathname: path.join(__dirname, '/../renderer/index.html'),
             protocol: 'file:',

--- a/packages/gui/webpack.react.babel.ts
+++ b/packages/gui/webpack.react.babel.ts
@@ -6,7 +6,7 @@ import TerserPlugin from 'terser-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import LodashModuleReplacementPlugin from 'lodash-webpack-plugin';
 
-const PORT = 3000;
+const PORT = Number(process.env.PORT) || 3000;
 const CONTEXT = __dirname;
 const DEV = process.env.NODE_ENV !== 'production';
 

--- a/packages/gui/webpack.react.babel.ts
+++ b/packages/gui/webpack.react.babel.ts
@@ -1,10 +1,13 @@
 import webpack from 'webpack';
 import path from 'path';
+import dotenv from 'dotenv';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import LoadablePlugin from '@loadable/webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import LodashModuleReplacementPlugin from 'lodash-webpack-plugin';
+
+dotenv.config({ path: path.join(__dirname, '.env') });
 
 const PORT = Number(process.env.CHIA_GUI_PORT) || 3000;
 const CONTEXT = __dirname;

--- a/packages/gui/webpack.react.babel.ts
+++ b/packages/gui/webpack.react.babel.ts
@@ -6,7 +6,7 @@ import TerserPlugin from 'terser-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import LodashModuleReplacementPlugin from 'lodash-webpack-plugin';
 
-const PORT = Number(process.env.PORT) || 3000;
+const PORT = Number(process.env.CHIA_GUI_PORT) || 3000;
 const CONTEXT = __dirname;
 const DEV = process.env.NODE_ENV !== 'production';
 


### PR DESCRIPTION
Allowed to set port from env. Only effective in dev.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only URL and webpack devServer port wiring; no production load path or security-sensitive logic changes.
> 
> **Overview**
> **Development** GUI port is no longer fixed at 3000. Set **`CHIA_GUI_PORT`** (env or `packages/gui/.env` via webpack’s new `dotenv` load) and both the React **webpack dev server** and the **Electron** dev `loadURL` use that port, with **3000** as the fallback.
> 
> Production builds are unchanged: Electron still loads the packaged `file://` renderer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7196a67facfc5949ab4c35cc04df0043df5ab2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->