### PR TITLE
checkpoint: into main from release/2.7.3  @ c743718fad4f3cb3f846d0bbefee84477fec06cf

### DIFF
--- a/packages/gui/src/electron/commands/Commands.ts
+++ b/packages/gui/src/electron/commands/Commands.ts
@@ -1698,6 +1698,7 @@ export const Commands: Record<string, CommandSchema> = {
         message: () =>
           i18n._(/* i18n */ { id: "Requests the status of a list of coin records from the Wallet's coin store." }),
         defaults: { include_spent_coins: true },
+        allowConfirmationBypass: true,
       },
     ],
   },
@@ -1913,6 +1914,7 @@ export const Commands: Record<string, CommandSchema> = {
           is_transaction_block: data.is_transaction_block ?? null,
           prev_transaction_block_height: data.prev_transaction_block_height ?? null,
         }),
+        allowConfirmationBypass: true,
       },
     ],
   },


### PR DESCRIPTION
Source hash: c743718fad4f3cb3f846d0bbefee84477fec06cf
Remaining commits: 3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only flags on read-only wallet RPC wrappers; no change to spend or signing flows unless the user explicitly grants bypass permissions to a paired dapp.
> 
> **Overview**
> Two read-only wallet dapp commands in `Commands.ts` now set **`allowConfirmationBypass: true`**, matching other query APIs like balances and sync status.
> 
> **`chia_getCoinRecordsByNames`** and **`chia_getHeightInfo`** can be included in a paired app’s “always allow without confirmation” permission list (`chia_requestPermissions`), so repeated coin-store lookups and height queries no longer require a manual approve dialog when the user has granted bypass for those commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5996392d436cd70a151924dae673456975d9e151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->