### PR TITLE
checkpoint: into main from release/2.7.3  @ e71ee50d32a5a88692397978db6217aaa5faa951

### DIFF
--- a/packages/gui/src/electron/utils/openReactDialog.tsx
+++ b/packages/gui/src/electron/utils/openReactDialog.tsx
@@ -309,7 +309,25 @@ export default function openReactDialog<TResponse, TProps extends object>(
       // open dev tools
       // dialog.webContents.openDevTools();
 
-      dialog.once('ready-to-show', () => dialog.show());
+      // Reveal the dialog. `ready-to-show` is the preferred fast path, but on some
+      // compositors (notably Wayland/mutter) that event can fail to fire, which
+      // would otherwise leave the dialog hidden forever even though the page has
+      // loaded. Guard the show in a once-only helper and back it with
+      // `did-finish-load` and a timeout fallback so the dialog is always revealed.
+      let hasShownDialog = false;
+      const showDialog = () => {
+        // Latch the flag only after a successful `show()` so a failed attempt
+        // doesn't block the other triggers.
+        if (hasShownDialog || dialog.isDestroyed()) {
+          return;
+        }
+        dialog.show();
+        hasShownDialog = true;
+      };
+
+      dialog.once('ready-to-show', showDialog);
+      dialog.webContents.once('did-finish-load', showDialog);
+      setTimeout(showDialog, 5000);
 
       if (hideMenu) {
         dialog.setMenu(null);


### PR DESCRIPTION
Source hash: e71ee50d32a5a88692397978db6217aaa5faa951
Remaining commits: 2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Electron window lifecycle change with no security or data impact; minor risk of an early show before paint on slow loads, mitigated by the usual fast path.
> 
> **Overview**
> Fixes React modal dialogs in the Electron GUI staying invisible on some Linux setups (especially **Wayland/mutter**) when **`ready-to-show`** never fires, even though the page has loaded.
> 
> **`openReactDialog`** now uses a once-only **`showDialog`** helper that still prefers **`ready-to-show`**, but also shows on **`did-finish-load`** and a **5s timeout** fallback. A latch runs only after a successful **`show()`**, and **`isDestroyed()`** is checked so duplicate triggers do not error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf06c0a057f80923d899b963024de2afcdd6fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->