### PR TITLE
[CHIA-4226] Fix GUI not appearing when ready-to-show event doesn't fire

### DIFF
--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -807,13 +807,23 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
       mainWindow.setIcon(appIcon);
     }
 
-    mainWindow.once('ready-to-show', () => {
-      if (!mainWindow) {
-        throw new Error('`mainWindow` is empty');
+    // Reveal the window. `ready-to-show` is the preferred fast path, but on some
+    // compositors (notably Wayland/mutter) that event can fail to fire, which
+    // would otherwise leave the window hidden forever even though the page has
+    // loaded. Guard the show in a once-only helper and back it with
+    // `did-finish-load` and a timeout fallback so the window is always revealed.
+    let hasShownMainWindow = false;
+    const showMainWindow = () => {
+      if (hasShownMainWindow || !mainWindow) {
+        return;
       }
-
+      hasShownMainWindow = true;
       mainWindow.show();
-    });
+    };
+
+    mainWindow.once('ready-to-show', showMainWindow);
+    mainWindow.webContents.once('did-finish-load', showMainWindow);
+    setTimeout(showMainWindow, 5000);
 
     // don't show remote daeomn detials in the title bar
     if (!manageDaemonLifetime(NET)) {

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -814,11 +814,15 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
     // `did-finish-load` and a timeout fallback so the window is always revealed.
     let hasShownMainWindow = false;
     const showMainWindow = () => {
-      if (hasShownMainWindow || !mainWindow) {
+      // `mainWindow` is never reset to null on close, so a destroyed window is
+      // still a truthy reference; guard with `isDestroyed()` to avoid throwing
+      // if a trigger fires after the window is gone. Latch the flag only after a
+      // successful `show()` so a failed attempt doesn't block the other triggers.
+      if (hasShownMainWindow || !mainWindow || mainWindow.isDestroyed()) {
         return;
       }
-      hasShownMainWindow = true;
       mainWindow.show();
+      hasShownMainWindow = true;
     };
 
     mainWindow.once('ready-to-show', showMainWindow);


### PR DESCRIPTION
Addressing https://github.com/Chia-Network/chia-blockchain-gui/issues/2940

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Electron startup/window visibility logic with idempotent guards; no auth, data, or network behavior changes.
> 
> **Overview**
> Fixes a case where the Chia GUI could stay invisible on Linux (especially **Wayland/mutter**) when Electron’s **`ready-to-show`** event never fires, even though the renderer has loaded.
> 
> Window reveal is now handled by a **once-only** `showMainWindow` helper that calls `mainWindow.show()` only if the window still exists and isn’t destroyed, and sets a latch **after** a successful show so other triggers can still run if show fails. **`ready-to-show`** remains the primary path, with **`webContents` `did-finish-load`** and a **5s timeout** as fallbacks so the main window is shown at most once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1db82f777fc28123157cc1c32330ecf98fa5b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->