### PR TITLE
checkpoint: into main from release/2.7.3  @ d90e22c7ca322bece56aa7fb023c19b989086ef2

### DIFF
--- a/packages/api-react/src/services/wallet.ts
+++ b/packages/api-react/src/services/wallet.ts
@@ -1061,8 +1061,9 @@ export const walletApi = apiWithTag.injectEndpoints({
 
           poolStates.forEach((poolStateItem: any) => {
             const poolWalletStatus = poolWalletStates.find(
-              (item) => item.launcherId === poolStateItem.poolConfig.launcherId,
+              (item) => normalizeHex(item.launcherId) === normalizeHex(poolStateItem.poolConfig.launcherId),
             );
+
             if (!poolWalletStatus) {
               external.push({
                 poolState: normalizePoolState(poolStateItem),

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -53,7 +53,7 @@ import PreferencesAPI from './constants/PreferencesAPI';
 import About from './dialogs/About/About';
 import Confirm, { type ConfirmProps } from './dialogs/Confirm/Confirm';
 import KeyDetail from './dialogs/KeyDetail/KeyDetail';
-import { readPrefs, savePrefs, migratePrefs } from './prefs';
+import { readPrefs, savePrefs, migratePrefs, sanitizeRendererPrefs } from './prefs';
 import { readAddressBook, saveAddressBook } from './utils/addressBook';
 import chiaEnvironment, { chiaInit } from './utils/chiaEnvironment';
 import { dispatchPairRequest } from './utils/dispatchPairRequest';


### PR DESCRIPTION
Source hash: d90e22c7ca322bece56aa7fb023c19b989086ef2
Remaining commits: 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fixes: ID normalization for plot wallet joins and blocking renderer writes to protected pref keys; no broad auth or transaction logic changes in this diff.
> 
> **Overview**
> **Plot NFT matching** in `getPlotNFTs` now compares farmer pool state to wallet pool status using `normalizeHex` on both `launcherId` values, so Plot NFTs still join correctly when one side uses a `0x` prefix and the other does not.
> 
> **Electron preferences IPC** imports and applies `sanitizeRendererPrefs` before persisting or migrating prefs from the renderer, so protected keys such as `customLogPath` cannot be set or changed through generic save/migrate calls (only the trusted main-process log path flow can update them).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19338545e69968e384abcc33b31c02362f88af6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->