### PR TITLE
[CHIA-4305] allow confirm bypass for getHeightInfo

### DIFF
--- a/packages/gui/src/electron/commands/Commands.ts
+++ b/packages/gui/src/electron/commands/Commands.ts
@@ -1913,6 +1913,7 @@ export const Commands: Record<string, CommandSchema> = {
           is_transaction_block: data.is_transaction_block ?? null,
           prev_transaction_block_height: data.prev_transaction_block_height ?? null,
         }),
+        allowConfirmationBypass: true,
       },
     ],
   },

--- a/packages/gui/src/electron/commands/Commands.ts
+++ b/packages/gui/src/electron/commands/Commands.ts
@@ -1698,6 +1698,7 @@ export const Commands: Record<string, CommandSchema> = {
         message: () =>
           i18n._(/* i18n */ { id: "Requests the status of a list of coin records from the Wallet's coin store." }),
         defaults: { include_spent_coins: true },
+        allowConfirmationBypass: true,
       },
     ],
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only dapp command metadata only; bypass still requires explicit user-granted permissions like existing query commands.
> 
> **Overview**
> Marks two read-only wallet dapp APIs as eligible for **always-allow** permissions so paired apps can call them without a confirmation prompt on every request.
> 
> In `Commands.ts`, `allowConfirmationBypass: true` is added for **`chia_getHeightInfo`** (wallet height / block timestamp info) and **`chia_getCoinRecordsByNames`** (coin record lookups by name), matching other low-risk query commands like balances and sync status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af59c08838436d2e49d3c2a2add4305f7e923ba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->