### PR TITLE
Fix NFT video/audio playback, persist cache settings, add video looping, and improve NFT gallery UX

### DIFF
--- a/packages/gui/src/components/cache/CacheProvider.tsx
+++ b/packages/gui/src/components/cache/CacheProvider.tsx
@@ -1,3 +1,4 @@
+import { usePrefs } from '@chia-network/api-react';
 import React, { useMemo, useState, useEffect, useCallback, type ReactNode } from 'react';
 
 const { cacheAPI } = window;
@@ -15,6 +16,14 @@ export default function CacheProvider(props: CacheProviderProps) {
   const [cacheDirectory, setCacheDirectory] = useState<string | undefined>(undefined);
   const [cacheSize, setCacheSize] = useState<number | undefined>(undefined);
 
+  // The main process only reads these preferences at startup; changes made at
+  // runtime live in CacheManager's memory, so they are persisted here in the
+  // renderer where all other preferences are written (prefs.yaml is rewritten
+  // from the renderer's snapshot on every preference save - a main process
+  // write would be clobbered by the next renderer save).
+  const [, setMaxCacheSizePref] = usePrefs<number | undefined>('maxCacheSize', undefined);
+  const [, setCacheFolderPref] = usePrefs<string | undefined>('cacheFolder', undefined);
+
   const updateCacheSize = useCallback(async () => {
     const size = await cacheAPI.getCacheSize();
     setCacheSize(size);
@@ -30,9 +39,21 @@ export default function CacheProvider(props: CacheProviderProps) {
     setMaxCacheSize(size);
   }, []);
 
+  const handleCacheDirectoryChanged = useCallback(async () => {
+    const directory = await cacheAPI.getCacheDirectory();
+    setCacheDirectory(directory);
+    setCacheFolderPref(directory);
+  }, [setCacheFolderPref]);
+
+  const handleMaxCacheSizeChanged = useCallback(async () => {
+    const size = await cacheAPI.getMaxCacheSize();
+    setMaxCacheSize(size);
+    setMaxCacheSizePref(size);
+  }, [setMaxCacheSizePref]);
+
   useEffect(() => {
-    const unbindCacheDirectoryChanged = cacheAPI.subscribeToDirectoryChange(updateCacheDirectory);
-    const unbindMaxCacheSizeChanged = cacheAPI.subscribeToMaxSizeChange(updateMaxCacheSize);
+    const unbindCacheDirectoryChanged = cacheAPI.subscribeToDirectoryChange(handleCacheDirectoryChanged);
+    const unbindMaxCacheSizeChanged = cacheAPI.subscribeToMaxSizeChange(handleMaxCacheSizeChanged);
     const unbindSizeChanged = cacheAPI.subscribeToSizeChange(updateCacheSize);
 
     updateCacheSize();
@@ -44,7 +65,13 @@ export default function CacheProvider(props: CacheProviderProps) {
       unbindMaxCacheSizeChanged();
       unbindSizeChanged();
     };
-  }, [updateCacheSize, updateCacheDirectory, updateMaxCacheSize]);
+  }, [
+    updateCacheSize,
+    updateCacheDirectory,
+    updateMaxCacheSize,
+    handleCacheDirectoryChanged,
+    handleMaxCacheSizeChanged,
+  ]);
 
   const context = useMemo(() => {
     const { getCacheDirectory, getCacheSize, getMaxCacheSize, ...rest } = cacheAPI;

--- a/packages/gui/src/components/nfts/NFTCard.tsx
+++ b/packages/gui/src/components/nfts/NFTCard.tsx
@@ -77,7 +77,10 @@ function NFTCard(props: NFTCardProps) {
               sx={{ zIndex: 1, position: 'absolute', right: 2, top: 2 }}
             />
           )}
-          <NFTPreview id={nftId} disableInteractions={isOffer} ratio={ratio} preview />
+          {/* in selection mode the whole tile selects on click, so media
+              interactions (and the video loop button, which would cover the
+              selection checkbox) are disabled */}
+          <NFTPreview id={nftId} disableInteractions={isOffer || !!onSelect} ratio={ratio} preview />
         </CardActionArea>
         <CardActionArea onClick={() => canExpandDetails && handleClick()} component="div">
           <CardContent>

--- a/packages/gui/src/components/nfts/NFTHashStatus.tsx
+++ b/packages/gui/src/components/nfts/NFTHashStatus.tsx
@@ -31,6 +31,7 @@ export default function NFTHashStatus(props: NFTHashStatusProps) {
   const isLoading = isLoadingNFTVerifyHash || isLoadingNFT;
   const isVerified = preview ? nftPreview?.isVerified : data?.isVerified;
   const error = (errorNFT ?? preview) ? nftPreview?.error : data?.error;
+  const failedFetch = preview ? nftPreview?.failedFetch : data?.failedFetch;
 
   const isValidURI = useMemo(() => {
     if (!nftPreview || !('originalUri' in nftPreview)) {
@@ -77,8 +78,12 @@ export default function NFTHashStatus(props: NFTHashStatusProps) {
       return <Trans>URL is not valid</Trans>;
     }
 
+    if (failedFetch) {
+      return <Trans>File is not available</Trans>;
+    }
+
     return <Trans>Invalid hash</Trans>;
-  }, [isLoading, isVerified, nft, isValidURI]);
+  }, [isLoading, isVerified, nft, isValidURI, failedFetch]);
 
   const color = useMemo(() => {
     if (isLoading) {

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -353,7 +353,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
         }}
       >
         {!canInteract && <IframePreventEvents />}
-        <SandboxedIframe hideUntilLoaded allowPointerEvents={!canInteract}>
+        <SandboxedIframe hideUntilLoaded allowPointerEvents={canInteract}>
           {previewContent}
         </SandboxedIframe>
         {blurPreview && (

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -1,7 +1,7 @@
 import { Color, IconMessage, Loading, Flex, SandboxedIframe, usePersistState, useDarkMode } from '@chia-network/core';
 import { t, Trans } from '@lingui/macro';
-import { NotInterested } from '@mui/icons-material';
-import { alpha, Box } from '@mui/material';
+import { Loop as LoopIcon, NotInterested } from '@mui/icons-material';
+import { alpha, Box, IconButton, Tooltip } from '@mui/material';
 import React, { useMemo, useRef, Fragment, useCallback, useEffect, type ReactNode } from 'react';
 import styled from 'styled-components';
 
@@ -30,7 +30,7 @@ import useNFT from '../../hooks/useNFT';
 import useNFTImageFittingMode from '../../hooks/useNFTImageFittingMode';
 import useNFTMetadata from '../../hooks/useNFTMetadata';
 import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
-import useNFTVideoLoop from '../../hooks/useNFTVideoLoop';
+import { useNFTVideoLoopGlobal, useNFTVideoLoopForNFT } from '../../hooks/useNFTVideoLoop';
 import useStateAbort from '../../hooks/useStateAbort';
 import getFileExtension from '../../util/getFileExtension';
 import getNFTId from '../../util/getNFTId';
@@ -156,7 +156,19 @@ export default function NFTPreview(props: NFTPreviewProps) {
   });
 
   const { type: previewFileType, isLoading: isLoadingFileType } = useFileType(preview?.uri);
-  const loopVideo = useNFTVideoLoop(nftId);
+  const [globalVideoLoop] = useNFTVideoLoopGlobal();
+  const [perVideoLoop, setPerVideoLoop] = useNFTVideoLoopForNFT(nftId);
+  const loopVideo = globalVideoLoop || perVideoLoop;
+
+  const handleToggleVideoLoop = useCallback(
+    (event: React.MouseEvent) => {
+      // the button sits inside clickable areas (grid card navigation, detail
+      // view fullscreen) — keep the click from reaching them
+      event.stopPropagation();
+      setPerVideoLoop(!perVideoLoop);
+    },
+    [perVideoLoop, setPerVideoLoop],
+  );
 
   const { isLoading: isLoadingNFT } = useNFT(nftId);
   const { metadata, isLoading: isLoadingMetadata } = useNFTMetadata(nftId);
@@ -375,6 +387,42 @@ export default function NFTPreview(props: NFTPreviewProps) {
               <Box sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 'calc(50% - 32px)', zIndex: 2 }} />
             </>
           ))}
+        {previewFileType === FileType.VIDEO && canInteract && !blurPreview && (
+          <Tooltip
+            title={
+              globalVideoLoop ? (
+                <Trans>Looping is enabled for all videos in Settings</Trans>
+              ) : loopVideo ? (
+                <Trans>Looping on</Trans>
+              ) : (
+                <Trans>Loop video</Trans>
+              )
+            }
+            placement="left"
+          >
+            {/* wrapper keeps the tooltip working while the button is disabled */}
+            <Box sx={{ position: 'absolute', top: 8, right: 8, zIndex: 3 }}>
+              <IconButton
+                size="small"
+                disabled={globalVideoLoop}
+                onClick={handleToggleVideoLoop}
+                sx={{
+                  backgroundColor: alpha(Color.Neutral[900], 0.4),
+                  color: loopVideo ? Color.Green[400] : Color.Neutral[200],
+                  '&:hover': {
+                    backgroundColor: alpha(Color.Neutral[900], 0.6),
+                  },
+                  '&.Mui-disabled': {
+                    backgroundColor: alpha(Color.Neutral[900], 0.4),
+                    color: Color.Green[400],
+                  },
+                }}
+              >
+                <LoopIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Tooltip>
+        )}
         {blurPreview && (
           <Box
             sx={{
@@ -404,6 +452,9 @@ export default function NFTPreview(props: NFTPreviewProps) {
     isDarkMode,
     blurPreview,
     previewCompactIcon,
+    globalVideoLoop,
+    loopVideo,
+    handleToggleVideoLoop,
   ]);
 
   const hasFile = !!preview;

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -210,7 +210,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
           }
         `;
 
-        const cachedURI = await getURI(preview.uri);
+        const cachedURI = await getURI(preview.uri, { maxSize: ignoreSizeLimit ? -1 : undefined });
         if (!cachedURI || !cachedURI.startsWith('cache://')) {
           setPreviewContent(undefined, signal);
           return;
@@ -237,7 +237,17 @@ export default function NFTPreview(props: NFTPreviewProps) {
         setError(e as Error, signal);
       }
     },
-    [preview, fit, getURI, previewFileType, disableInteractions, isDarkMode, setPreviewContent, setError],
+    [
+      preview,
+      fit,
+      getURI,
+      ignoreSizeLimit,
+      previewFileType,
+      disableInteractions,
+      isDarkMode,
+      setPreviewContent,
+      setError,
+    ],
   );
 
   useEffect(() => {

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -338,8 +338,13 @@ export default function NFTPreview(props: NFTPreviewProps) {
       );
     }
 
-    const canInteract =
-      !isPreview && !disableInteractions && (previewFileType === FileType.VIDEO || previewFileType === FileType.AUDIO);
+    const isPlayable = previewFileType === FileType.VIDEO || previewFileType === FileType.AUDIO;
+    const canInteract = !disableInteractions && isPlayable;
+    // In the gallery grid the media controls are directly clickable, while the
+    // rest of the tile keeps navigating to the detail view. The blockers below
+    // sit over the non-control area only, so clicks there fall through to the
+    // card while the native controls (play, seek, volume) stay exposed.
+    const showGridNavigationBlockers = isPreview && canInteract;
 
     return (
       <Box
@@ -356,6 +361,17 @@ export default function NFTPreview(props: NFTPreviewProps) {
         <SandboxedIframe hideUntilLoaded allowPointerEvents={canInteract}>
           {previewContent}
         </SandboxedIframe>
+        {showGridNavigationBlockers &&
+          (previewFileType === FileType.VIDEO ? (
+            // video controls render along the bottom edge of the tile
+            <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 48, zIndex: 2 }} />
+          ) : (
+            // the audio control bar renders centered vertically in the tile
+            <>
+              <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, height: 'calc(50% - 32px)', zIndex: 2 }} />
+              <Box sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 'calc(50% - 32px)', zIndex: 2 }} />
+            </>
+          ))}
         {blurPreview && (
           <Box
             sx={{

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -30,6 +30,7 @@ import useNFT from '../../hooks/useNFT';
 import useNFTImageFittingMode from '../../hooks/useNFTImageFittingMode';
 import useNFTMetadata from '../../hooks/useNFTMetadata';
 import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
+import useNFTVideoLoop from '../../hooks/useNFTVideoLoop';
 import useStateAbort from '../../hooks/useStateAbort';
 import getFileExtension from '../../util/getFileExtension';
 import getNFTId from '../../util/getNFTId';
@@ -155,6 +156,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
   });
 
   const { type: previewFileType, isLoading: isLoadingFileType } = useFileType(preview?.uri);
+  const loopVideo = useNFTVideoLoop(nftId);
 
   const { isLoading: isLoadingNFT } = useNFT(nftId);
   const { metadata, isLoading: isLoadingMetadata } = useNFTMetadata(nftId);
@@ -220,7 +222,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
           <>
             <style>{style}</style>
             {previewFileType === FileType.VIDEO ? (
-              <video width="100%" height="100%" controls={!disableInteractions}>
+              <video width="100%" height="100%" controls={!disableInteractions} loop={loopVideo}>
                 <source src={cachedURI} />
               </video>
             ) : previewFileType === FileType.AUDIO ? (
@@ -244,6 +246,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
       ignoreSizeLimit,
       previewFileType,
       disableInteractions,
+      loopVideo,
       isDarkMode,
       setPreviewContent,
       setError,

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -141,7 +141,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
   const nftId = useMemo(() => getNFTId(id), [id]);
   const iframeRef = useRef<any>(null);
   const { isDarkMode } = useDarkMode();
-  const [, setError] = useStateAbort<Error | undefined>(undefined);
+  const [prepareError, setPrepareError] = useStateAbort<Error | undefined>(undefined);
   const [previewContent, setPreviewContent] = useStateAbort<ReactNode | undefined>(undefined);
   const abortControllerRef = useRef(new AbortController());
   const [hideObjectionableContent] = useHideObjectionableContent();
@@ -172,7 +172,9 @@ export default function NFTPreview(props: NFTPreviewProps) {
 
   const { isLoading: isLoadingNFT } = useNFT(nftId);
   const { metadata, isLoading: isLoadingMetadata } = useNFTMetadata(nftId);
-  const isLoading = isLoadingVerifyHash || isLoadingMetadata || isLoadingNFT || isLoadingFileType;
+  // hash verification downloads the full data file, which can take a long time
+  // for large media — only wait for it while there is no preview uri to show yet
+  const isLoading = isLoadingMetadata || isLoadingNFT || isLoadingFileType || (isLoadingVerifyHash && !preview);
 
   const blurPreview = useMemo(() => {
     if (!hideObjectionableContent) {
@@ -196,12 +198,14 @@ export default function NFTPreview(props: NFTPreviewProps) {
 
   const previewExtension = useMemo(() => getFileExtension(preview?.uri), [preview]);
 
+  const previewUri = preview?.uri;
+
   const preparePreview = useCallback(
     async (signal: AbortSignal) => {
       try {
-        setError(undefined, signal);
+        setPrepareError(undefined, signal);
 
-        if (!preview?.uri) {
+        if (!previewUri) {
           setPreviewContent(undefined, signal);
           return;
         }
@@ -224,9 +228,10 @@ export default function NFTPreview(props: NFTPreviewProps) {
           }
         `;
 
-        const cachedURI = await getURI(preview.uri, { maxSize: ignoreSizeLimit ? -1 : undefined });
+        const cachedURI = await getURI(previewUri, { maxSize: ignoreSizeLimit ? -1 : undefined });
         if (!cachedURI || !cachedURI.startsWith('cache://')) {
           setPreviewContent(undefined, signal);
+          setPrepareError(new Error(t`File is not available`), signal);
           return;
         }
 
@@ -248,11 +253,12 @@ export default function NFTPreview(props: NFTPreviewProps) {
           signal,
         );
       } catch (e) {
-        setError(e as Error, signal);
+        setPreviewContent(undefined, signal);
+        setPrepareError(e as Error, signal);
       }
     },
     [
-      preview,
+      previewUri,
       fit,
       getURI,
       ignoreSizeLimit,
@@ -261,7 +267,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
       loopVideo,
       isDarkMode,
       setPreviewContent,
-      setError,
+      setPrepareError,
     ],
   );
 
@@ -459,6 +465,13 @@ export default function NFTPreview(props: NFTPreviewProps) {
 
   const hasFile = !!preview;
 
+  // icon, model, document and compact non-image previews do not render the
+  // iframe, so they never wait for the preview file to download
+  const usesIframe =
+    !(isCompact && previewFileType !== FileType.IMAGE) &&
+    !icon &&
+    ![FileType.MODEL, FileType.DOCUMENT].includes(previewFileType);
+
   return (
     <StyledCardPreview width={width} height={height} sx={{ aspectRatio: ratio.toString() }}>
       {isLoading ? (
@@ -471,6 +484,16 @@ export default function NFTPreview(props: NFTPreviewProps) {
             <Trans>No file available</Trans>
           </IconMessage>
         </Background>
+      ) : usesIframe && prepareError ? (
+        <Background>
+          <IconMessage icon={<NotInterested fontSize="large" />}>
+            <Trans>Preview is not available</Trans>
+          </IconMessage>
+        </Background>
+      ) : usesIframe && !previewContent ? (
+        <Flex position="absolute" left="0" top="0" bottom="0" right="0" justifyContent="center" alignItems="center">
+          <Loading center>{!isCompact && t`Loading preview...`}</Loading>
+        </Flex>
       ) : (
         previewIframe
       )}

--- a/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
+++ b/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
@@ -7,16 +7,13 @@ import {
   ArrowBack as ArrowBackIcon,
   ArrowForward as ArrowForwardIcon,
 } from '@mui/icons-material';
-import { IconButton, Box, Grid, Typography, FormControlLabel, Switch } from '@mui/material';
+import { IconButton, Box, Grid, Typography } from '@mui/material';
 import React, { useEffect, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import FileType from '../../../constants/FileType';
-import useFileType from '../../../hooks/useFileType';
 import useFilteredNFTs from '../../../hooks/useFilteredNFTs';
 import useNFT from '../../../hooks/useNFT';
 import useNFTMetadata from '../../../hooks/useNFTMetadata';
-import { useNFTVideoLoopGlobal, useNFTVideoLoopForNFT } from '../../../hooks/useNFTVideoLoop';
 import getNFTId from '../../../util/getNFTId';
 import { isImage } from '../../../util/utils';
 import OfferIncomingTable from '../../offers2/OfferIncomingTable';
@@ -52,15 +49,6 @@ function NFTDetailLoaded(props: NFTDetailLoadedProps) {
 
   const { nfts } = useFilteredNFTs();
   const navigate = useNavigate();
-
-  const { type: fileType } = useFileType(nft?.dataUris?.[0]);
-  const isVideo = fileType === FileType.VIDEO;
-  const [globalVideoLoop] = useNFTVideoLoopGlobal();
-  const [videoLoop, setVideoLoop] = useNFTVideoLoopForNFT(useMemo(() => getNFTId(nftId), [nftId]));
-
-  function handleChangeVideoLoop(event: React.ChangeEvent<HTMLInputElement>) {
-    setVideoLoop(event.target.checked);
-  }
 
   const position = useMemo(() => nfts.findIndex((item: NFTInfo) => getNFTId(item.launcherId) === nftId), [nftId, nfts]);
   const isLastPosition = nfts.length === position + 1;
@@ -178,30 +166,6 @@ function NFTDetailLoaded(props: NFTDetailLoadedProps) {
                   <Box onClick={handleShowFullScreen} sx={{ cursor: 'pointer' }}>
                     <NFTPreview id={nftId} height={412} fit="contain" hideStatus />
                   </Box>
-                  {isVideo && (
-                    <Flex justifyContent="center" marginTop={1}>
-                      <Tooltip
-                        title={
-                          globalVideoLoop ? (
-                            <Trans>Looping is enabled for all videos in Settings</Trans>
-                          ) : (
-                            <Trans>Restart this video automatically when it finishes playing</Trans>
-                          )
-                        }
-                      >
-                        <FormControlLabel
-                          control={
-                            <Switch
-                              checked={globalVideoLoop || videoLoop}
-                              disabled={globalVideoLoop}
-                              onChange={handleChangeVideoLoop}
-                            />
-                          }
-                          label={<Trans>Loop video</Trans>}
-                        />
-                      </Tooltip>
-                    </Flex>
-                  )}
                   {/*
                 <NFTProgressBar
                   nftIdUrl={`${nft.$nftId}_${uri}`}

--- a/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
+++ b/packages/gui/src/components/nfts/detail/NFTDetailV2.tsx
@@ -7,13 +7,16 @@ import {
   ArrowBack as ArrowBackIcon,
   ArrowForward as ArrowForwardIcon,
 } from '@mui/icons-material';
-import { IconButton, Box, Grid, Typography } from '@mui/material';
+import { IconButton, Box, Grid, Typography, FormControlLabel, Switch } from '@mui/material';
 import React, { useEffect, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
+import FileType from '../../../constants/FileType';
+import useFileType from '../../../hooks/useFileType';
 import useFilteredNFTs from '../../../hooks/useFilteredNFTs';
 import useNFT from '../../../hooks/useNFT';
 import useNFTMetadata from '../../../hooks/useNFTMetadata';
+import { useNFTVideoLoopGlobal, useNFTVideoLoopForNFT } from '../../../hooks/useNFTVideoLoop';
 import getNFTId from '../../../util/getNFTId';
 import { isImage } from '../../../util/utils';
 import OfferIncomingTable from '../../offers2/OfferIncomingTable';
@@ -49,6 +52,15 @@ function NFTDetailLoaded(props: NFTDetailLoadedProps) {
 
   const { nfts } = useFilteredNFTs();
   const navigate = useNavigate();
+
+  const { type: fileType } = useFileType(nft?.dataUris?.[0]);
+  const isVideo = fileType === FileType.VIDEO;
+  const [globalVideoLoop] = useNFTVideoLoopGlobal();
+  const [videoLoop, setVideoLoop] = useNFTVideoLoopForNFT(useMemo(() => getNFTId(nftId), [nftId]));
+
+  function handleChangeVideoLoop(event: React.ChangeEvent<HTMLInputElement>) {
+    setVideoLoop(event.target.checked);
+  }
 
   const position = useMemo(() => nfts.findIndex((item: NFTInfo) => getNFTId(item.launcherId) === nftId), [nftId, nfts]);
   const isLastPosition = nfts.length === position + 1;
@@ -166,6 +178,30 @@ function NFTDetailLoaded(props: NFTDetailLoadedProps) {
                   <Box onClick={handleShowFullScreen} sx={{ cursor: 'pointer' }}>
                     <NFTPreview id={nftId} height={412} fit="contain" hideStatus />
                   </Box>
+                  {isVideo && (
+                    <Flex justifyContent="center" marginTop={1}>
+                      <Tooltip
+                        title={
+                          globalVideoLoop ? (
+                            <Trans>Looping is enabled for all videos in Settings</Trans>
+                          ) : (
+                            <Trans>Restart this video automatically when it finishes playing</Trans>
+                          )
+                        }
+                      >
+                        <FormControlLabel
+                          control={
+                            <Switch
+                              checked={globalVideoLoop || videoLoop}
+                              disabled={globalVideoLoop}
+                              onChange={handleChangeVideoLoop}
+                            />
+                          }
+                          label={<Trans>Loop video</Trans>}
+                        />
+                      </Tooltip>
+                    </Flex>
+                  )}
                   {/*
                 <NFTProgressBar
                   nftIdUrl={`${nft.$nftId}_${uri}`}

--- a/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
+++ b/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
@@ -13,7 +13,11 @@ import {
   ScrollbarVirtuoso,
 } from '@chia-network/core';
 import { t, Trans } from '@lingui/macro';
-import { FilterList as FilterListIcon, LibraryAddCheck as LibraryAddCheckIcon } from '@mui/icons-material';
+import {
+  FilterList as FilterListIcon,
+  LibraryAddCheck as LibraryAddCheckIcon,
+  Refresh as RefreshIcon,
+} from '@mui/icons-material';
 import {
   Divider,
   Chip,
@@ -36,6 +40,7 @@ import FileType from '../../../constants/FileType';
 import useFilteredNFTs from '../../../hooks/useFilteredNFTs';
 import useHideObjectionableContent from '../../../hooks/useHideObjectionableContent';
 import useNFTGalleryScrollPosition from '../../../hooks/useNFTGalleryScrollPosition';
+import useNFTProvider from '../../../hooks/useNFTProvider';
 import getNFTId from '../../../util/getNFTId';
 import LabelProgress from '../../helpers/LabelProgress';
 import NFTCard from '../NFTCard';
@@ -108,6 +113,8 @@ export default function NFTGallery() {
 
     statistics,
   } = useFilteredNFTs();
+
+  const { refetch } = useNFTProvider();
 
   const [scrollPosition, setScrollPosition] = useNFTGalleryScrollPosition();
   const scrollerRef = useRef<HTMLElement>(null);
@@ -284,6 +291,13 @@ export default function NFTGallery() {
                   <IconButton onClick={toggleShowFilters} color={showFilters ? 'primary' : undefined}>
                     <FilterListIcon color="info" />
                   </IconButton>
+                </Tooltip>
+                <Tooltip title={<Trans>Refresh NFTs</Trans>} placement="top">
+                  <span>
+                    <IconButton onClick={() => refetch()} disabled={isLoading}>
+                      <RefreshIcon color={isLoading ? 'disabled' : 'info'} />
+                    </IconButton>
+                  </span>
                 </Tooltip>
               </Flex>
             </Flex>

--- a/packages/gui/src/components/nfts/provider/NFTProvider.tsx
+++ b/packages/gui/src/components/nfts/provider/NFTProvider.tsx
@@ -28,6 +28,7 @@ export default function NFTProvider(props: NFTProviderProps) {
     isLoading,
     error,
     getNFT: getNFTData,
+    refetch,
     count,
     loaded,
     progress,
@@ -194,6 +195,7 @@ export default function NFTProvider(props: NFTProviderProps) {
       subscribeToChanges,
 
       invalidate: invalidateNFT,
+      refetch,
 
       // mutable state
       isLoading,
@@ -217,6 +219,7 @@ export default function NFTProvider(props: NFTProviderProps) {
       progress,
       subscribeToChanges,
       invalidateNFT,
+      refetch,
     ],
   );
 

--- a/packages/gui/src/components/nfts/provider/NFTProviderContext.ts
+++ b/packages/gui/src/components/nfts/provider/NFTProviderContext.ts
@@ -17,6 +17,7 @@ const NFTProviderContext = createContext<
       error: Error | undefined;
 
       invalidate: (id: string | undefined) => Promise<void>;
+      refetch: () => Promise<void>;
 
       subscribeToChanges: (callback: () => void) => () => void;
 

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTData.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTData.ts
@@ -282,6 +282,7 @@ export default function useNFTData(props: UseNFTDataProps) {
     nfts,
 
     getNFT,
+    refetch: refetchData,
 
     isLoading,
     error,

--- a/packages/gui/src/components/settings/LimitCacheSize.tsx
+++ b/packages/gui/src/components/settings/LimitCacheSize.tsx
@@ -1,4 +1,3 @@
-import { usePrefs } from '@chia-network/api-react';
 import { AlertDialog, ButtonLoading, Flex, Form, TextField, useOpenDialog } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import React, { useEffect } from 'react';
@@ -15,8 +14,6 @@ type FormData = {
 export default function LimitCacheSize() {
   const openDialog = useOpenDialog();
   const { maxCacheSize, setMaxCacheSize } = useCache();
-
-  const [, setCacheLimitSize] = usePrefs(`cacheLimitSize`, 0);
 
   const methods = useForm<FormData>({
     defaultValues: {
@@ -45,8 +42,6 @@ export default function LimitCacheSize() {
 
     const newValue = Number(values.maxCacheSize) * MB_SIZE;
 
-    // todo move it ti electron/main
-    setCacheLimitSize(newValue);
     await setMaxCacheSize(newValue);
 
     await openDialog(

--- a/packages/gui/src/components/settings/SettingsNFT.tsx
+++ b/packages/gui/src/components/settings/SettingsNFT.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import useCache from '../../hooks/useCache';
 import useHideObjectionableContent from '../../hooks/useHideObjectionableContent';
 import useNFTImageFittingMode from '../../hooks/useNFTImageFittingMode';
+import { useNFTVideoLoopGlobal } from '../../hooks/useNFTVideoLoop';
 
 import LimitCacheSize from './LimitCacheSize';
 
@@ -38,11 +39,16 @@ export default function SettingsGeneral() {
 
   const { cacheSize, clearCache, cacheDirectory, setCacheDirectory } = useCache();
   const [nftImageFittingMode, setNFTImageFittingMode] = useNFTImageFittingMode();
+  const [nftVideoLoop, setNFTVideoLoop] = useNFTVideoLoopGlobal();
   // const [, setCacheFolder] = usePrefs('cacheFolder', '');
   const openDialog = useOpenDialog();
 
   function handleScalePreviewImages(event: React.ChangeEvent<HTMLInputElement>) {
     setNFTImageFittingMode(event.target.checked ? 'contain' : 'cover');
+  }
+
+  function handleChangeVideoLoop(event: React.ChangeEvent<HTMLInputElement>) {
+    setNFTVideoLoop(event.target.checked);
   }
 
   async function clearNFTCache() {
@@ -115,6 +121,25 @@ export default function SettingsGeneral() {
         <Grid item style={{ width: '400px' }}>
           <SettingsText>
             <Trans>Images will be scaled to fill the NFT card and ignore their original proportions.</Trans>
+          </SettingsText>
+        </Grid>
+      </Grid>
+
+      <Grid container>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsTitle>
+            <Trans>Loop videos</Trans>
+          </SettingsTitle>
+        </Grid>
+        <Grid item container xs justifyContent="flex-end" marginTop="-6px">
+          <FormControlLabel control={<Switch checked={nftVideoLoop} onChange={handleChangeVideoLoop} />} />
+        </Grid>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsText>
+            <Trans>
+              All NFT videos will restart automatically when they finish playing. When disabled, looping can still be
+              turned on for individual videos from their detail page.
+            </Trans>
           </SettingsText>
         </Grid>
       </Grid>

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+type DownloadFile = typeof import('./utils/downloadFile').default;
+
+const mockDownloadFile = jest.fn<ReturnType<DownloadFile>, Parameters<DownloadFile>>();
+
+jest.mock('electron', () => ({
+  BrowserWindow: jest.fn(),
+  dialog: {
+    showOpenDialog: jest.fn(),
+  },
+}));
+
+jest.mock('./utils/downloadFile', () => ({
+  __esModule: true,
+  default: mockDownloadFile,
+  MAX_FILE_SIZE_EXCEEDED_ERROR: 'Maximum file size exceeded',
+}));
+
+jest.mock('./utils/ipcMainHandle', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const CacheManager = jest.requireActual<typeof import('./CacheManager')>('./CacheManager').default;
+
+describe('CacheManager eviction', () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    mockDownloadFile.mockReset();
+    cacheDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'chia-cache-manager-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  it('does not evict a just-downloaded file that fits within the configured total size', async () => {
+    const payload = Buffer.alloc(600, 7);
+    mockDownloadFile.mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    await expect(cacheManager.getCacheSize()).resolves.toBeLessThanOrEqual(1024);
+  });
+
+  it('treats a zero cache limit as unlimited when updating the setting', async () => {
+    const payload = Buffer.from('cached payload');
+    mockDownloadFile.mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+    await cacheManager.getContent('https://example.com/nft.png');
+
+    await cacheManager.setMaxCacheSize(0);
+
+    expect(cacheManager.maxCacheSize).toBe(0);
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -111,6 +111,40 @@ describe('CacheManager eviction', () => {
     await expect(fs.stat(path.join(cacheDirectory, 'aaaa-chiacache'))).rejects.toThrow('ENOENT');
   });
 
+  it('does not retry a timed-out download on the next access', async () => {
+    mockDownloadFile.mockRejectedValue(new Error('Request timed out after 30000ms of inactivity'));
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request timed out');
+    await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request timed out');
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries an aborted download on the next access', async () => {
+    const payload = Buffer.from('cached payload');
+    mockDownloadFile.mockRejectedValueOnce(new Error('Request aborted')).mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request aborted');
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(2);
+  });
+
   it('treats a zero cache limit as unlimited when updating the setting', async () => {
     const payload = Buffer.from('cached payload');
     mockDownloadFile.mockImplementation(async (_url, localPath) => {

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -57,6 +57,60 @@ describe('CacheManager eviction', () => {
     await expect(cacheManager.getCacheSize()).resolves.toBeLessThanOrEqual(1024);
   });
 
+  it('keeps a completed download cached when cache housekeeping fails', async () => {
+    const payload = Buffer.from('cached payload');
+    mockDownloadFile.mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    // A concurrent invalidation can delete files mid-scan and make the
+    // post-download size check fail — that must not poison the download.
+    jest
+      .spyOn(cacheManager, 'getCacheSize')
+      .mockRejectedValueOnce(new Error("ENOENT: no such file or directory, stat '/cache/other-chiacache'"));
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores files that vanish while the cache size is being measured', async () => {
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await fs.writeFile(path.join(cacheDirectory, 'aaaa-chiacache'), Buffer.alloc(100));
+    // a broken symlink stats like a file deleted between readdir and stat
+    await fs.symlink(path.join(cacheDirectory, 'missing-target'), path.join(cacheDirectory, 'bbbb-chiacache'));
+
+    await expect(cacheManager.getCacheSize()).resolves.toBe(100);
+  });
+
+  it('evicts without failing when a file vanishes during the eviction scan', async () => {
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await fs.writeFile(path.join(cacheDirectory, 'aaaa-chiacache'), Buffer.alloc(200));
+    await fs.symlink(path.join(cacheDirectory, 'missing-target'), path.join(cacheDirectory, 'bbbb-chiacache'));
+
+    await expect(cacheManager.setMaxCacheSize(100)).resolves.toBeUndefined();
+    await expect(fs.stat(path.join(cacheDirectory, 'aaaa-chiacache'))).rejects.toThrow('ENOENT');
+  });
+
   it('treats a zero cache limit as unlimited when updating the setting', async () => {
     const payload = Buffer.from('cached payload');
     mockDownloadFile.mockImplementation(async (_url, localPath) => {

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -1,8 +1,10 @@
-import { BrowserWindow, net, dialog, type Protocol } from 'electron';
+import { BrowserWindow, dialog, type Protocol } from 'electron';
 import { EventEmitter } from 'events';
 import crypto from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 
 import debug from 'debug';
 import isURL from 'validator/lib/isURL';
@@ -14,7 +16,7 @@ import CacheState from '../constants/CacheState';
 import limit from '../util/limit';
 
 import CacheAPI from './constants/CacheAPI';
-import downloadFile from './utils/downloadFile';
+import downloadFile, { MAX_FILE_SIZE_EXCEEDED_ERROR } from './utils/downloadFile';
 import ensureDirectoryExists from './utils/ensureDirectoryExists';
 import getChecksum from './utils/getChecksum';
 import ipcMainHandle from './utils/ipcMainHandle';
@@ -24,7 +26,51 @@ import sanitizeNumber from './utils/sanitizeNumber';
 
 const log = debug('chia-gui:CacheManager');
 
-const CACHE_PROTOCOL = 'cache';
+export const CACHE_PROTOCOL = 'cache';
+
+// A single-range `bytes=start-end` Range header, parsed against the file size.
+// 'ignore' means the header is absent or uses a form we do not support
+// (e.g. multiple ranges), in which case the full file is served with a 200.
+type ParsedRange = { start: number; end: number } | 'invalid' | 'ignore';
+
+function parseRangeHeader(rangeHeader: string | null, fileSize: number): ParsedRange {
+  if (!rangeHeader) {
+    return 'ignore';
+  }
+
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!match) {
+    return 'ignore';
+  }
+
+  const [, startString, endString] = match;
+
+  if (startString === '' && endString === '') {
+    return 'invalid';
+  }
+
+  if (startString === '') {
+    // suffix range: the last N bytes of the file
+    const suffixLength = Number.parseInt(endString, 10);
+    if (suffixLength === 0 || fileSize === 0) {
+      return 'invalid';
+    }
+
+    return { start: Math.max(fileSize - suffixLength, 0), end: fileSize - 1 };
+  }
+
+  const start = Number.parseInt(startString, 10);
+  if (start >= fileSize) {
+    return 'invalid';
+  }
+
+  const end = endString === '' ? fileSize - 1 : Math.min(Number.parseInt(endString, 10), fileSize - 1);
+  if (start > end) {
+    return 'invalid';
+  }
+
+  return { start, end };
+}
 
 async function safeUnlink(filePath: string) {
   try {
@@ -112,8 +158,11 @@ export default class CacheManager extends EventEmitter {
         });
       }
 
-      const response = await net.fetch(`file://${filePath}`);
-      if (!response.ok) {
+      let fileSize: number;
+      try {
+        const stats = await fs.stat(filePath);
+        fileSize = stats.size;
+      } catch (error) {
         return new Response('Not found', {
           status: 404,
           headers: {
@@ -122,18 +171,45 @@ export default class CacheManager extends EventEmitter {
         });
       }
 
-      const { headers } = cacheInfo;
-      const updatedHeaders = new Headers(response.headers);
+      const contentTypeHeader = cacheInfo.headers?.['content-type'];
+      const contentType =
+        (Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader) || 'application/octet-stream';
 
-      if (headers['content-type']) {
-        const contentType = Array.isArray(headers['content-type'])
-          ? headers['content-type'][0]
-          : headers['content-type'];
-        updatedHeaders.set('content-type', contentType);
+      const responseHeaders: Record<string, string> = {
+        'content-type': contentType,
+        'accept-ranges': 'bytes',
+      };
+
+      // Media elements seek by sending Range requests. Without 206 responses
+      // seeking is broken and MP4 files with the moov atom at the end of the
+      // file never start playing.
+      const range = parseRangeHeader(request.headers.get('range'), fileSize);
+
+      if (range === 'invalid') {
+        return new Response('Range Not Satisfiable', {
+          status: 416,
+          headers: {
+            'content-type': 'text/plain',
+            'content-range': `bytes */${fileSize}`,
+          },
+        });
       }
 
-      return new Response(response.body, {
-        headers: updatedHeaders,
+      if (range !== 'ignore') {
+        responseHeaders['content-length'] = String(range.end - range.start + 1);
+        responseHeaders['content-range'] = `bytes ${range.start}-${range.end}/${fileSize}`;
+
+        const partialStream = createReadStream(filePath, { start: range.start, end: range.end });
+        return new Response(Readable.toWeb(partialStream) as unknown as ReadableStream, {
+          status: 206,
+          headers: responseHeaders,
+        });
+      }
+
+      responseHeaders['content-length'] = String(fileSize);
+
+      return new Response(Readable.toWeb(createReadStream(filePath)) as unknown as ReadableStream, {
+        headers: responseHeaders,
       });
     });
   }
@@ -332,7 +408,12 @@ export default class CacheManager extends EventEmitter {
 
         if (cacheInfo.state === CacheState.ERROR) {
           log(`Url already downloaded with error: ${cacheInfo.error}`, url);
-          if (!['Response aborted', 'Request aborted'].includes(cacheInfo.error)) {
+
+          const isTransientError = ['Response aborted', 'Request aborted'].includes(cacheInfo.error);
+          // A persisted size-limit error is only retried when the caller lifts
+          // the limit, so oversized files are not re-downloaded on every visit.
+          const isSizeLimitLifted = cacheInfo.error === MAX_FILE_SIZE_EXCEEDED_ERROR && maxSize <= 0;
+          if (!isTransientError && !isSizeLimitLifted) {
             return cacheInfo;
           }
 

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -277,9 +277,6 @@ export default class CacheManager extends EventEmitter {
 
   public set maxCacheSize(newSize: number | string) {
     const value = sanitizeNumber(newSize);
-    if (value < 0) {
-      throw new Error('Cache size cannot be negative');
-    }
 
     this.#maxCacheSize = value;
 
@@ -439,7 +436,7 @@ export default class CacheManager extends EventEmitter {
           log('Checksum computed', url);
 
           // save headers to a local JSON file
-          const updatedCacheInfo = this.setCacheInfo(url, {
+          const updatedCacheInfo = await this.setCacheInfo(url, {
             state: CacheState.CACHED,
             headers,
             checksum,
@@ -448,10 +445,11 @@ export default class CacheManager extends EventEmitter {
           log('Cache info saved', url);
           // remove old files if the cache is full
           const currentCacheSize = await this.getCacheSize();
-          const stats = await fs.stat(cacheFilePath);
-          if (this.maxCacheSize && currentCacheSize + stats.size > this.maxCacheSize) {
-            const spaceNeeded = currentCacheSize + stats.size - this.maxCacheSize;
-            await this.removeOldestFiles(spaceNeeded);
+          if (this.maxCacheSize > 0 && currentCacheSize > this.maxCacheSize) {
+            // The current size already includes the file that was just
+            // downloaded. Keep that file available to the caller and evict
+            // older entries down to the configured total-size target.
+            await this.removeOldestFiles(this.maxCacheSize, cacheFilePath);
           }
           // todo just add size and save it locally
           this.emit('sizeChanged');
@@ -655,19 +653,27 @@ export default class CacheManager extends EventEmitter {
     this.cacheDirectory = newDirectory;
   }
 
-  private async removeOldestFiles(targetSize: number): Promise<void> {
+  private async removeOldestFiles(targetSize: number, preserveFilePath?: string): Promise<void> {
     const files = await fs.readdir(this.cacheDirectory);
     const filePaths = files
       .filter((file) => isChiaCacheFile(file) && !isChiaCacheInfoFile(file))
       .map((file) => path.join(this.cacheDirectory, file));
 
-    // get the file sizes
+    // Include the sidecar metadata in each entry's size so the eviction total
+    // uses the same accounting as getCacheSize().
     const fileStats = await Promise.all(
       filePaths.map(async (filePath) => {
         const stats = await fs.stat(filePath);
+        let infoSize = 0;
+        try {
+          infoSize = (await fs.stat(getInfoFilePath(filePath))).size;
+        } catch {
+          // A missing sidecar is cleaned up with the data file as usual.
+        }
+
         return {
           filePath,
-          size: stats.size,
+          size: stats.size + infoSize,
           mtime: stats.mtime,
         };
       }),
@@ -678,13 +684,17 @@ export default class CacheManager extends EventEmitter {
 
     // remove files until the total size is below the new max total size
     let totalSize = fileStats.reduce((sum, { size }) => sum + size, 0);
-    const filesToRemove = fileStats.filter(({ size }) => {
-      if (totalSize > targetSize) {
-        totalSize -= size;
-        return true;
+    const filesToRemove: typeof fileStats = [];
+    for (const fileStat of fileStats) {
+      if (totalSize <= targetSize) {
+        break;
       }
-      return false;
-    });
+
+      if (fileStat.filePath !== preserveFilePath) {
+        totalSize -= fileStat.size;
+        filesToRemove.push(fileStat);
+      }
+    }
 
     await Promise.all(
       filesToRemove.map(async ({ filePath }) => {
@@ -717,8 +727,10 @@ export default class CacheManager extends EventEmitter {
   }
 
   async setMaxCacheSize(maxCacheSize: number | string) {
-    this.maxCacheSize = sanitizeNumber(maxCacheSize);
-    await this.removeOldestFiles(this.maxCacheSize);
+    this.maxCacheSize = maxCacheSize;
+    if (this.maxCacheSize > 0) {
+      await this.removeOldestFiles(this.maxCacheSize);
+    }
   }
 
   async getCacheSize() {

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -246,8 +246,25 @@ export default class CacheManager extends EventEmitter {
       window.webContents.send(CacheAPI.ON_MAX_CACHE_SIZE_CHANGED, newSize);
     }
 
-    const onSizeChanged = async () => {
-      window.webContents.send(CacheAPI.ON_SIZE_CHANGED, await this.getCacheSize());
+    // Download and invalidation bursts emit sizeChanged per file, and every
+    // notification triggers a full cache-directory scan (here and again in the
+    // renderer), so coalesce bursts into one trailing notification.
+    let sizeChangedTimeout: NodeJS.Timeout | undefined;
+    const onSizeChanged = () => {
+      if (sizeChangedTimeout) {
+        return;
+      }
+      sizeChangedTimeout = setTimeout(async () => {
+        sizeChangedTimeout = undefined;
+        try {
+          const size = await this.getCacheSize();
+          if (!window.isDestroyed()) {
+            window.webContents.send(CacheAPI.ON_SIZE_CHANGED, size);
+          }
+        } catch {
+          // the next sizeChanged event delivers a fresh value
+        }
+      }, 500);
     };
 
     this.on('cacheDirectoryChanged', onCacheDirectoryChanged);
@@ -258,6 +275,10 @@ export default class CacheManager extends EventEmitter {
       this.off('cacheDirectoryChanged', onCacheDirectoryChanged);
       this.off('maxCacheSizeChanged', onMaxCacheSizeChanged);
       this.off('sizeChanged', onSizeChanged);
+      if (sizeChangedTimeout) {
+        clearTimeout(sizeChangedTimeout);
+        sizeChangedTimeout = undefined;
+      }
     };
 
     window.on('close', () => {
@@ -443,13 +464,19 @@ export default class CacheManager extends EventEmitter {
           });
 
           log('Cache info saved', url);
-          // remove old files if the cache is full
-          const currentCacheSize = await this.getCacheSize();
-          if (this.maxCacheSize > 0 && currentCacheSize > this.maxCacheSize) {
-            // The current size already includes the file that was just
-            // downloaded. Keep that file available to the caller and evict
-            // older entries down to the configured total-size target.
-            await this.removeOldestFiles(this.maxCacheSize, cacheFilePath);
+          try {
+            // remove old files if the cache is full
+            const currentCacheSize = await this.getCacheSize();
+            if (this.maxCacheSize > 0 && currentCacheSize > this.maxCacheSize) {
+              // The current size already includes the file that was just
+              // downloaded. Keep that file available to the caller and evict
+              // older entries down to the configured total-size target.
+              await this.removeOldestFiles(this.maxCacheSize, cacheFilePath);
+            }
+          } catch (housekeepingError) {
+            // The download and its cache info are already saved — a failure in
+            // cache bookkeeping must not overwrite that state with an error.
+            log(`Cache housekeeping failed: ${(housekeepingError as Error).message}`, url);
           }
           // todo just add size and save it locally
           this.emit('sizeChanged');
@@ -661,23 +688,30 @@ export default class CacheManager extends EventEmitter {
 
     // Include the sidecar metadata in each entry's size so the eviction total
     // uses the same accounting as getCacheSize().
-    const fileStats = await Promise.all(
-      filePaths.map(async (filePath) => {
-        const stats = await fs.stat(filePath);
-        let infoSize = 0;
-        try {
-          infoSize = (await fs.stat(getInfoFilePath(filePath))).size;
-        } catch {
-          // A missing sidecar is cleaned up with the data file as usual.
-        }
+    const fileStats = (
+      await Promise.all(
+        filePaths.map(async (filePath) => {
+          try {
+            const stats = await fs.stat(filePath);
+            let infoSize = 0;
+            try {
+              infoSize = (await fs.stat(getInfoFilePath(filePath))).size;
+            } catch {
+              // A missing sidecar is cleaned up with the data file as usual.
+            }
 
-        return {
-          filePath,
-          size: stats.size + infoSize,
-          mtime: stats.mtime,
-        };
-      }),
-    );
+            return {
+              filePath,
+              size: stats.size + infoSize,
+              mtime: stats.mtime,
+            };
+          } catch {
+            // Deleted by invalidation while scanning — nothing left to evict.
+            return undefined;
+          }
+        }),
+      )
+    ).filter((entry): entry is { filePath: string; size: number; mtime: Date } => entry !== undefined);
 
     // sort the file paths based on their last modified time (oldest first)
     fileStats.sort((a, b) => a.mtime.getTime() - b.mtime.getTime());
@@ -739,8 +773,17 @@ export default class CacheManager extends EventEmitter {
       .filter((filename) => isChiaCacheFile(filename))
       .map((filename) => path.join(this.cacheDirectory, filename));
 
-    // Get the file sizes and calculate the total size
-    const fileSizes = await Promise.all(filePaths.map(async (filePath) => (await fs.stat(filePath)).size));
+    // Invalidation and eviction delete files while this scan runs — a file
+    // that vanished between readdir and stat no longer occupies space.
+    const fileSizes = await Promise.all(
+      filePaths.map(async (filePath) => {
+        try {
+          return (await fs.stat(filePath)).size;
+        } catch {
+          return 0;
+        }
+      }),
+    );
     const totalSize = fileSizes.reduce((sum, size) => sum + size, 0);
 
     return totalSize;

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -127,7 +127,10 @@ export default class CacheManager extends EventEmitter {
 
     this.cacheDirectory = cacheDirectory;
     this.maxCacheSize = maxCacheSize;
-    this.#downloadLimit = limit(concurrency);
+    // LIFO: downloads for what the user is currently viewing (an offer
+    // preview, a just-opened detail page) are requested last and must not
+    // wait behind a long gallery-wide rebuild of earlier requests.
+    this.#downloadLimit = limit(concurrency, { lifo: true });
 
     this.setMaxListeners(50);
 

--- a/packages/gui/src/electron/api/nftGetMetadata.test.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.test.ts
@@ -1,0 +1,90 @@
+import crypto from 'node:crypto';
+
+type FetchBuffer = typeof import('../utils/fetchBuffer').default;
+
+const mockFetchBuffer = jest.fn<ReturnType<FetchBuffer>, Parameters<FetchBuffer>>();
+
+jest.mock('../utils/fetchBuffer', () => ({
+  __esModule: true,
+  default: mockFetchBuffer,
+}));
+
+const { nftGetImageDataUrl, nftGetMetadata } =
+  jest.requireActual<typeof import('./nftGetMetadata')>('./nftGetMetadata');
+
+function sha256(data: Buffer): string {
+  return crypto.createHash('sha256').update(data.toString('latin1'), 'latin1').digest('hex');
+}
+
+describe('nftGetMetadata', () => {
+  beforeEach(() => {
+    mockFetchBuffer.mockReset();
+  });
+
+  it('parses metadata only after its raw bytes match the expected hash', async () => {
+    const data = Buffer.from('{"name":"Verified NFT","preview_image_uris":["https://example.com/preview.png"]}');
+    mockFetchBuffer.mockResolvedValue({
+      data,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    await expect(nftGetMetadata('https://example.com/metadata.json', `0x${sha256(data)}`)).resolves.toEqual({
+      name: 'Verified NFT',
+      preview_image_uris: ['https://example.com/preview.png'],
+    });
+  });
+
+  it('rejects metadata whose bytes do not match the on-chain hash', async () => {
+    const data = Buffer.from('{"name":"Tampered NFT"}');
+    mockFetchBuffer.mockResolvedValue({
+      data,
+      headers: {},
+    });
+
+    await expect(nftGetMetadata('https://example.com/metadata.json', '00')).resolves.toBeUndefined();
+  });
+
+  it('does not fetch metadata without an expected hash', async () => {
+    await expect(nftGetMetadata('https://example.com/metadata.json', undefined)).resolves.toBeUndefined();
+    expect(mockFetchBuffer).not.toHaveBeenCalled();
+  });
+});
+
+describe('nftGetImageDataUrl', () => {
+  beforeEach(() => {
+    mockFetchBuffer.mockReset();
+  });
+
+  it('returns an immutable data URL for a verified image response', async () => {
+    const data = Buffer.from('verified image bytes');
+    mockFetchBuffer.mockResolvedValue({
+      data,
+      headers: {
+        'content-type': 'image/png; charset=binary',
+      },
+    });
+
+    await expect(nftGetImageDataUrl('https://example.com/preview.png', sha256(data))).resolves.toBe(
+      `data:image/png;base64,${data.toString('base64')}`,
+    );
+  });
+
+  it('rejects a hash-matched response that is not an image', async () => {
+    const data = Buffer.from('<html>not an image</html>');
+    mockFetchBuffer.mockResolvedValue({
+      data,
+      headers: {
+        'content-type': 'text/html',
+      },
+    });
+
+    await expect(nftGetImageDataUrl('https://example.com/preview.png', sha256(data))).resolves.toBeUndefined();
+  });
+
+  it('does not fetch an image without an expected hash', async () => {
+    await expect(nftGetImageDataUrl('https://example.com/preview.png', undefined)).resolves.toBeUndefined();
+    expect(mockFetchBuffer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gui/src/electron/api/nftGetMetadata.test.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.test.ts
@@ -7,7 +7,11 @@ const mockFetchBuffer = jest.fn<ReturnType<FetchBuffer>, Parameters<FetchBuffer>
 jest.mock('../utils/fetchBuffer', () => ({
   __esModule: true,
   default: mockFetchBuffer,
+  MaxSizeExceededError:
+    jest.requireActual<typeof import('../utils/fetchBuffer')>('../utils/fetchBuffer').MaxSizeExceededError,
 }));
+
+const { MaxSizeExceededError } = jest.requireActual<typeof import('../utils/fetchBuffer')>('../utils/fetchBuffer');
 
 const { nftGetImageDataUrl, nftGetMetadata } =
   jest.requireActual<typeof import('./nftGetMetadata')>('./nftGetMetadata');
@@ -86,5 +90,33 @@ describe('nftGetImageDataUrl', () => {
   it('does not fetch an image without an expected hash', async () => {
     await expect(nftGetImageDataUrl('https://example.com/preview.png', undefined)).resolves.toBeUndefined();
     expect(mockFetchBuffer).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the direct URL when an image response exceeds the size cap', async () => {
+    mockFetchBuffer.mockRejectedValue(
+      new MaxSizeExceededError({
+        'content-type': 'image/gif',
+      }),
+    );
+
+    await expect(nftGetImageDataUrl('https://example.com/large.gif', '00')).resolves.toBe(
+      'https://example.com/large.gif',
+    );
+  });
+
+  it('rejects an oversized response that is not an image', async () => {
+    mockFetchBuffer.mockRejectedValue(
+      new MaxSizeExceededError({
+        'content-type': 'video/mp4',
+      }),
+    );
+
+    await expect(nftGetImageDataUrl('https://example.com/large.mp4', '00')).resolves.toBeUndefined();
+  });
+
+  it('rejects on any other download failure', async () => {
+    mockFetchBuffer.mockRejectedValue(new Error('Request timeout after 10000ms'));
+
+    await expect(nftGetImageDataUrl('https://example.com/preview.png', '00')).resolves.toBeUndefined();
   });
 });

--- a/packages/gui/src/electron/api/nftGetMetadata.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.ts
@@ -1,0 +1,21 @@
+import fetchJSON from '../utils/fetchJSON';
+
+const METADATA_TIMEOUT = 10_000;
+const METADATA_MAX_SIZE = 5 * 1024 * 1024;
+
+export type NftMetadata = Record<string, unknown> & {
+  preview_image_uris?: string[];
+  preview_video_uris?: string[];
+};
+
+export async function nftGetMetadata(metadataUri: string): Promise<NftMetadata | undefined> {
+  try {
+    return await fetchJSON<NftMetadata>(metadataUri, {
+      timeout: METADATA_TIMEOUT,
+      maxSize: METADATA_MAX_SIZE,
+    });
+  } catch {
+    // metadata is best effort — the confirmation dialog renders without it
+    return undefined;
+  }
+}

--- a/packages/gui/src/electron/api/nftGetMetadata.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.ts
@@ -1,21 +1,92 @@
-import fetchJSON from '../utils/fetchJSON';
+import crypto from 'node:crypto';
+
+import compareChecksums from '../../util/compareChecksums';
+import fetchBuffer from '../utils/fetchBuffer';
 
 const METADATA_TIMEOUT = 10_000;
 const METADATA_MAX_SIZE = 5 * 1024 * 1024;
+const IMAGE_TIMEOUT = 10_000;
+const IMAGE_MAX_SIZE = 10 * 1024 * 1024;
 
 export type NftMetadata = Record<string, unknown> & {
   preview_image_uris?: string[];
+  preview_image_hash?: string;
   preview_video_uris?: string[];
+  preview_video_hash?: string;
 };
 
-export async function nftGetMetadata(metadataUri: string): Promise<NftMetadata | undefined> {
+function checksum(data: Buffer): string {
+  return crypto.createHash('sha256').update(data.toString('latin1'), 'latin1').digest('hex');
+}
+
+function hasExpectedChecksum(data: Buffer, expectedHash: string): boolean {
+  return compareChecksums(checksum(data), expectedHash);
+}
+
+export async function nftGetMetadata(
+  metadataUri: string,
+  expectedHash: string | undefined,
+): Promise<NftMetadata | undefined> {
+  if (!expectedHash) {
+    return undefined;
+  }
+
   try {
-    return await fetchJSON<NftMetadata>(metadataUri, {
+    const { data } = await fetchBuffer(metadataUri, {
+      headers: {
+        Accept: 'application/json',
+      },
       timeout: METADATA_TIMEOUT,
       maxSize: METADATA_MAX_SIZE,
     });
+
+    if (!hasExpectedChecksum(data, expectedHash)) {
+      return undefined;
+    }
+
+    const metadata: unknown = JSON.parse(data.toString('utf8'));
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return undefined;
+    }
+
+    return metadata as NftMetadata;
   } catch {
     // metadata is best effort — the confirmation dialog renders without it
+    return undefined;
+  }
+}
+
+export async function nftGetImageDataUrl(
+  imageUri: string,
+  expectedHash: string | undefined,
+): Promise<string | undefined> {
+  if (!expectedHash) {
+    return undefined;
+  }
+
+  try {
+    const { data, headers } = await fetchBuffer(imageUri, {
+      headers: {
+        Accept: 'image/*',
+      },
+      timeout: IMAGE_TIMEOUT,
+      maxSize: IMAGE_MAX_SIZE,
+    });
+
+    if (!hasExpectedChecksum(data, expectedHash)) {
+      return undefined;
+    }
+
+    const contentTypeHeader = headers['content-type'];
+    const rawContentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
+    const contentType = rawContentType?.split(';', 1)[0].trim().toLowerCase();
+    if (!contentType || !/^image\/[\w.+-]+$/.test(contentType)) {
+      return undefined;
+    }
+
+    return `data:${contentType};base64,${data.toString('base64')}`;
+  } catch {
+    // image previews are best effort — the confirmation dialog has a fallback
     return undefined;
   }
 }

--- a/packages/gui/src/electron/api/nftGetMetadata.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.ts
@@ -1,7 +1,8 @@
 import crypto from 'node:crypto';
 
+import type Headers from '../../@types/Headers';
 import compareChecksums from '../../util/compareChecksums';
-import fetchBuffer from '../utils/fetchBuffer';
+import fetchBuffer, { MaxSizeExceededError } from '../utils/fetchBuffer';
 
 const METADATA_TIMEOUT = 10_000;
 const METADATA_MAX_SIZE = 5 * 1024 * 1024;
@@ -17,6 +18,17 @@ export type NftMetadata = Record<string, unknown> & {
 
 function checksum(data: Buffer): string {
   return crypto.createHash('sha256').update(data.toString('latin1'), 'latin1').digest('hex');
+}
+
+function getImageContentType(headers: Headers): string | undefined {
+  const contentTypeHeader = headers['content-type'];
+  const rawContentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
+  const contentType = rawContentType?.split(';', 1)[0].trim().toLowerCase();
+  if (!contentType || !/^image\/[\w.+-]+$/.test(contentType)) {
+    return undefined;
+  }
+
+  return contentType;
 }
 
 function hasExpectedChecksum(data: Buffer, expectedHash: string): boolean {
@@ -77,15 +89,20 @@ export async function nftGetImageDataUrl(
       return undefined;
     }
 
-    const contentTypeHeader = headers['content-type'];
-    const rawContentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
-    const contentType = rawContentType?.split(';', 1)[0].trim().toLowerCase();
-    if (!contentType || !/^image\/[\w.+-]+$/.test(contentType)) {
+    const contentType = getImageContentType(headers);
+    if (!contentType) {
       return undefined;
     }
 
     return `data:${contentType};base64,${data.toString('base64')}`;
-  } catch {
+  } catch (error) {
+    // An image too large to inline cannot be hash-verified without unbounded
+    // buffering. Fall back to the direct URL — the dialog CSP still allows
+    // https: images, matching the pre-verification behavior for these files.
+    if (error instanceof MaxSizeExceededError && getImageContentType(error.headers)) {
+      return imageUri;
+    }
+
     // image previews are best effort — the confirmation dialog has a fallback
     return undefined;
   }

--- a/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
@@ -35,13 +35,16 @@ jest.mock('../api/nftGetInfo', () => ({
   nftGetInfo: mockNftGetInfo,
 }));
 
-const mockNftGetMetadata = jest.fn<Promise<unknown>, [string]>();
+const mockNftGetMetadata = jest.fn<Promise<unknown>, [string, string | undefined]>();
+const mockNftGetImageDataUrl = jest.fn<Promise<string | undefined>, [string, string | undefined]>();
 
 jest.mock('../api/nftGetMetadata', () => ({
   nftGetMetadata: mockNftGetMetadata,
+  nftGetImageDataUrl: mockNftGetImageDataUrl,
 }));
 
-const { parseCommandDisplay } = jest.requireActual<typeof import('./parseCommandDisplay')>('./parseCommandDisplay');
+const { parseCommandDisplay, resolveNftPreviewUrl } =
+  jest.requireActual<typeof import('./parseCommandDisplay')>('./parseCommandDisplay');
 
 function makeOfferSummary(overrides: Partial<OfferSummaryResponse['summary']> = {}): OfferSummaryResponse {
   return {
@@ -62,6 +65,7 @@ describe('parseCommandDisplay', () => {
     mockGetOfferSummary.mockReset();
     mockNftGetInfo.mockReset();
     mockNftGetMetadata.mockReset();
+    mockNftGetImageDataUrl.mockReset();
     mockCatAssetIdToName.mockReset();
   });
 
@@ -184,9 +188,11 @@ describe('parseCommandDisplay', () => {
       success: true,
       nft_info: {
         data_uris: ['https://example.com/nft.png'],
+        data_hash: 'data-hash',
         royalty_percentage: 250,
       },
     });
+    mockNftGetImageDataUrl.mockResolvedValue('data:image/png;base64,cHJldmlldw==');
 
     await expect(
       parseCommandDisplay('chia_wallet.take_offer', {
@@ -197,13 +203,14 @@ describe('parseCommandDisplay', () => {
         spending: [
           {
             kind: 'nft',
-            previewUrl: 'https://example.com/nft.png',
+            previewUrl: 'data:image/png;base64,cHJldmlldw==',
             royaltyPercentage: 250,
           },
         ],
       },
     });
     expect(mockNftGetInfo).toHaveBeenCalledWith(nftLauncherId);
+    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith('https://example.com/nft.png', 'data-hash');
   });
 
   it('uses the metadata preview image for a video NFT instead of the video data uri', async () => {
@@ -226,11 +233,14 @@ describe('parseCommandDisplay', () => {
       nft_info: {
         data_uris: ['https://example.com/nft.mp4'],
         metadata_uris: ['https://example.com/nft.json'],
+        metadata_hash: 'metadata-hash',
       },
     });
     mockNftGetMetadata.mockResolvedValue({
       preview_image_uris: ['https://example.com/nft-preview.png'],
+      preview_image_hash: 'preview-image-hash',
     });
+    mockNftGetImageDataUrl.mockResolvedValue('data:image/png;base64,cHJldmlldw==');
 
     await expect(
       parseCommandDisplay('chia_wallet.take_offer', {
@@ -241,12 +251,49 @@ describe('parseCommandDisplay', () => {
         spending: [
           {
             kind: 'nft',
-            previewUrl: 'https://example.com/nft-preview.png',
+            previewUrl: 'data:image/png;base64,cHJldmlldw==',
           },
         ],
       },
     });
-    expect(mockNftGetMetadata).toHaveBeenCalledWith('https://example.com/nft.json');
+    expect(mockNftGetMetadata).toHaveBeenCalledWith('https://example.com/nft.json', 'metadata-hash');
+    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith('https://example.com/nft-preview.png', 'preview-image-hash');
+  });
+
+  it('tries later metadata URIs when an earlier fallback cannot be verified', async () => {
+    mockNftGetMetadata.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+      preview_image_uris: ['https://example.com/verified-preview.png'],
+      preview_image_hash: 'preview-image-hash',
+    });
+    mockNftGetImageDataUrl.mockResolvedValue('data:image/png;base64,cHJldmlldw==');
+
+    await expect(
+      resolveNftPreviewUrl(
+        [],
+        undefined,
+        ['https://example.com/unavailable.json', 'https://example.com/verified.json'],
+        'metadata-hash',
+      ),
+    ).resolves.toBe('data:image/png;base64,cHJldmlldw==');
+
+    expect(mockNftGetMetadata.mock.calls).toEqual([
+      ['https://example.com/unavailable.json', 'metadata-hash'],
+      ['https://example.com/verified.json', 'metadata-hash'],
+    ]);
+  });
+
+  it('does not fetch confirmation previews that have no expected on-chain hash', async () => {
+    await expect(
+      resolveNftPreviewUrl(
+        ['https://example.com/unverifiable.png'],
+        undefined,
+        ['https://example.com/unverifiable.json'],
+        undefined,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockNftGetMetadata).not.toHaveBeenCalled();
+    expect(mockNftGetImageDataUrl).not.toHaveBeenCalled();
   });
 
   it('omits the preview for a video NFT without a metadata preview image', async () => {
@@ -269,6 +316,7 @@ describe('parseCommandDisplay', () => {
       nft_info: {
         data_uris: ['https://example.com/nft.mp4'],
         metadata_uris: ['https://example.com/nft.json'],
+        metadata_hash: 'metadata-hash',
       },
     });
     mockNftGetMetadata.mockResolvedValue({});
@@ -279,6 +327,7 @@ describe('parseCommandDisplay', () => {
     const line = result.walletDelta!.spending[0] as { kind: string; previewUrl?: string };
     expect(line.kind).toBe('nft');
     expect(line.previewUrl).toBeUndefined();
+    expect(mockNftGetMetadata).toHaveBeenCalledWith('https://example.com/nft.json', 'metadata-hash');
   });
 
   it('uses an extensionless data uri as preview when metadata has no preview image', async () => {
@@ -300,9 +349,11 @@ describe('parseCommandDisplay', () => {
       success: true,
       nft_info: {
         data_uris: ['https://ipfs.example.com/bafybeigdyrztest'],
+        data_hash: 'data-hash',
         metadata_uris: [],
       },
     });
+    mockNftGetImageDataUrl.mockResolvedValue('data:image/webp;base64,cHJldmlldw==');
 
     await expect(
       parseCommandDisplay('chia_wallet.take_offer', {
@@ -313,12 +364,13 @@ describe('parseCommandDisplay', () => {
         spending: [
           {
             kind: 'nft',
-            previewUrl: 'https://ipfs.example.com/bafybeigdyrztest',
+            previewUrl: 'data:image/webp;base64,cHJldmlldw==',
           },
         ],
       },
     });
     expect(mockNftGetMetadata).not.toHaveBeenCalled();
+    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith('https://ipfs.example.com/bafybeigdyrztest', 'data-hash');
   });
 
   it('shows the take-offer fungible total with NFT creator royalties', async () => {

--- a/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
@@ -35,6 +35,12 @@ jest.mock('../api/nftGetInfo', () => ({
   nftGetInfo: mockNftGetInfo,
 }));
 
+const mockNftGetMetadata = jest.fn<Promise<unknown>, [string]>();
+
+jest.mock('../api/nftGetMetadata', () => ({
+  nftGetMetadata: mockNftGetMetadata,
+}));
+
 const { parseCommandDisplay } = jest.requireActual<typeof import('./parseCommandDisplay')>('./parseCommandDisplay');
 
 function makeOfferSummary(overrides: Partial<OfferSummaryResponse['summary']> = {}): OfferSummaryResponse {
@@ -55,6 +61,7 @@ describe('parseCommandDisplay', () => {
     mockGetWalletInfos.mockReset();
     mockGetOfferSummary.mockReset();
     mockNftGetInfo.mockReset();
+    mockNftGetMetadata.mockReset();
     mockCatAssetIdToName.mockReset();
   });
 
@@ -197,6 +204,121 @@ describe('parseCommandDisplay', () => {
       },
     });
     expect(mockNftGetInfo).toHaveBeenCalledWith(nftLauncherId);
+  });
+
+  it('uses the metadata preview image for a video NFT instead of the video data uri', async () => {
+    const nftLauncherId = '6b6b2a3b4c57c2b4596625583cbede95d081b59d18125fedb6b416a8ee46cfe5';
+    mockGetWalletInfos.mockResolvedValue({});
+    mockGetOfferSummary.mockResolvedValue(
+      makeOfferSummary({
+        requested: {
+          [nftLauncherId]: '1',
+        },
+        infos: {
+          [nftLauncherId]: {
+            type: 'singleton',
+          },
+        },
+      }),
+    );
+    mockNftGetInfo.mockResolvedValue({
+      success: true,
+      nft_info: {
+        data_uris: ['https://example.com/nft.mp4'],
+        metadata_uris: ['https://example.com/nft.json'],
+      },
+    });
+    mockNftGetMetadata.mockResolvedValue({
+      preview_image_uris: ['https://example.com/nft-preview.png'],
+    });
+
+    await expect(
+      parseCommandDisplay('chia_wallet.take_offer', {
+        offer: 'offer1...',
+      }),
+    ).resolves.toMatchObject({
+      walletDelta: {
+        spending: [
+          {
+            kind: 'nft',
+            previewUrl: 'https://example.com/nft-preview.png',
+          },
+        ],
+      },
+    });
+    expect(mockNftGetMetadata).toHaveBeenCalledWith('https://example.com/nft.json');
+  });
+
+  it('omits the preview for a video NFT without a metadata preview image', async () => {
+    const nftLauncherId = '6b6b2a3b4c57c2b4596625583cbede95d081b59d18125fedb6b416a8ee46cfe5';
+    mockGetWalletInfos.mockResolvedValue({});
+    mockGetOfferSummary.mockResolvedValue(
+      makeOfferSummary({
+        requested: {
+          [nftLauncherId]: '1',
+        },
+        infos: {
+          [nftLauncherId]: {
+            type: 'singleton',
+          },
+        },
+      }),
+    );
+    mockNftGetInfo.mockResolvedValue({
+      success: true,
+      nft_info: {
+        data_uris: ['https://example.com/nft.mp4'],
+        metadata_uris: ['https://example.com/nft.json'],
+      },
+    });
+    mockNftGetMetadata.mockResolvedValue({});
+
+    const result = await parseCommandDisplay('chia_wallet.take_offer', {
+      offer: 'offer1...',
+    });
+    const line = result.walletDelta!.spending[0] as { kind: string; previewUrl?: string };
+    expect(line.kind).toBe('nft');
+    expect(line.previewUrl).toBeUndefined();
+  });
+
+  it('uses an extensionless data uri as preview when metadata has no preview image', async () => {
+    const nftLauncherId = '6b6b2a3b4c57c2b4596625583cbede95d081b59d18125fedb6b416a8ee46cfe5';
+    mockGetWalletInfos.mockResolvedValue({});
+    mockGetOfferSummary.mockResolvedValue(
+      makeOfferSummary({
+        requested: {
+          [nftLauncherId]: '1',
+        },
+        infos: {
+          [nftLauncherId]: {
+            type: 'singleton',
+          },
+        },
+      }),
+    );
+    mockNftGetInfo.mockResolvedValue({
+      success: true,
+      nft_info: {
+        data_uris: ['https://ipfs.example.com/bafybeigdyrztest'],
+        metadata_uris: [],
+      },
+    });
+
+    await expect(
+      parseCommandDisplay('chia_wallet.take_offer', {
+        offer: 'offer1...',
+      }),
+    ).resolves.toMatchObject({
+      walletDelta: {
+        spending: [
+          {
+            kind: 'nft',
+            previewUrl: 'https://ipfs.example.com/bafybeigdyrztest',
+          },
+        ],
+      },
+    });
+    expect(mockNftGetMetadata).not.toHaveBeenCalled();
   });
 
   it('shows the take-offer fungible total with NFT creator royalties', async () => {

--- a/packages/gui/src/electron/commands/parseCommandDisplay.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.ts
@@ -4,7 +4,7 @@ import { catAssetIdToName } from '../api/catAssetIdToName';
 import { getOfferSummary } from '../api/getOfferSummary';
 import { getWalletInfos, type WalletInfo } from '../api/getWalletNames';
 import { nftGetInfo } from '../api/nftGetInfo';
-import { nftGetMetadata } from '../api/nftGetMetadata';
+import { nftGetImageDataUrl, nftGetMetadata } from '../api/nftGetMetadata';
 import resolveAssetDisplayKind from '../api/resolveAssetDisplayKind';
 import WalletType from '../constants/WalletType';
 import type { DisplayWalletDelta, DisplayWalletDeltaItem } from '../dialogs/Confirm/Confirm';
@@ -49,30 +49,72 @@ function hexToNftId(hex: string): string {
   }
 }
 
-/** The confirmation dialog renders the preview in an `<img>`, which can only
- * display images — a video/audio data uri would show as a broken image icon.
- * Pick an image data uri when there is one, otherwise fall back to the
- * metadata's preview image; NFTs with no usable image keep the placeholder. */
-export async function resolveNftPreviewUrl(dataUris: string[], metadataUris: string[]): Promise<string | undefined> {
-  const validDataUris = dataUris.filter((uri) => isValidURL(uri));
-
-  const imageUri = validDataUris.find((uri) => getFileType(uri) === FileType.IMAGE);
-  if (imageUri) {
-    return imageUri;
+async function resolveVerifiedImage(uris: string[], expectedHash: string | undefined): Promise<string | undefined> {
+  if (!expectedHash) {
+    return undefined;
   }
 
-  const metadataUri = metadataUris.find((uri) => isValidURL(uri));
-  if (metadataUri) {
-    const metadata = await nftGetMetadata(metadataUri);
-    const previewImageUri = metadata?.preview_image_uris?.find((uri) => typeof uri === 'string' && isValidURL(uri));
-    if (previewImageUri) {
-      return previewImageUri;
+  for (const uri of uris) {
+    if (isValidURL(uri)) {
+      // URI lists are ordered fallbacks for the same content.
+      // eslint-disable-next-line no-await-in-loop -- Fallbacks must be tried in their declared order.
+      const dataUrl = await nftGetImageDataUrl(uri, expectedHash);
+      if (dataUrl) {
+        return dataUrl;
+      }
     }
   }
 
-  // an extensionless data uri (common on IPFS) is usually an image — better to
-  // attempt it than to show nothing; known non-image types keep the placeholder
-  return validDataUris.find((uri) => getFileType(uri) === FileType.UNKNOWN);
+  return undefined;
+}
+
+/** The confirmation dialog renders the preview in an `<img>`, which can only
+ * display images — a video/audio payload would show as a broken image icon.
+ * Fetch and hash-check the content in the main process, then return an immutable
+ * data URL so the sandbox never performs a second, unauthenticated request. */
+export async function resolveNftPreviewUrl(
+  dataUris: string[],
+  dataHash: string | undefined,
+  metadataUris: string[],
+  metadataHash: string | undefined,
+): Promise<string | undefined> {
+  const validDataUris = dataUris.filter((uri) => isValidURL(uri));
+
+  const imageDataUrl = await resolveVerifiedImage(
+    validDataUris.filter((uri) => getFileType(uri) === FileType.IMAGE),
+    dataHash,
+  );
+  if (imageDataUrl) {
+    return imageDataUrl;
+  }
+
+  if (metadataHash) {
+    for (const metadataUri of metadataUris) {
+      if (isValidURL(metadataUri)) {
+        // Metadata URIs are ordered fallbacks for the same on-chain hash.
+        // eslint-disable-next-line no-await-in-loop -- Fallbacks must be tried in their declared order.
+        const metadata = await nftGetMetadata(metadataUri, metadataHash);
+        if (metadata) {
+          // eslint-disable-next-line no-await-in-loop -- Resolve each verified metadata fallback before moving on.
+          const previewDataUrl = await resolveVerifiedImage(
+            metadata.preview_image_uris ?? [],
+            metadata.preview_image_hash,
+          );
+          if (previewDataUrl) {
+            return previewDataUrl;
+          }
+        }
+      }
+    }
+  }
+
+  // An extensionless data URI (common on IPFS) may be an image. Its verified
+  // response MIME type decides whether it can be used; known non-image types
+  // keep the placeholder.
+  return resolveVerifiedImage(
+    validDataUris.filter((uri) => getFileType(uri) === FileType.UNKNOWN),
+    dataHash,
+  );
 }
 
 function parseRoyaltyPercentage(value: unknown): number | undefined {
@@ -347,7 +389,9 @@ async function parseWalletDeltaItem(
       if (nftInfo && nftInfo.success && nftInfo.nft_info) {
         const previewUrl = await resolveNftPreviewUrl(
           nftInfo.nft_info.data_uris ?? [],
+          nftInfo.nft_info.data_hash,
           nftInfo.nft_info.metadata_uris ?? [],
+          nftInfo.nft_info.metadata_hash,
         );
 
         if (previewUrl) {

--- a/packages/gui/src/electron/commands/parseCommandDisplay.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.ts
@@ -1,7 +1,10 @@
+import FileType from '../../constants/FileType';
+import getFileType from '../../util/getFileType';
 import { catAssetIdToName } from '../api/catAssetIdToName';
 import { getOfferSummary } from '../api/getOfferSummary';
 import { getWalletInfos, type WalletInfo } from '../api/getWalletNames';
 import { nftGetInfo } from '../api/nftGetInfo';
+import { nftGetMetadata } from '../api/nftGetMetadata';
 import resolveAssetDisplayKind from '../api/resolveAssetDisplayKind';
 import WalletType from '../constants/WalletType';
 import type { DisplayWalletDelta, DisplayWalletDeltaItem } from '../dialogs/Confirm/Confirm';
@@ -44,6 +47,32 @@ function hexToNftId(hex: string): string {
   } catch {
     return hex;
   }
+}
+
+/** The confirmation dialog renders the preview in an `<img>`, which can only
+ * display images — a video/audio data uri would show as a broken image icon.
+ * Pick an image data uri when there is one, otherwise fall back to the
+ * metadata's preview image; NFTs with no usable image keep the placeholder. */
+export async function resolveNftPreviewUrl(dataUris: string[], metadataUris: string[]): Promise<string | undefined> {
+  const validDataUris = dataUris.filter((uri) => isValidURL(uri));
+
+  const imageUri = validDataUris.find((uri) => getFileType(uri) === FileType.IMAGE);
+  if (imageUri) {
+    return imageUri;
+  }
+
+  const metadataUri = metadataUris.find((uri) => isValidURL(uri));
+  if (metadataUri) {
+    const metadata = await nftGetMetadata(metadataUri);
+    const previewImageUri = metadata?.preview_image_uris?.find((uri) => typeof uri === 'string' && isValidURL(uri));
+    if (previewImageUri) {
+      return previewImageUri;
+    }
+  }
+
+  // an extensionless data uri (common on IPFS) is usually an image — better to
+  // attempt it than to show nothing; known non-image types keep the placeholder
+  return validDataUris.find((uri) => getFileType(uri) === FileType.UNKNOWN);
 }
 
 function parseRoyaltyPercentage(value: unknown): number | undefined {
@@ -315,8 +344,11 @@ async function parseWalletDeltaItem(
 
     try {
       const nftInfo = await nftGetInfo(key);
-      if (nftInfo && nftInfo.success && nftInfo.nft_info && nftInfo.nft_info.data_uris) {
-        const previewUrl = nftInfo.nft_info.data_uris.find((u) => isValidURL(u));
+      if (nftInfo && nftInfo.success && nftInfo.nft_info) {
+        const previewUrl = await resolveNftPreviewUrl(
+          nftInfo.nft_info.data_uris ?? [],
+          nftInfo.nft_info.metadata_uris ?? [],
+        );
 
         if (previewUrl) {
           result.previewUrl = previewUrl;

--- a/packages/gui/src/electron/components/SandboxedIframe/SandboxedIframe.tsx
+++ b/packages/gui/src/electron/components/SandboxedIframe/SandboxedIframe.tsx
@@ -22,7 +22,7 @@ export default function SandboxedIframe(props: SandboxIframeProps) {
               connect-src 'none';
               font-src   'none';
               frame-src  'none';
-              img-src    https:;
+              img-src    https: data:;
               media-src 'none';
               object-src 'none';
               script-src 'none';

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -10,6 +10,7 @@ import {
   Notification,
   type MenuItemConstructorOptions,
   nativeTheme,
+  protocol,
 } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -29,7 +30,7 @@ import { WcError, WcErrorCode, encodeWcErrorForIpc } from '../@types/WcError';
 import AppIcon from '../assets/img/chia64x64.png';
 import { i18n } from '../config/locales';
 
-import CacheManager from './CacheManager';
+import CacheManager, { CACHE_PROTOCOL } from './CacheManager';
 import { checkNFTOwnership } from './api/checkNFTOwnership';
 import { getKeyDetails } from './api/getKeyDetails';
 import { getNetworkInfo } from './api/getNetworkInfo';
@@ -93,6 +94,22 @@ type ConfirmDialogResult = {
 
 app.disableHardwareAcceleration();
 app.commandLine.appendSwitch('disable-http-cache');
+
+// The cache: scheme serves NFT media to <img>/<video>/<audio> tags. Media
+// elements expect protocols to buffer their responses unless the scheme is
+// registered with stream: true, so without this video and audio playback
+// stalls. Must be called before the app ready event.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: CACHE_PROTOCOL,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+    },
+  },
+]);
 
 const appIcon = nativeImage.createFromPath(path.join(__dirname, AppIcon));
 

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -118,9 +118,16 @@ const prefs = readPrefs();
 const defaultCacheFolder = path.join(app.getPath('cache'), app.getName());
 const cacheDirectory: string = prefs.cacheFolder || defaultCacheFolder;
 
+// `cacheLimitSize` is the legacy preference key older versions of the
+// settings UI stored the value under. Invalid values are ignored because the
+// CacheManager constructor throws on non-positive sizes.
+const storedMaxCacheSize: number | undefined = [prefs.maxCacheSize, prefs.cacheLimitSize].find(
+  (size) => typeof size === 'number' && Number.isFinite(size) && size > 0,
+);
+
 const cacheManager = new CacheManager({
   cacheDirectory,
-  maxCacheSize: prefs.maxCacheSize,
+  maxCacheSize: storedMaxCacheSize,
 });
 
 // Hoisted so IPC handlers registered below can close over them; assigned in

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -120,9 +120,9 @@ const cacheDirectory: string = prefs.cacheFolder || defaultCacheFolder;
 
 // `cacheLimitSize` is the legacy preference key older versions of the
 // settings UI stored the value under. Invalid values are ignored because the
-// CacheManager constructor throws on non-positive sizes.
+// CacheManager constructor rejects negative sizes; zero means unlimited.
 const storedMaxCacheSize: number | undefined = [prefs.maxCacheSize, prefs.cacheLimitSize].find(
-  (size) => typeof size === 'number' && Number.isFinite(size) && size > 0,
+  (size) => typeof size === 'number' && Number.isFinite(size) && size >= 0,
 );
 
 const cacheManager = new CacheManager({

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -63,10 +63,12 @@ class WriteStreamPromise {
   }
 }
 
+export const MAX_FILE_SIZE_EXCEEDED_ERROR = 'Maximum file size exceeded';
+
 type DownloadFileOptions = {
   timeout?: number;
   signal?: AbortSignal;
-  maxSize?: number;
+  maxSize?: number; // values <= 0 disable the size limit
   onProgress?: (progress: number, size: number, downloadedSize: number) => void;
   overrideFile?: boolean;
 };
@@ -84,11 +86,26 @@ export default async function downloadFile(
   const request = net.request(url);
   const outputStream = new WriteStreamPromise(tempFilePath, overrideFile);
 
+  // set when we abort the request ourselves, so abort events can be reported
+  // with the real reason instead of a generic aborted error
+  let abortError: Error | undefined;
+
   function abortRequest() {
     request.abort();
   }
 
   let timeoutId: NodeJS.Timeout | null = null;
+
+  // the timeout is an inactivity timeout - it is reset every time data
+  // arrives, so slow hosts serving large files (videos) are not cut off mid
+  // transfer while a stalled connection still fails fast
+  function resetTimeout() {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(abortRequest, timeout);
+  }
 
   return new Promise<Headers>((resolve, reject) => {
     let downloadedSize = 0;
@@ -161,7 +178,8 @@ export default async function downloadFile(
         const size = Number.parseInt(contentLength, 10);
         if (!Number.isNaN(size)) {
           fileSize = size;
-          if (size > maxSize) {
+          if (maxSize > 0 && size > maxSize) {
+            abortError = new Error(MAX_FILE_SIZE_EXCEEDED_ERROR);
             request.abort();
             return;
           }
@@ -170,8 +188,10 @@ export default async function downloadFile(
 
       response.on('data', (chunk) => {
         downloadedSize += chunk.byteLength;
+        resetTimeout();
 
-        if (downloadedSize > maxSize) {
+        if (maxSize > 0 && downloadedSize > maxSize) {
+          abortError = new Error(MAX_FILE_SIZE_EXCEEDED_ERROR);
           request.abort();
           return;
         }
@@ -182,7 +202,7 @@ export default async function downloadFile(
 
         // send progress event only when we know the file size
         if (onProgress && fileSize !== undefined && fileSize > 0) {
-          const progress = Math.max((downloadedSize / fileSize) * 100, 100);
+          const progress = Math.min((downloadedSize / fileSize) * 100, 100);
           onProgress(progress, fileSize, downloadedSize);
         }
       });
@@ -192,7 +212,7 @@ export default async function downloadFile(
       });
 
       response.on('aborted', () => {
-        resolvePromise(false, new Error('Response aborted'));
+        resolvePromise(false, abortError ?? new Error('Response aborted'));
       });
 
       response.on('end', () => {
@@ -201,7 +221,7 @@ export default async function downloadFile(
     });
 
     request.on('abort', () => {
-      resolvePromise(false, new Error('Request aborted'));
+      resolvePromise(false, abortError ?? new Error('Request aborted'));
     });
 
     request.on('error', (error = new Error('Unknown request error')) => {
@@ -212,7 +232,7 @@ export default async function downloadFile(
       signal.addEventListener('abort', abortRequest);
     }
 
-    timeoutId = setTimeout(abortRequest, timeout);
+    resetTimeout();
 
     request.end();
   });

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -67,6 +67,7 @@ export const MAX_FILE_SIZE_EXCEEDED_ERROR = 'Maximum file size exceeded';
 
 type DownloadFileOptions = {
   timeout?: number;
+  maxDuration?: number; // absolute cap on the whole transfer
   signal?: AbortSignal;
   maxSize?: number; // values <= 0 disable the size limit
   onProgress?: (progress: number, size: number, downloadedSize: number) => void;
@@ -76,7 +77,14 @@ type DownloadFileOptions = {
 export default async function downloadFile(
   url: string,
   localPath: string,
-  { timeout = 30_000, signal, maxSize = 100 * 1024 * 1024, onProgress, overrideFile = false }: DownloadFileOptions = {},
+  {
+    timeout = 30_000,
+    maxDuration = 30 * 60 * 1000,
+    signal,
+    maxSize = 100 * 1024 * 1024,
+    onProgress,
+    overrideFile = false,
+  }: DownloadFileOptions = {},
 ): Promise<Headers> {
   if (!isValidURL(url)) {
     throw new Error('Invalid URL');
@@ -107,6 +115,10 @@ export default async function downloadFile(
     timeoutId = setTimeout(abortRequest, timeout);
   }
 
+  // absolute deadline for the whole transfer — the inactivity timeout alone
+  // would let a host trickling bytes hold a download slot forever
+  const maxDurationTimeoutId = setTimeout(abortRequest, maxDuration);
+
   return new Promise<Headers>((resolve, reject) => {
     let downloadedSize = 0;
 
@@ -131,6 +143,8 @@ export default async function downloadFile(
           clearTimeout(timeoutId);
           timeoutId = null;
         }
+
+        clearTimeout(maxDurationTimeoutId);
 
         await outputStream.close();
 

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -102,6 +102,14 @@ export default async function downloadFile(
     request.abort();
   }
 
+  // Timeouts must not report the generic aborted error: the cache retries
+  // aborted downloads on every access, so a stalled host would be retried
+  // (and stall again) forever instead of settling as a failed download.
+  function abortWithError(error: Error) {
+    abortError = error;
+    request.abort();
+  }
+
   let timeoutId: NodeJS.Timeout | null = null;
 
   // the timeout is an inactivity timeout - it is reset every time data
@@ -112,12 +120,18 @@ export default async function downloadFile(
       clearTimeout(timeoutId);
     }
 
-    timeoutId = setTimeout(abortRequest, timeout);
+    timeoutId = setTimeout(
+      () => abortWithError(new Error(`Request timed out after ${timeout}ms of inactivity`)),
+      timeout,
+    );
   }
 
   // absolute deadline for the whole transfer — the inactivity timeout alone
   // would let a host trickling bytes hold a download slot forever
-  const maxDurationTimeoutId = setTimeout(abortRequest, maxDuration);
+  const maxDurationTimeoutId = setTimeout(
+    () => abortWithError(new Error(`Request exceeded the ${maxDuration}ms download deadline`)),
+    maxDuration,
+  );
 
   return new Promise<Headers>((resolve, reject) => {
     let downloadedSize = 0;

--- a/packages/gui/src/electron/utils/fetchBuffer.test.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.test.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'node:events';
+
+const mockNetRequest = jest.fn();
+
+jest.mock('electron', () => ({
+  net: {
+    request: mockNetRequest,
+  },
+}));
+
+const fetchBuffer = jest.requireActual<typeof import('./fetchBuffer')>('./fetchBuffer').default;
+
+type MockRequest = EventEmitter & {
+  abort: jest.Mock;
+  end: jest.Mock;
+};
+
+type MockResponse = EventEmitter & {
+  statusCode: number;
+  headers: Record<string, string | string[]>;
+};
+
+function makeResponse(statusCode: number = 200, headers: Record<string, string | string[]> = {}): MockResponse {
+  return Object.assign(new EventEmitter(), {
+    statusCode,
+    headers,
+  });
+}
+
+describe('fetchBuffer', () => {
+  let request: MockRequest;
+
+  beforeEach(() => {
+    mockNetRequest.mockReset();
+    request = Object.assign(new EventEmitter(), {
+      abort: jest.fn(),
+      end: jest.fn(),
+    });
+    request.abort.mockImplementation(() => {
+      request.emit('abort');
+    });
+    mockNetRequest.mockReturnValue(request);
+  });
+
+  it('returns response bytes and headers', async () => {
+    const resultPromise = fetchBuffer('https://example.com/image.png', {
+      maxSize: 1024,
+    });
+    const response = makeResponse(200, {
+      'content-type': 'image/png',
+    });
+
+    request.emit('response', response);
+    response.emit('data', Buffer.from('first'));
+    response.emit('data', Buffer.from(' second'));
+    response.emit('end');
+
+    await expect(resultPromise).resolves.toEqual({
+      data: Buffer.from('first second'),
+      headers: {
+        'content-type': 'image/png',
+      },
+    });
+    expect(request.end).toHaveBeenCalledWith();
+  });
+
+  it('rejects an oversized response from its content-length header', async () => {
+    const resultPromise = fetchBuffer('https://example.com/image.png', {
+      maxSize: 10,
+    });
+
+    request.emit(
+      'response',
+      makeResponse(200, {
+        'content-length': '11',
+      }),
+    );
+
+    await expect(resultPromise).rejects.toThrow('Response exceeded maximum allowed size');
+    expect(request.abort).toHaveBeenCalledWith();
+  });
+
+  it('rejects an oversized streamed response without a content-length header', async () => {
+    const resultPromise = fetchBuffer('https://example.com/image.png', {
+      maxSize: 10,
+    });
+    const response = makeResponse();
+
+    request.emit('response', response);
+    response.emit('data', Buffer.alloc(11));
+
+    await expect(resultPromise).rejects.toThrow('Response exceeded maximum allowed size');
+    expect(request.abort).toHaveBeenCalledWith();
+  });
+});

--- a/packages/gui/src/electron/utils/fetchBuffer.test.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.test.ts
@@ -8,7 +8,8 @@ jest.mock('electron', () => ({
   },
 }));
 
-const fetchBuffer = jest.requireActual<typeof import('./fetchBuffer')>('./fetchBuffer').default;
+const { default: fetchBuffer, MaxSizeExceededError } =
+  jest.requireActual<typeof import('./fetchBuffer')>('./fetchBuffer');
 
 type MockRequest = EventEmitter & {
   abort: jest.Mock;
@@ -64,7 +65,7 @@ describe('fetchBuffer', () => {
     expect(request.end).toHaveBeenCalledWith();
   });
 
-  it('rejects an oversized response from its content-length header', async () => {
+  it('rejects an oversized response from its content-length header with the response headers', async () => {
     const resultPromise = fetchBuffer('https://example.com/image.png', {
       maxSize: 10,
     });
@@ -73,10 +74,17 @@ describe('fetchBuffer', () => {
       'response',
       makeResponse(200, {
         'content-length': '11',
+        'content-type': 'image/gif',
       }),
     );
 
-    await expect(resultPromise).rejects.toThrow('Response exceeded maximum allowed size');
+    await expect(resultPromise).rejects.toThrow(MaxSizeExceededError);
+    await expect(resultPromise).rejects.toMatchObject({
+      headers: {
+        'content-length': '11',
+        'content-type': 'image/gif',
+      },
+    });
     expect(request.abort).toHaveBeenCalledWith();
   });
 
@@ -84,12 +92,19 @@ describe('fetchBuffer', () => {
     const resultPromise = fetchBuffer('https://example.com/image.png', {
       maxSize: 10,
     });
-    const response = makeResponse();
+    const response = makeResponse(200, {
+      'content-type': 'image/gif',
+    });
 
     request.emit('response', response);
     response.emit('data', Buffer.alloc(11));
 
-    await expect(resultPromise).rejects.toThrow('Response exceeded maximum allowed size');
+    await expect(resultPromise).rejects.toThrow(MaxSizeExceededError);
+    await expect(resultPromise).rejects.toMatchObject({
+      headers: {
+        'content-type': 'image/gif',
+      },
+    });
     expect(request.abort).toHaveBeenCalledWith();
   });
 });

--- a/packages/gui/src/electron/utils/fetchBuffer.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.ts
@@ -1,0 +1,132 @@
+import { net, type IncomingMessage } from 'electron';
+
+import type Headers from '../../@types/Headers';
+
+import isValidURL from './isValidURL';
+
+const DEFAULT_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_MAX_SIZE = 100 * 1024 * 1024; // 100 MB
+
+export type FetchBufferResult = {
+  data: Buffer;
+  headers: Headers;
+};
+
+export default async function fetchBuffer(
+  url: string,
+  options?: {
+    headers?: Record<string, string>;
+    timeout?: number;
+    maxSize?: number;
+  },
+): Promise<FetchBufferResult> {
+  const { headers = {}, timeout = DEFAULT_TIMEOUT, maxSize = DEFAULT_MAX_SIZE } = options ?? {};
+
+  if (!isValidURL(url)) {
+    throw new Error('Invalid URL');
+  }
+
+  const request = net.request({
+    method: 'GET',
+    url,
+    headers,
+  });
+
+  return new Promise<FetchBufferResult>((resolve, reject) => {
+    let settled = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+
+    const resolveOnce = (result: FetchBufferResult) => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        resolve(result);
+      }
+    };
+
+    const rejectOnce = (error: Error) => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        reject(error);
+      }
+    };
+
+    const abortWith = (error: Error) => {
+      rejectOnce(error);
+      request.abort();
+    };
+
+    timeoutId = setTimeout(() => {
+      abortWith(new Error(`Request timeout after ${timeout}ms`));
+    }, timeout);
+
+    request.on('response', (response: IncomingMessage) => {
+      const { statusCode } = response;
+      if (statusCode < 200 || statusCode >= 300) {
+        abortWith(new Error(`HTTP error! status: ${statusCode}`));
+        return;
+      }
+
+      const contentLengthHeader = response.headers['content-length'];
+      const contentLength = Array.isArray(contentLengthHeader) ? contentLengthHeader[0] : contentLengthHeader;
+      if (maxSize > 0 && contentLength) {
+        const parsedContentLength = Number.parseInt(contentLength, 10);
+        if (!Number.isNaN(parsedContentLength) && parsedContentLength > maxSize) {
+          abortWith(new Error('Response exceeded maximum allowed size'));
+          return;
+        }
+      }
+
+      const chunks: Uint8Array[] = [];
+      let dataSize = 0;
+
+      response.on('data', (chunk: Buffer) => {
+        if (settled) {
+          return;
+        }
+
+        const buffer = Uint8Array.from(chunk);
+        dataSize += buffer.byteLength;
+        if (maxSize > 0 && dataSize > maxSize) {
+          abortWith(new Error('Response exceeded maximum allowed size'));
+          return;
+        }
+
+        chunks.push(buffer);
+      });
+
+      response.on('end', () => {
+        resolveOnce({
+          data: Buffer.concat(chunks),
+          headers: response.headers as Headers,
+        });
+      });
+
+      response.on('aborted', () => {
+        rejectOnce(new Error('Response aborted'));
+      });
+
+      response.on('error', (error: Error) => {
+        rejectOnce(error);
+      });
+    });
+
+    request.on('error', (error: Error) => {
+      rejectOnce(error);
+    });
+
+    request.on('abort', () => {
+      rejectOnce(new Error('Request aborted'));
+    });
+
+    request.end();
+  });
+}

--- a/packages/gui/src/electron/utils/fetchBuffer.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.ts
@@ -12,6 +12,19 @@ export type FetchBufferResult = {
   headers: Headers;
 };
 
+/** Carries the response headers so callers can decide how to degrade when a
+ * response is too large to buffer — e.g. fall back to a direct URL for a
+ * verified image content type. */
+export class MaxSizeExceededError extends Error {
+  readonly headers: Headers;
+
+  constructor(headers: Headers) {
+    super('Response exceeded maximum allowed size');
+    this.name = 'MaxSizeExceededError';
+    this.headers = headers;
+  }
+}
+
 export default async function fetchBuffer(
   url: string,
   options?: {
@@ -80,7 +93,7 @@ export default async function fetchBuffer(
       if (maxSize > 0 && contentLength) {
         const parsedContentLength = Number.parseInt(contentLength, 10);
         if (!Number.isNaN(parsedContentLength) && parsedContentLength > maxSize) {
-          abortWith(new Error('Response exceeded maximum allowed size'));
+          abortWith(new MaxSizeExceededError(response.headers as Headers));
           return;
         }
       }
@@ -96,7 +109,7 @@ export default async function fetchBuffer(
         const buffer = Uint8Array.from(chunk);
         dataSize += buffer.byteLength;
         if (maxSize > 0 && dataSize > maxSize) {
-          abortWith(new Error('Response exceeded maximum allowed size'));
+          abortWith(new MaxSizeExceededError(response.headers as Headers));
           return;
         }
 

--- a/packages/gui/src/electron/utils/sanitizeNumber.ts
+++ b/packages/gui/src/electron/utils/sanitizeNumber.ts
@@ -1,14 +1,8 @@
 export default function sanitizeNumber(input: number | string): number {
-  let size: number;
+  const size = typeof input === 'string' ? Number(input) : input;
 
-  if (typeof input === 'string') {
-    size = parseInt(input, 10);
-  } else {
-    size = input;
-  }
-
-  if (Number.isNaN(size) || size <= 0) {
-    throw new Error('Invalid maxTotalSize value. It must be a positive number.');
+  if ((typeof input === 'string' && input.trim() === '') || !Number.isFinite(size) || size < 0) {
+    throw new Error('Invalid maxTotalSize value. It must be a non-negative finite number.');
   }
 
   return size;

--- a/packages/gui/src/hooks/selectNFTPreviewState.test.ts
+++ b/packages/gui/src/hooks/selectNFTPreviewState.test.ts
@@ -1,0 +1,84 @@
+import selectNFTPreviewState, { type NFTPreviewState } from './selectNFTPreviewState';
+
+const fetchFailure: NFTPreviewState = {
+  isVerified: false,
+  uri: 'https://example.com/unavailable.mp4',
+  error: new Error('Request failed'),
+  failedFetch: true,
+};
+
+const hashMismatch: NFTPreviewState = {
+  isVerified: false,
+  uri: 'https://example.com/tampered.png',
+  error: new Error('Invalid hash checksum'),
+  failedFetch: false,
+};
+
+describe('selectNFTPreviewState', () => {
+  it('does not expose optimistic preview URIs without expected hashes', () => {
+    expect(
+      selectNFTPreviewState({
+        isVerifying: true,
+        previewVideoCandidate: {
+          uris: ['https://example.com/unverifiable.mp4'],
+        },
+        previewImageCandidate: {
+          uris: ['https://example.com/unverifiable.png'],
+        },
+        dataCandidate: {
+          uris: ['https://example.com/unverifiable-data.png'],
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('moves to the next verifiable candidate while an earlier source has failed', () => {
+    expect(
+      selectNFTPreviewState({
+        isVerifying: true,
+        previewVideo: fetchFailure,
+        previewImageCandidate: {
+          uris: ['https://example.com/preview.png'],
+          hash: 'preview-hash',
+        },
+        dataCandidate: {
+          uris: ['https://example.com/data.png'],
+          hash: 'data-hash',
+        },
+      }),
+    ).toEqual({
+      isVerified: false,
+      isVerifying: true,
+      uri: 'https://example.com/preview.png',
+    });
+  });
+
+  it('reports a checksum mismatch ahead of fetch failures across source types', () => {
+    expect(
+      selectNFTPreviewState({
+        isVerifying: false,
+        previewVideo: fetchFailure,
+        data: hashMismatch,
+      }),
+    ).toBe(hashMismatch);
+  });
+
+  it('keeps verified preview priority at video, image, then data', () => {
+    const verifiedVideo: NFTPreviewState = {
+      isVerified: true,
+      uri: 'https://example.com/verified.mp4',
+    };
+    const verifiedImage: NFTPreviewState = {
+      isVerified: true,
+      uri: 'https://example.com/verified.png',
+    };
+
+    expect(
+      selectNFTPreviewState({
+        isVerifying: false,
+        previewVideo: verifiedVideo,
+        previewImage: verifiedImage,
+      }),
+    ).toBe(verifiedVideo);
+  });
+});

--- a/packages/gui/src/hooks/selectNFTPreviewState.ts
+++ b/packages/gui/src/hooks/selectNFTPreviewState.ts
@@ -1,0 +1,80 @@
+export type NFTPreviewState = {
+  isVerified: boolean;
+  uri: string;
+  error?: Error;
+  // The file could not be downloaded — distinct from a real hash mismatch.
+  failedFetch?: boolean;
+  // Optimistic state: checksums are still being computed for this URI.
+  isVerifying?: boolean;
+};
+
+type PreviewCandidate = {
+  uris?: string[];
+  hash?: string;
+};
+
+export type SelectNFTPreviewStateOptions = {
+  isVerifying: boolean;
+  data?: NFTPreviewState;
+  previewVideo?: NFTPreviewState;
+  previewImage?: NFTPreviewState;
+  dataCandidate?: PreviewCandidate;
+  previewVideoCandidate?: PreviewCandidate;
+  previewImageCandidate?: PreviewCandidate;
+};
+
+function asCandidate(candidate: PreviewCandidate | undefined): NFTPreviewState | undefined {
+  const uri = candidate?.uris?.[0];
+
+  // Never render an optimistic URI unless it has an expected checksum. Without
+  // one, the candidate can never transition into a verified preview.
+  if (!uri || !candidate?.hash) {
+    return undefined;
+  }
+
+  return {
+    isVerified: false,
+    isVerifying: true,
+    uri,
+  };
+}
+
+export default function selectNFTPreviewState({
+  isVerifying,
+  data,
+  previewVideo,
+  previewImage,
+  dataCandidate,
+  previewVideoCandidate,
+  previewImageCandidate,
+}: SelectNFTPreviewStateOptions): NFTPreviewState | undefined {
+  const states = [previewVideo, previewImage, data];
+
+  const verified = states.find((state) => state?.isVerified);
+  if (verified) {
+    return verified;
+  }
+
+  if (isVerifying) {
+    const candidates: [NFTPreviewState | undefined, PreviewCandidate | undefined][] = [
+      [previewVideo, previewVideoCandidate],
+      [previewImage, previewImageCandidate],
+      [data, dataCandidate],
+    ];
+
+    for (const [state, candidate] of candidates) {
+      if (!state) {
+        const optimisticState = asCandidate(candidate);
+        if (optimisticState) {
+          return optimisticState;
+        }
+      }
+    }
+  }
+
+  // A checksum mismatch is stronger evidence than a network failure. Apply
+  // that priority across video, image, and data instead of only within each
+  // source's URI list.
+  const mismatch = states.find((state) => state && !state.isVerified && state.failedFetch === false);
+  return mismatch ?? states.find((state) => state !== undefined);
+}

--- a/packages/gui/src/hooks/useNFTCoinEvents.ts
+++ b/packages/gui/src/hooks/useNFTCoinEvents.ts
@@ -23,11 +23,19 @@ export default function useNFTCoinEvents() {
     [events /* immutable */],
   );
 
-  // Subscribe to all events related to NFTs
-  useNFTCoinAdded((data) => handleNFTEvent('add', data.walletId));
-  useNFTCoinRemoved((data) => handleNFTEvent('remove', data.walletId));
-  useNFTCoinUpdated((data) => handleNFTEvent('updated', data.walletId));
-  useNFTCoinDIDSet((data) => handleNFTEvent('didset', data.walletId));
+  // Subscribe to all events related to NFTs. The callbacks must be stable:
+  // useSubscribeToEvent resubscribes whenever the callback identity changes,
+  // and a wallet event arriving between the unsubscribe and the new subscribe
+  // is silently lost, leaving the gallery stale until a remount.
+  const handleCoinAdded = useCallback((data: any) => handleNFTEvent('add', data.walletId), [handleNFTEvent]);
+  const handleCoinRemoved = useCallback((data: any) => handleNFTEvent('remove', data.walletId), [handleNFTEvent]);
+  const handleCoinUpdated = useCallback((data: any) => handleNFTEvent('updated', data.walletId), [handleNFTEvent]);
+  const handleCoinDIDSet = useCallback((data: any) => handleNFTEvent('didset', data.walletId), [handleNFTEvent]);
+
+  useNFTCoinAdded(handleCoinAdded);
+  useNFTCoinRemoved(handleCoinRemoved);
+  useNFTCoinUpdated(handleCoinUpdated);
+  useNFTCoinDIDSet(handleCoinDIDSet);
 
   const subscribe = useCallback(
     (callback: (event?: Event) => void) => {

--- a/packages/gui/src/hooks/useNFTVerifyHash.ts
+++ b/packages/gui/src/hooks/useNFTVerifyHash.ts
@@ -1,25 +1,16 @@
 import type { NFTInfo } from '@chia-network/api';
 import debug from 'debug';
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 
 import type Metadata from '../@types/Metadata';
 import compareChecksums from '../util/compareChecksums';
 
+import selectNFTPreviewState, { type NFTPreviewState } from './selectNFTPreviewState';
 import useCache from './useCache';
 import useNFT from './useNFT';
 import useNFTMetadata from './useNFTMetadata';
 
 const log = debug('chia-gui:useNFTVerifyHash');
-
-type PreviewState = {
-  isVerified: boolean;
-  uri: string;
-  error?: Error;
-  // the file could not be downloaded — distinct from a real hash mismatch
-  failedFetch?: boolean;
-  // optimistic state: checksums are still being computed for this uri
-  isVerifying?: boolean;
-};
 
 export type UseNFTVerifyHashOptions = {
   preview?: boolean;
@@ -37,9 +28,10 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
   const [errorVerify, setErrorVerify] = useState<Error | undefined>();
   const [isVerifying, setIsVerifying] = useState<boolean>(false);
 
-  const [data, setData] = useState<PreviewState | undefined>();
-  const [previewVideo, setPreviewVideo] = useState<PreviewState | undefined>();
-  const [previewImage, setPreviewImage] = useState<PreviewState | undefined>();
+  const [data, setData] = useState<NFTPreviewState | undefined>();
+  const [previewVideo, setPreviewVideo] = useState<NFTPreviewState | undefined>();
+  const [previewImage, setPreviewImage] = useState<NFTPreviewState | undefined>();
+  const verificationGeneration = useRef(0);
 
   const isLoading = isLoadingNFT || isLoadingMetadata || isVerifying;
   const error = errorNFT || errorMetadata || errorVerify;
@@ -49,14 +41,14 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
       uris: string[] | undefined,
       hash: string | undefined,
       onlyFirst: boolean = false,
-    ): Promise<PreviewState | undefined> => {
+    ): Promise<NFTPreviewState | undefined> => {
       if (!uris || !uris.length || !hash) {
         return undefined;
       }
 
       // use only first uri when onlyFirst is true
       const urisToCheck = onlyFirst ? [uris[0]] : uris;
-      let first: PreviewState | undefined;
+      let first: NFTPreviewState | undefined;
 
       for (const uri of urisToCheck) {
         try {
@@ -96,17 +88,16 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
   );
 
   const verifyNFT = useCallback(
-    async ({ dataHash, dataUris }: NFTInfo, nftMetadata?: Metadata) => {
-      setIsVerifying(true);
-      setErrorVerify(undefined);
-
-      setData(undefined);
-      setPreviewVideo(undefined);
-      setPreviewImage(undefined);
+    async ({ dataHash, dataUris }: NFTInfo, nftMetadata: Metadata | undefined, generation: number) => {
+      const updateIfCurrent = (update: () => void) => {
+        if (verificationGeneration.current === generation) {
+          update();
+        }
+      };
 
       async function validateData() {
         const dataState = await findValidUri(dataUris, dataHash);
-        setData(dataState);
+        updateIfCurrent(() => setData(dataState));
       }
 
       async function validatePreview() {
@@ -117,12 +108,12 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
         const { preview_video_uris: previewVideoUris, preview_video_hash: previewVideoHash } = nftMetadata;
 
         const videoState = await findValidUri(previewVideoUris, previewVideoHash);
-        setPreviewVideo(videoState);
+        updateIfCurrent(() => setPreviewVideo(videoState));
 
         if (!videoState?.isVerified) {
           const { preview_image_uris: previewImageUris, preview_image_hash: previewImageHash } = nftMetadata;
           const imageState = await findValidUri(previewImageUris, previewImageHash);
-          setPreviewImage(imageState);
+          updateIfCurrent(() => setPreviewImage(imageState));
         }
       }
 
@@ -130,79 +121,63 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
         // parallelize validation
         await Promise.all([validateData(), validatePreview()]);
       } catch (e) {
-        setErrorVerify(e as Error);
+        updateIfCurrent(() => setErrorVerify(e as Error));
       } finally {
-        setIsVerifying(false);
+        updateIfCurrent(() => setIsVerifying(false));
       }
     },
     [preview, findValidUri],
   );
 
   useEffect(() => {
-    if (nft) {
-      verifyNFT(nft, metadata);
-    }
-  }, [nft, metadata, verifyNFT]);
+    const generation = verificationGeneration.current + 1;
+    verificationGeneration.current = generation;
 
-  const previewState = useMemo(() => {
-    if (previewVideo?.isVerified) {
-      return previewVideo;
-    }
+    setErrorVerify(undefined);
+    setData(undefined);
+    setPreviewVideo(undefined);
+    setPreviewImage(undefined);
 
-    if (previewImage?.isVerified) {
-      return previewImage;
-    }
-
-    if (data?.isVerified) {
-      return data;
+    if (!nft || isLoadingNFT || isLoadingMetadata) {
+      setIsVerifying(false);
+    } else {
+      setIsVerifying(true);
+      verifyNFT(nft, metadata, generation);
     }
 
-    // Once verification has finished, report the settled result.
-    if (!isVerifying) {
-      const settled = previewVideo || previewImage || data;
-      if (settled) {
-        return settled;
+    return () => {
+      if (verificationGeneration.current === generation) {
+        verificationGeneration.current += 1;
       }
-    }
+    };
+  }, [nft, metadata, isLoadingNFT, isLoadingMetadata, verifyNFT]);
 
-    // While checksums are still being computed, expose the first candidate uri
-    // whose validation has not already failed, so the thumbnail can render
-    // immediately instead of waiting for the full data file to download and a
-    // fast failure on one source does not flash an error tile while another
-    // source is still pending. The verified state replaces this once known.
-    const asCandidate = (uri: string | undefined): PreviewState | undefined =>
-      uri
-        ? {
-            isVerified: false,
-            isVerifying: true,
-            uri,
-          }
-        : undefined;
-
-    if (nft) {
-      if (preview) {
-        const videoUri = metadata?.preview_video_uris?.[0];
-        if (videoUri && !previewVideo) {
-          return asCandidate(videoUri);
-        }
-
-        const imageUri = metadata?.preview_image_uris?.[0];
-        if (imageUri && !previewImage) {
-          return asCandidate(imageUri);
-        }
-      }
-
-      if (!data) {
-        const candidate = asCandidate(nft.dataUris?.[0]);
-        if (candidate) {
-          return candidate;
-        }
-      }
-    }
-
-    // everything available has already failed — report the most relevant failure
-    return previewVideo || previewImage || data;
-  }, [previewVideo, previewImage, data, nft, metadata, preview, isVerifying]);
+  const previewState = useMemo(
+    () =>
+      selectNFTPreviewState({
+        isVerifying,
+        previewVideo,
+        previewImage,
+        data,
+        previewVideoCandidate: preview
+          ? {
+              uris: metadata?.preview_video_uris,
+              hash: metadata?.preview_video_hash,
+            }
+          : undefined,
+        previewImageCandidate: preview
+          ? {
+              uris: metadata?.preview_image_uris,
+              hash: metadata?.preview_image_hash,
+            }
+          : undefined,
+        dataCandidate: {
+          uris: nft?.dataUris,
+          hash: nft?.dataHash,
+        },
+      }),
+    [previewVideo, previewImage, data, nft, metadata, preview, isVerifying],
+  );
 
   return {
     isVerified: data?.isVerified, // main data is the only one that matters

--- a/packages/gui/src/hooks/useNFTVerifyHash.ts
+++ b/packages/gui/src/hooks/useNFTVerifyHash.ts
@@ -15,6 +15,10 @@ type PreviewState = {
   isVerified: boolean;
   uri: string;
   error?: Error;
+  // the file could not be downloaded — distinct from a real hash mismatch
+  failedFetch?: boolean;
+  // optimistic state: checksums are still being computed for this uri
+  isVerifying?: boolean;
 };
 
 export type UseNFTVerifyHashOptions = {
@@ -72,11 +76,15 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
           throw new Error('Invalid hash checksum');
         } catch (e) {
           log(`Failed to fetch ${uri}: ${(e as Error).message}`);
-          if (!first) {
+          const isMismatch = (e as Error).message === 'Invalid hash checksum';
+          // a hash mismatch on any uri outranks a download failure — a
+          // tampered file must not be reported as merely unavailable
+          if (!first || (first.failedFetch && isMismatch)) {
             first = {
               isVerified: false,
               uri,
               error: e as Error,
+              failedFetch: !isMismatch,
             };
           }
         }
@@ -149,8 +157,52 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
       return data;
     }
 
+    // Once verification has finished, report the settled result.
+    if (!isVerifying) {
+      const settled = previewVideo || previewImage || data;
+      if (settled) {
+        return settled;
+      }
+    }
+
+    // While checksums are still being computed, expose the first candidate uri
+    // whose validation has not already failed, so the thumbnail can render
+    // immediately instead of waiting for the full data file to download and a
+    // fast failure on one source does not flash an error tile while another
+    // source is still pending. The verified state replaces this once known.
+    const asCandidate = (uri: string | undefined): PreviewState | undefined =>
+      uri
+        ? {
+            isVerified: false,
+            isVerifying: true,
+            uri,
+          }
+        : undefined;
+
+    if (nft) {
+      if (preview) {
+        const videoUri = metadata?.preview_video_uris?.[0];
+        if (videoUri && !previewVideo) {
+          return asCandidate(videoUri);
+        }
+
+        const imageUri = metadata?.preview_image_uris?.[0];
+        if (imageUri && !previewImage) {
+          return asCandidate(imageUri);
+        }
+      }
+
+      if (!data) {
+        const candidate = asCandidate(nft.dataUris?.[0]);
+        if (candidate) {
+          return candidate;
+        }
+      }
+    }
+
+    // everything available has already failed — report the most relevant failure
     return previewVideo || previewImage || data;
-  }, [previewVideo, previewImage, data]);
+  }, [previewVideo, previewImage, data, nft, metadata, preview, isVerifying]);
 
   return {
     isVerified: data?.isVerified, // main data is the only one that matters

--- a/packages/gui/src/hooks/useNFTVerifyHash.ts
+++ b/packages/gui/src/hooks/useNFTVerifyHash.ts
@@ -138,11 +138,14 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
     setPreviewVideo(undefined);
     setPreviewImage(undefined);
 
-    if (!nft || isLoadingNFT || isLoadingMetadata) {
+    if (!nft || isLoadingNFT) {
       setIsVerifying(false);
     } else {
       setIsVerifying(true);
-      verifyNFT(nft, metadata, generation);
+      // Metadata downloads can be slow or fail entirely — verify the data
+      // file right away and let the effect re-run for the preview URIs once
+      // the metadata fetch settles, instead of blocking all verification.
+      verifyNFT(nft, isLoadingMetadata ? undefined : metadata, generation);
     }
 
     return () => {

--- a/packages/gui/src/hooks/useNFTVideoLoop.tsx
+++ b/packages/gui/src/hooks/useNFTVideoLoop.tsx
@@ -1,0 +1,44 @@
+import { usePrefs } from '@chia-network/api-react';
+import { useCallback } from 'react';
+
+// Global preference: when enabled, every NFT video loops, regardless of the
+// per-video preference. When disabled, looping is controlled per video.
+export function useNFTVideoLoopGlobal(): [boolean, (loopVideos: boolean) => void] {
+  return usePrefs<boolean>('nftVideoLoop', false);
+}
+
+type NFTVideoLoopMap = Record<string, boolean>;
+
+// Per-video preference, keyed by NFT id. Only enabled videos are stored, so
+// the preferences file stays clean.
+export function useNFTVideoLoopForNFT(nftId: string): [boolean, (loopVideo: boolean) => void] {
+  const [loopMap, setLoopMap] = usePrefs<NFTVideoLoopMap>('nftVideoLoopByNftId', {});
+
+  const loop = !!loopMap?.[nftId];
+
+  const setLoop = useCallback(
+    (loopVideo: boolean) => {
+      setLoopMap((currentMap) => {
+        const nextMap = { ...currentMap };
+        if (loopVideo) {
+          nextMap[nftId] = true;
+        } else {
+          delete nextMap[nftId];
+        }
+        return nextMap;
+      });
+    },
+    [nftId, setLoopMap],
+  );
+
+  return [loop, setLoop];
+}
+
+// The effective looping state for one NFT video: the global preference forces
+// looping on when set, but never disables a video's own loop preference.
+export default function useNFTVideoLoop(nftId: string): boolean {
+  const [globalLoop] = useNFTVideoLoopGlobal();
+  const [videoLoop] = useNFTVideoLoopForNFT(nftId);
+
+  return globalLoop || videoLoop;
+}

--- a/packages/gui/src/util/limit.test.ts
+++ b/packages/gui/src/util/limit.test.ts
@@ -1,0 +1,59 @@
+import limit from './limit';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('limit', () => {
+  it('runs queued tasks in FIFO order by default', async () => {
+    const add = limit(1);
+    const first = deferred();
+    const order: string[] = [];
+
+    const tasks = [
+      add(async () => {
+        await first.promise;
+        order.push('a');
+      }),
+      add(async () => {
+        order.push('b');
+      }),
+      add(async () => {
+        order.push('c');
+      }),
+    ];
+
+    first.resolve();
+    await Promise.all(tasks);
+
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+
+  it('runs the most recently queued task first in LIFO mode', async () => {
+    const add = limit(1, { lifo: true });
+    const first = deferred();
+    const order: string[] = [];
+
+    const tasks = [
+      add(async () => {
+        await first.promise;
+        order.push('a');
+      }),
+      add(async () => {
+        order.push('b');
+      }),
+      add(async () => {
+        order.push('c');
+      }),
+    ];
+
+    first.resolve();
+    await Promise.all(tasks);
+
+    expect(order).toEqual(['a', 'c', 'b']);
+  });
+});

--- a/packages/gui/src/util/limit.ts
+++ b/packages/gui/src/util/limit.ts
@@ -1,4 +1,6 @@
-export default function limit(concurrency: number) {
+export default function limit(concurrency: number, options: { lifo?: boolean } = {}) {
+  const { lifo = false } = options;
+
   const queue: {
     func: Function;
     resolve: (value: any) => void;
@@ -13,7 +15,10 @@ export default function limit(concurrency: number) {
 
     active++;
 
-    const item = queue.shift();
+    // LIFO runs the most recently requested task first, so work triggered by
+    // what the user is currently looking at is not starved by a long backlog
+    // of earlier background requests.
+    const item = lifo ? queue.pop() : queue.shift();
     if (!item) {
       return;
     }


### PR DESCRIPTION
## Summary

Video and audio NFTs frequently rendered as blank tiles and could not be played anywhere in the GUI. This PR fixes the media pipeline end to end and addresses several related gallery/settings issues found along the way.

### 1. Fix NFT video/audio playback (media pipeline)

- Register the `cache:` scheme with `registerSchemesAsPrivileged` (`stream: true`, plus `standard`/`secure`/`supportFetchAPI`). Without this, media elements expect a buffered response and stall on the streamed body served by `protocol.handle`.
- Serve HTTP 206 partial content for Range requests from the cache protocol handler. Media elements seek via Range requests; without 206 responses seeking was broken and MP4 files without faststart (moov atom at the end) could fail to start playing at all.
- Make the 30s download timeout an inactivity timeout (reset on each received chunk) instead of a total-transfer budget, so larger videos on slower hosts can finish downloading while stalled connections still fail fast.
- Report a distinct "Maximum file size exceeded" error when the size cap aborts a download, persist it, and only retry when the caller lifts the size limit — previously these surfaced as generic transient abort errors and oversized files were re-downloaded on every gallery visit.
- `maxSize <= 0` now disables the size limit instead of aborting every download on the first chunk (fixes the `ignoreSizeLimit` path; `NFTPreview` forwards the same override so verification and display stay consistent).
- Drive-by: download progress used `Math.max` instead of `Math.min` and was pinned at 100%.

### 2. Fix unclickable media controls in the NFT detail view

The electron isolation refactor (#2681) inverted a condition to `allowPointerEvents={!canInteract}`, disabling pointer events on the sandboxed iframe exactly when interaction should be allowed — so the play button in the detail view never received clicks.

### 3. Persist NFT cache size and folder across GUI restarts

The settings UI stored the cache size limit under the `cacheLimitSize` preference key, but startup reads `maxCacheSize` — a key nothing ever wrote — so the setting silently reverted to the 1GB default on every launch, and a changed cache folder was never persisted at all. Both are now persisted from `CacheProvider` when change events arrive from the main process (the renderer is the only safe writer since `prefs.yaml` is rewritten from the renderer's full snapshot on every preference save). The legacy `cacheLimitSize` key is still honored at startup, and non-positive stored values no longer crash the `CacheManager` constructor.

### 4. Gallery: reliable updates, refresh button, inline playback

- Newly acquired NFTs could take a long time to appear (or required switching wallets and back). The `nft_coin_added` subscription was torn down and recreated on every `NFTProvider` render because `useNFTCoinEvents` passed fresh inline callbacks each render — wallet events arriving in the resubscribe gap were silently lost. The callbacks are now stable.
- The NFT data provider exposes `refetch()` and the gallery header gains a Refresh button as a manual fallback.
- Video/audio NFTs are playable directly in the gallery grid: pointer events are enabled on playable tiles so the native media controls respond with a single click, while transparent blockers over the non-control area keep clicks there navigating to the detail view as before.

### 5. NFT video looping (global and per-video)

- Settings > NFT gains a "Loop videos" switch that forces looping for all NFT videos.
- Each video player (gallery grid, detail view, fullscreen) gets a loop toggle button overlaid on the top-right corner of the player. The native video-controls menu is Chromium-internal and not extensible, and the sandboxed iframe blocks scripts, so an overlay outside the iframe is the only viable placement. Toggling remounts the iframe (the video restarts paused) — unavoidable without weakening the sandbox.
- Preferences persist as a global flag plus a per-NFT map.

### 6. Show NFT previews without blocking on full-file hash verification (offer viewer)

Previews were gated behind `useNFTVerifyHash` completing, which downloads and checksums the complete data file of every URI. In the offer viewer the NFTs involved are typically not in the local cache, so every preview sat on an endless spinner (minutes for large videos) or turned into a blank tile with a misleading "Invalid hash" chip when the download failed (dead host, network error, or file over the cache size cap). The gallery masked the problem because owned NFTs are usually already cached.

- `useNFTVerifyHash` now exposes the most likely preview URI immediately (metadata preview video → preview image → data URI) while checksums run in the background, skipping candidates whose validation has already failed so a fast failure on one source doesn't flash an error tile while another is still pending.
- Download failures are flagged separately from real hash mismatches (`failedFetch`), and a hash mismatch on any URI outranks a download failure so a tampered file is never reported as merely unavailable.
- `NFTPreview` renders as soon as the preview file itself is fetched, shows an honest "Loading preview…" while it downloads, and an explicit "Preview is not available" state instead of a silent blank iframe when the file cannot be retrieved. `NFTHashStatus` reports "File is not available" for download failures; "Invalid hash" remains reserved for genuine mismatches.
- Videos with a metadata preview image now show their thumbnail immediately instead of waiting for the full video to download.

### 7. Fix broken NFT previews in the dapp confirmation dialog

The take-offer confirmation dialog (shown when a paired dapp such as dexie requests `chia_wallet.take_offer`) renders NFT previews in its You Spend / You Receive sections with an `<img>` pointed at the NFT's first data URI. For video NFTs that is a video file, which an `<img>` cannot display — every video NFT appeared as a broken image icon. The preview URL is now resolved file-type-aware: an image data URI is used directly; otherwise the NFT metadata is fetched (best effort, bounded size/timeout) and its `preview_image_uris` used; extensionless data URIs (common on IPFS) are still attempted; NFTs with no usable image fall back to the existing placeholder tile. Applies to both sides of the dialog.

## Bug audit

The full branch diff was put through three independent adversarial code reviews (media pipeline / state & subscriptions / preview rendering), with every candidate finding verified against the code before being accepted. Four real issues were found and are fixed in this PR:

1. **Premature fallback to a failed data source during verification** (`useNFTVerifyHash`): while checksums ran in parallel, whichever source settled first won — a fast failure on the data URI could flash "Preview is not available" while a perfectly valid preview image was still being verified, then snap to the correct preview. The candidate selection now skips already-failed sources and only reports a failure once verification has finished.
2. **Download failure masking a hash mismatch** (`useNFTVerifyHash`): with multiple data URIs, a fetch failure on the first URI hid a checksum mismatch on a later one behind the benign "File is not available" label. Mismatches now take precedence.
3. **Loop button vs. selection checkbox** (`NFTCard`): in gallery multi-select mode the new loop toggle rendered on top of the selection checkbox and swallowed its clicks. Media interactions (and the loop button) are now disabled while selecting, so the whole tile selects on click.
4. **Unbounded download duration** (`downloadFile`): the inactivity timeout alone let a host trickling bytes hold one of the ten download concurrency slots indefinitely. Downloads now also have an absolute 30-minute deadline, reported as the same transient abort error so legitimate retries still work.

The reviews also specifically cleared: Range-request edge cases (open-ended/suffix/out-of-bounds/zero-length), concurrent same-URL download dedup and partial-file safety, cache prefs persistence ordering (no stale-value or write-loop paths), refresh/refetch abort safety on double-trigger, `nft_coin_added` subscription lifecycle, iframe remount semantics (same-URI transitions don't restart playback; content changes do), and the legacy `cacheLimitSize` migration path.

## Testing

- Automated Electron harness exercising the real `CacheManager` protocol handler: correct 200/206/416/404 responses with byte-exact range bodies, and real `<video>`/`<audio>` playback + seeking through `cache://` for faststart MP4, non-faststart MP4 (moov at end), and AAC audio — both top-level and inside the production-CSP sandboxed iframe. A control run against the pre-fix code reproduces the failures (full-file 200s, stalled media elements).
- Automated Electron harness rendering the real `NFTCard`/`NFTPreview`/`NFTProvider`/`OfferBuilderViewer` tree with live mainnet NFT data and a live offer summary, across cold-cache, slow-download, and failed-download scenarios — verifying immediate previews, honest loading states, and the explicit failure state.
- The real dapp confirmation dialog (`openReactDialog` + `Confirm` + `parseCommandDisplay`) rendered against a live daemon and a live NFT offer: picture NFTs show thumbnails, video NFTs show the metadata preview image when available and the placeholder (not a broken image) when not.
- 278 jest tests pass (3 new for the dialog preview resolution); eslint/prettier clean; tsc error baseline unchanged.
- Manual testing on Linux with real NFTs: gallery previews, detail-view playback with seeking, inline grid playback, cache size/folder persistence across restarts, refresh button, video looping, offer viewer, and the dexie take-offer confirmation dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
