### PR TITLE
[CHIA-4295] fix_dialog_popup_loading

### DIFF
--- a/packages/gui/src/electron/utils/openReactDialog.tsx
+++ b/packages/gui/src/electron/utils/openReactDialog.tsx
@@ -309,7 +309,25 @@ export default function openReactDialog<TResponse, TProps extends object>(
       // open dev tools
       // dialog.webContents.openDevTools();
 
-      dialog.once('ready-to-show', () => dialog.show());
+      // Reveal the dialog. `ready-to-show` is the preferred fast path, but on some
+      // compositors (notably Wayland/mutter) that event can fail to fire, which
+      // would otherwise leave the dialog hidden forever even though the page has
+      // loaded. Guard the show in a once-only helper and back it with
+      // `did-finish-load` and a timeout fallback so the dialog is always revealed.
+      let hasShownDialog = false;
+      const showDialog = () => {
+        // Latch the flag only after a successful `show()` so a failed attempt
+        // doesn't block the other triggers.
+        if (hasShownDialog || dialog.isDestroyed()) {
+          return;
+        }
+        dialog.show();
+        hasShownDialog = true;
+      };
+
+      dialog.once('ready-to-show', showDialog);
+      dialog.webContents.once('did-finish-load', showDialog);
+      setTimeout(showDialog, 5000);
 
       if (hideMenu) {
         dialog.setMenu(null);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized UX fix in dialog show timing with no auth, data, or API behavior changes; worst case is a dialog appearing slightly earlier than ideal on the fallback path.
> 
> **Overview**
> Fixes React modal dialogs in the Electron GUI staying invisible on some Linux setups (especially **Wayland/mutter**) when Electron’s **`ready-to-show`** event never fires, even though the dialog page has loaded.
> 
> **`openReactDialog`** now uses a single **`showDialog`** helper with a latch so **`show()`** runs at most once: still on **`ready-to-show`**, plus **`did-finish-load`** and a **5s timeout** as fallbacks. The latch is set only after a successful show so a failed attempt does not block the other triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 841f1279a9ead647b36713f3d22c85156ac99b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->