### PR TITLE
CHIA-4297 - GUI Bug: Plot NFT assigned to a different key

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -1061,8 +1061,9 @@ export const walletApi = apiWithTag.injectEndpoints({
 
           poolStates.forEach((poolStateItem: any) => {
             const poolWalletStatus = poolWalletStates.find(
-              (item) => item.launcherId === poolStateItem.poolConfig.launcherId,
+              (item) => normalizeHex(item.launcherId) === normalizeHex(poolStateItem.poolConfig.launcherId),
             );
+
             if (!poolWalletStatus) {
               external.push({
                 poolState: normalizePoolState(poolStateItem),

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -53,7 +53,7 @@ import PreferencesAPI from './constants/PreferencesAPI';
 import About from './dialogs/About/About';
 import Confirm, { type ConfirmProps } from './dialogs/Confirm/Confirm';
 import KeyDetail from './dialogs/KeyDetail/KeyDetail';
-import { readPrefs, savePrefs, migratePrefs } from './prefs';
+import { readPrefs, savePrefs, migratePrefs, sanitizeRendererPrefs } from './prefs';
 import { readAddressBook, saveAddressBook } from './utils/addressBook';
 import chiaEnvironment, { chiaInit } from './utils/chiaEnvironment';
 import { dispatchPairRequest } from './utils/dispatchPairRequest';


### PR DESCRIPTION
use the correct comparison for launcherId

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted ID normalization for plot NFT display plus prefs sanitization on IPC; no auth or transaction logic changes.
> 
> **Overview**
> Fixes **CHIA-4297**, where Plot NFTs could look tied to the wrong key because farmer `poolState` and wallet pool status were joined on raw `launcherId` strings.
> 
> `getPlotNFTs` now compares **`normalizeHex`** on both `poolWalletStatus.launcherId` and `poolConfig.launcherId`, so `0x` prefix and casing differences from newer RPC responses no longer break the match (and mis-route NFTs into the `external` bucket).
> 
> The Electron main process also **sanitizes renderer preference payloads** on save/migrate via `sanitizeRendererPrefs`, so protected keys such as `customLogPath` cannot be changed from the renderer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97bb7b0faf46910cf200555c45b9678a9c00f2f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->