### PR TITLE
Add 2.7.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+for setuptools_scm/PEP 440 reasons.
+
+## 2.7.3 Chia blockchain 2026-07-16
+
+### Changed
+
+- Allow `chia_getHeightInfo` and `chia_getCoinRecordsByNames` WalletConnect commands to bypass confirmation prompts for read-only queries
+
+### Fixed
+
+- Fix confirmation dialogs not appearing on Linux (especially Wayland) when the `ready-to-show` event never fires
+- Fix Plot NFTs appearing assigned to the wrong key due to `launcherId` hex normalization
+- Fix log viewing in the reference wallet GUI by restoring missing Electron main-process imports
+- Fix "Asset type is not valid" error when confirming offers to sell NFTs


### PR DESCRIPTION
Add CHANGELOG.md entry for the 2.7.3 release.

## Summary
- 1 Changed entry (WalletConnect confirmation bypass for read-only queries)
- 4 Fixed entries (dialog popup, Plot NFT key, log viewer imports, NFT offer asset type)
- GUI-only release (no chia-blockchain changes in this release branch)

Note: The BigInt parsing fix (#2981) was reverted by #2983, so it is excluded from these notes.

Changes only touch CHANGELOG.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Introduces **CHANGELOG.md** (Keep a Changelog format) and documents the **2.7.3** GUI release dated 2026-07-16.
> 
> **Changed:** WalletConnect read-only commands `chia_getHeightInfo` and `chia_getCoinRecordsByNames` may skip confirmation prompts.
> 
> **Fixed:** Linux/Wayland confirmation dialogs when `ready-to-show` never fires; Plot NFT key assignment (`launcherId` hex normalization); reference wallet log viewer (Electron main-process imports); NFT sell offers ("Asset type is not valid").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d205b8bbe257d276b512c7bf2ac8f5ec7821f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->