### PR TITLE
CHIA-4304 - "Error: Asset type is not valid" when creating Offer to sell NFT

### DIFF
--- a/packages/gui/src/components/offers/NFTOfferEditor.tsx
+++ b/packages/gui/src/components/offers/NFTOfferEditor.tsx
@@ -528,7 +528,7 @@ function buildOfferRequest(params: NFTBuildOfferRequestParams) {
       [nftLauncherId]: nftAmount,
       [tokenWalletInfo.walletId]: mojoAmount,
     },
-    exchangeType === NFTOfferExchangeType.TokenForNFT ? driverDict : undefined,
+    driverDict,
     feeMojoAmount,
   ];
 }

--- a/packages/gui/src/electron/api/catAssetIdToName.ts
+++ b/packages/gui/src/electron/api/catAssetIdToName.ts
@@ -1,7 +1,8 @@
 import { sendCommand } from './sendCommand';
 
 type CatAssetIdToNameResponse = {
-  name?: string;
+  wallet_id?: number | null;
+  name?: string | null;
 };
 
 export async function catAssetIdToName(assetId: string) {

--- a/packages/gui/src/electron/api/resolveAssetDisplayKind.ts
+++ b/packages/gui/src/electron/api/resolveAssetDisplayKind.ts
@@ -24,7 +24,7 @@ export default async function resolveAssetDisplayKind(assetId: string): Promise<
   try {
     const catInfo = await catAssetIdToName(normalizedAssetId);
 
-    if (catInfo.wallet_id != null || catInfo.name != null) {
+    if (catInfo.wallet_id !== null || catInfo.name !== null) {
       return 'cat';
     }
   } catch {

--- a/packages/gui/src/electron/api/resolveAssetDisplayKind.ts
+++ b/packages/gui/src/electron/api/resolveAssetDisplayKind.ts
@@ -1,0 +1,35 @@
+import { catAssetIdToName } from './catAssetIdToName';
+import { nftGetInfo } from './nftGetInfo';
+
+export type ResolvedAssetDisplayKind = 'cat' | 'nft';
+
+function normalizeAssetId(assetId: string): string {
+  return (assetId.startsWith('0x') ? assetId.slice(2) : assetId).toLowerCase();
+}
+
+export default async function resolveAssetDisplayKind(assetId: string): Promise<ResolvedAssetDisplayKind | undefined> {
+  const normalizedAssetId = normalizeAssetId(assetId);
+
+  try {
+    const nftInfo = await nftGetInfo(normalizedAssetId);
+    const launcherId = nftInfo.nft_info?.launcher_id;
+
+    if (launcherId && normalizeAssetId(launcherId) === normalizedAssetId) {
+      return 'nft';
+    }
+  } catch {
+    // The wallet does not have indexed NFT data for this launcher ID.
+  }
+
+  try {
+    const catInfo = await catAssetIdToName(normalizedAssetId);
+
+    if (catInfo.wallet_id != null || catInfo.name != null) {
+      return 'cat';
+    }
+  } catch {
+    // The asset is not a CAT known to the local wallet.
+  }
+
+  return undefined;
+}

--- a/packages/gui/src/electron/api/resolveAssetDisplayKind.ts
+++ b/packages/gui/src/electron/api/resolveAssetDisplayKind.ts
@@ -24,7 +24,10 @@ export default async function resolveAssetDisplayKind(assetId: string): Promise<
   try {
     const catInfo = await catAssetIdToName(normalizedAssetId);
 
-    if (catInfo.wallet_id !== null || catInfo.name !== null) {
+    if (
+      (catInfo.wallet_id !== null && catInfo.wallet_id !== undefined) ||
+      (catInfo.name !== null && catInfo.name !== undefined)
+    ) {
       return 'cat';
     }
   } catch {

--- a/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
@@ -16,7 +16,7 @@ const mockGetWalletNames = jest.fn<Promise<WalletNamesResponse>, []>();
 const mockGetWalletInfos = jest.fn<Promise<WalletInfosResponse>, []>();
 const mockGetOfferSummary = jest.fn<Promise<OfferSummaryResponse | null>, [string]>();
 const mockNftGetInfo = jest.fn<Promise<unknown>, [string]>();
-const mockCatAssetIdToName = jest.fn<Promise<{ name?: string }>, [string]>();
+const mockCatAssetIdToName = jest.fn<Promise<{ wallet_id?: number | null; name?: string | null }>, [string]>();
 
 jest.mock('../api/catAssetIdToName', () => ({
   catAssetIdToName: mockCatAssetIdToName,
@@ -91,7 +91,7 @@ describe('parseCommandDisplay', () => {
     expect(mockGetWalletInfos).toHaveBeenCalledWith();
   });
 
-  it('uses the legacy CAT fallback for requested bytes32 create-offer assets without drivers', async () => {
+  it('resolves driverless requested CAT assets from the local wallet', async () => {
     const assetId = '1234567890123456789012345678901234567890123456789012345678901234';
 
     mockGetWalletInfos.mockResolvedValue({
@@ -116,7 +116,7 @@ describe('parseCommandDisplay', () => {
         ],
       },
     });
-    expect(mockNftGetInfo).not.toHaveBeenCalled();
+    expect(mockNftGetInfo).toHaveBeenCalledWith(assetId);
   });
 
   it('fails closed when create-offer params use xch keys instead of numeric wallet IDs', async () => {
@@ -488,9 +488,11 @@ describe('parseCommandDisplay', () => {
     expect(mockNftGetInfo).not.toHaveBeenCalled();
   });
 
-  it('fails closed for unresolved create-offer spending-side bytes32 assets without drivers', async () => {
+  it('renders unresolved create-offer spending-side bytes32 assets as unknown', async () => {
     const assetId = '31ffd54c5b38bb33352dc0be0ebf9cf4f29a6329156dd4811d6f4254f85c8200';
     mockGetWalletInfos.mockResolvedValue({});
+    mockNftGetInfo.mockRejectedValue(new Error('NFT not found'));
+    mockCatAssetIdToName.mockRejectedValue(new Error('CAT not found'));
 
     await expect(
       parseCommandDisplay('chia_wallet.create_offer_for_ids', {
@@ -498,9 +500,100 @@ describe('parseCommandDisplay', () => {
           [assetId]: '-1000',
         },
       }),
-    ).rejects.toThrow('Asset type is not valid');
+    ).resolves.toMatchObject({
+      walletDelta: {
+        spending: [
+          {
+            kind: 'unknown',
+            assetId,
+            amount: '1000',
+          },
+        ],
+      },
+    });
+    expect(mockCatAssetIdToName).toHaveBeenCalledWith(assetId);
+    expect(mockNftGetInfo).toHaveBeenCalledWith(assetId);
+  });
+
+  it('resolves driverless offered NFTs from the local wallet', async () => {
+    const assetId = '31ffd54c5b38bb33352dc0be0ebf9cf4f29a6329156dd4811d6f4254f85c8200';
+    mockGetWalletInfos.mockResolvedValue({});
+    mockNftGetInfo.mockResolvedValue({
+      nft_info: {
+        launcher_id: `0x${assetId}`,
+      },
+    });
+
+    await expect(
+      parseCommandDisplay('chia_wallet.create_offer_for_ids', {
+        offer: {
+          [assetId]: '-1',
+        },
+      }),
+    ).resolves.toMatchObject({
+      walletDelta: {
+        spending: [
+          {
+            kind: 'nft',
+          },
+        ],
+      },
+    });
     expect(mockCatAssetIdToName).not.toHaveBeenCalled();
-    expect(mockNftGetInfo).not.toHaveBeenCalled();
+  });
+
+  it('renders a CAT lookup with no wallet or name as unknown', async () => {
+    const assetId = '31ffd54c5b38bb33352dc0be0ebf9cf4f29a6329156dd4811d6f4254f85c8200';
+    mockGetWalletInfos.mockResolvedValue({});
+    mockNftGetInfo.mockRejectedValue(new Error('NFT not found'));
+    mockCatAssetIdToName.mockResolvedValue({ wallet_id: null, name: null });
+
+    await expect(
+      parseCommandDisplay('chia_wallet.create_offer_for_ids', {
+        offer: {
+          [assetId]: '-1',
+        },
+      }),
+    ).resolves.toMatchObject({
+      walletDelta: {
+        spending: [
+          {
+            kind: 'unknown',
+            assetId,
+            amount: '1',
+          },
+        ],
+      },
+    });
+  });
+
+  it('does not classify an NFT when its launcher ID does not match the offer asset ID', async () => {
+    const assetId = '31ffd54c5b38bb33352dc0be0ebf9cf4f29a6329156dd4811d6f4254f85c8200';
+    mockGetWalletInfos.mockResolvedValue({});
+    mockNftGetInfo.mockResolvedValue({
+      nft_info: {
+        launcher_id: 'd82dd03f8a9ad2f84353cd953c4de6b21dbaaf7de3ba3f4ddd9abe31ecba80ad',
+      },
+    });
+    mockCatAssetIdToName.mockRejectedValue(new Error('CAT not found'));
+
+    await expect(
+      parseCommandDisplay('chia_wallet.create_offer_for_ids', {
+        offer: {
+          [assetId]: '-1',
+        },
+      }),
+    ).resolves.toMatchObject({
+      walletDelta: {
+        spending: [
+          {
+            kind: 'unknown',
+            assetId,
+            amount: '1',
+          },
+        ],
+      },
+    });
   });
 
   it('fails closed for take-offer bytes32 assets missing offer summary type info', async () => {

--- a/packages/gui/src/electron/commands/parseCommandDisplay.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.ts
@@ -2,6 +2,7 @@ import { catAssetIdToName } from '../api/catAssetIdToName';
 import { getOfferSummary } from '../api/getOfferSummary';
 import { getWalletInfos, type WalletInfo } from '../api/getWalletNames';
 import { nftGetInfo } from '../api/nftGetInfo';
+import resolveAssetDisplayKind from '../api/resolveAssetDisplayKind';
 import WalletType from '../constants/WalletType';
 import type { DisplayWalletDelta, DisplayWalletDeltaItem } from '../dialogs/Confirm/Confirm';
 import { isNumericKey } from '../utils/isNumericKey';
@@ -13,7 +14,7 @@ import { parseMojos } from '../utils/parseMojos';
 import toBech32m from '../utils/toBech32m';
 import { type WalletDelta, offerSummaryToWalletDelta, createOfferToWalletDelta } from '../utils/walletDelta';
 
-type AssetDisplayKind = 'chia' | 'wallet' | 'cat' | 'nft';
+type AssetDisplayKind = 'chia' | 'wallet' | 'cat' | 'nft' | 'unknown';
 
 type AssetDisplayKinds = {
   spending: Record<string, AssetDisplayKind | undefined>;
@@ -205,33 +206,37 @@ function offerSummaryRoyaltyPercentages(offerSummary: OfferSummaryForDisplay): A
   return royaltyPercentages;
 }
 
-function createOfferAssetKinds(
+async function createOfferAssetKinds(
   walletDelta: WalletDelta,
   walletInfos: Record<string, WalletInfo>,
   driverDict: Record<string, unknown>,
-): AssetDisplayKinds {
+): Promise<AssetDisplayKinds> {
   const assetKinds: AssetDisplayKinds = {
     spending: {},
     receiving: {},
   };
 
-  for (const assetId of Object.keys(walletDelta.spending)) {
-    if (isNumericKey(assetId)) {
-      assetKinds.spending[assetId] = assetKindForWalletId(assetId, walletInfos);
-    } else {
-      assetKinds.spending[assetId] = assetKindForDriverDictAssetId(assetId, driverDict);
+  async function resolveAssetKind(assetId: string): Promise<AssetDisplayKind> {
+    const driverKind = assetKindForDriverDictAssetId(assetId, driverDict);
+    if (driverKind !== undefined) {
+      return driverKind;
     }
+
+    return (await resolveAssetDisplayKind(assetId)) ?? 'unknown';
   }
 
-  for (const assetId of Object.keys(walletDelta.receiving)) {
-    if (isNumericKey(assetId)) {
-      assetKinds.receiving[assetId] = assetKindForWalletId(assetId, walletInfos);
-    } else {
-      // Backend legacy behavior treats positive requested bytes32 assets with
-      // no explicit driver as CATs.
-      assetKinds.receiving[assetId] = assetKindForDriverDictAssetId(assetId, driverDict) ?? 'cat';
-    }
-  }
+  await Promise.all([
+    ...Object.keys(walletDelta.spending).map(async (assetId) => {
+      assetKinds.spending[assetId] = isNumericKey(assetId)
+        ? assetKindForWalletId(assetId, walletInfos)
+        : await resolveAssetKind(assetId);
+    }),
+    ...Object.keys(walletDelta.receiving).map(async (assetId) => {
+      assetKinds.receiving[assetId] = isNumericKey(assetId)
+        ? assetKindForWalletId(assetId, walletInfos)
+        : await resolveAssetKind(assetId);
+    }),
+  ]);
 
   return assetKinds;
 }
@@ -328,6 +333,14 @@ async function parseWalletDeltaItem(
     return result;
   }
 
+  if (assetKind === 'unknown') {
+    return {
+      kind: 'unknown',
+      assetId: key,
+      amount: value.toString(),
+    };
+  }
+
   if (assetKind !== 'cat') {
     throw new Error('Asset type is not valid');
   }
@@ -338,7 +351,7 @@ async function parseWalletDeltaItem(
     kind: 'cat',
     amount: mojoToCATLocaleString(value),
     assetId: key,
-    symbol: name,
+    symbol: name ?? undefined,
   };
 }
 
@@ -471,7 +484,7 @@ export async function parseCommandDisplay(command: string, params: Record<string
     const walletDelta = createOfferToWalletDelta(params.offer);
     const walletInfos = await getWalletInfos();
     const driverDict = params.driver_dict ?? {};
-    const assetKinds = createOfferAssetKinds(walletDelta, walletInfos, driverDict);
+    const assetKinds = await createOfferAssetKinds(walletDelta, walletInfos, driverDict);
     const royaltyPercentages = createOfferRoyaltyPercentages(walletDelta, driverDict);
 
     return {

--- a/packages/gui/src/electron/dialogs/Confirm/Confirm.tsx
+++ b/packages/gui/src/electron/dialogs/Confirm/Confirm.tsx
@@ -158,9 +158,7 @@ function OfferLineRow({ line, networkPrefix }: { line: DisplayWalletDeltaItem; n
   if (line.kind === 'unknown') {
     return (
       <div className="flex items-baseline gap-3">
-        <span className="text-sm font-medium text-chia-text">
-          {i18n._(/* i18n */ { id: 'Unknown Asset' })}
-        </span>
+        <span className="text-sm font-medium text-chia-text">{i18n._(/* i18n */ { id: 'Unknown Asset' })}</span>
         <span className="text-xs font-mono text-chia-text-secondary truncate max-w-[55%]">
           {shortenId(line.assetId)}
         </span>

--- a/packages/gui/src/electron/dialogs/Confirm/Confirm.tsx
+++ b/packages/gui/src/electron/dialogs/Confirm/Confirm.tsx
@@ -20,7 +20,8 @@ export type DisplayWalletDeltaItem =
   | { kind: 'xch'; amount: string; amountWithRoyalties?: string }
   | { kind: 'wallet'; walletId: string; amount: string; walletName?: string; amountWithRoyalties?: string }
   | { kind: 'cat'; amount: string; assetId: string; symbol?: string; amountWithRoyalties?: string }
-  | { kind: 'nft'; nftId: string; name?: string; previewUrl?: string; royaltyPercentage?: number };
+  | { kind: 'nft'; nftId: string; name?: string; previewUrl?: string; royaltyPercentage?: number }
+  | { kind: 'unknown'; assetId: string; amount: string };
 
 export type DisplayWalletDelta = {
   spending: DisplayWalletDeltaItem[];
@@ -94,6 +95,7 @@ function offerLineKey(line: DisplayWalletDeltaItem, index: number): string {
   if (line.kind === 'xch') return `xch-${line.amount}-${index}`;
   if (line.kind === 'wallet') return `wallet-${line.walletId}-${line.amount}-${index}`;
   if (line.kind === 'cat') return `cat-${line.assetId}-${line.amount}-${index}`;
+  if (line.kind === 'unknown') return `unknown-${line.assetId}-${line.amount}-${index}`;
   return `nft-${line.nftId}-${index}`;
 }
 
@@ -150,6 +152,21 @@ function OfferLineRow({ line, networkPrefix }: { line: DisplayWalletDeltaItem; n
             {i18n._(/* i18n */ { id: 'Total Amount with Royalties' })}: {line.amountWithRoyalties}
           </div>
         )}
+      </div>
+    );
+  }
+  if (line.kind === 'unknown') {
+    return (
+      <div className="flex items-baseline gap-3">
+        <span className="text-sm font-medium text-chia-text">
+          {i18n._(/* i18n */ { id: 'Unknown Asset' })}
+        </span>
+        <span className="text-xs font-mono text-chia-text-secondary truncate max-w-[55%]">
+          {shortenId(line.assetId)}
+        </span>
+        <span className="text-xs font-mono text-chia-text-secondary">
+          {i18n._(/* i18n */ { id: 'Raw Amount' })}: {line.amount}
+        </span>
       </div>
     );
   }

--- a/packages/gui/src/util/prepareNFTOffer.test.ts
+++ b/packages/gui/src/util/prepareNFTOffer.test.ts
@@ -110,7 +110,9 @@ describe('prepareNFTOffer', () => {
     expect(result.nft).toEqual(nftInfo);
     expect(result.id).toBe('8123ec891d048488ed110baff5b047e5b11e5ca4ee7a81c2ba04abf3eda4f077');
     expect(result.amount).toEqual(new BigNumber(-1));
-    expect(result.driver).toBeUndefined();
+    expect(result.driver).toBeTruthy();
+    expect(result.driver!.type).toBe('singleton');
+    expect(result.driver!.launcher_id).toBe(nftInfo.launcherId);
   });
 
   it('includes the ownership field if nft.supportsDid is true', () => {

--- a/packages/gui/src/util/prepareNFTOffer.ts
+++ b/packages/gui/src/util/prepareNFTOffer.ts
@@ -70,6 +70,6 @@ export function prepareNFTOffer(nft: NFTInfo, offeredNFT: boolean) {
     nft,
     id,
     amount: offeredNFT ? new BigNumber(-1) : new BigNumber(1),
-    driver: !offeredNFT ? driver : undefined,
+    driver,
   };
 }


### PR DESCRIPTION
add support for unknown assets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offer creation payloads and confirm-time asset classification for create-offer flows; incorrect resolution could mislabel assets in the UI but does not bypass wallet signing.
> 
> **Overview**
> Fixes **"Asset type is not valid"** when confirming **sell-NFT** offers by always attaching the NFT **singleton `driver_dict`** (not only on buy flows) in `NFTOfferEditor` / `prepareNFTOffer`.
> 
> Offer confirmation parsing no longer assumes driverless bytes32 legs are CATs or hard-fails. **`resolveAssetDisplayKind`** classifies assets via local **`nft_get_info`** / **`cat_asset_id_to_name`** (with launcher-ID matching for NFTs). Unresolved legs render as **`unknown`** in the confirm dialog instead of throwing. **`take_offer`** display behavior for missing summary types is unchanged (still fails closed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3646542d863271446e0eb7cf9ed49e624322d441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->