### PR TITLE
NFT media pipeline 2/3: video playback controls, looping & gallery UX

### DIFF
--- a/packages/gui/src/components/cache/CacheProvider.tsx
+++ b/packages/gui/src/components/cache/CacheProvider.tsx
@@ -1,3 +1,4 @@
+import { usePrefs } from '@chia-network/api-react';
 import React, { useMemo, useState, useEffect, useCallback, type ReactNode } from 'react';
 
 const { cacheAPI } = window;
@@ -15,6 +16,14 @@ export default function CacheProvider(props: CacheProviderProps) {
   const [cacheDirectory, setCacheDirectory] = useState<string | undefined>(undefined);
   const [cacheSize, setCacheSize] = useState<number | undefined>(undefined);
 
+  // The main process only reads these preferences at startup; changes made at
+  // runtime live in CacheManager's memory, so they are persisted here in the
+  // renderer where all other preferences are written (prefs.yaml is rewritten
+  // from the renderer's snapshot on every preference save - a main process
+  // write would be clobbered by the next renderer save).
+  const [, setMaxCacheSizePref] = usePrefs<number | undefined>('maxCacheSize', undefined);
+  const [, setCacheFolderPref] = usePrefs<string | undefined>('cacheFolder', undefined);
+
   const updateCacheSize = useCallback(async () => {
     const size = await cacheAPI.getCacheSize();
     setCacheSize(size);
@@ -30,9 +39,21 @@ export default function CacheProvider(props: CacheProviderProps) {
     setMaxCacheSize(size);
   }, []);
 
+  const handleCacheDirectoryChanged = useCallback(async () => {
+    const directory = await cacheAPI.getCacheDirectory();
+    setCacheDirectory(directory);
+    setCacheFolderPref(directory);
+  }, [setCacheFolderPref]);
+
+  const handleMaxCacheSizeChanged = useCallback(async () => {
+    const size = await cacheAPI.getMaxCacheSize();
+    setMaxCacheSize(size);
+    setMaxCacheSizePref(size);
+  }, [setMaxCacheSizePref]);
+
   useEffect(() => {
-    const unbindCacheDirectoryChanged = cacheAPI.subscribeToDirectoryChange(updateCacheDirectory);
-    const unbindMaxCacheSizeChanged = cacheAPI.subscribeToMaxSizeChange(updateMaxCacheSize);
+    const unbindCacheDirectoryChanged = cacheAPI.subscribeToDirectoryChange(handleCacheDirectoryChanged);
+    const unbindMaxCacheSizeChanged = cacheAPI.subscribeToMaxSizeChange(handleMaxCacheSizeChanged);
     const unbindSizeChanged = cacheAPI.subscribeToSizeChange(updateCacheSize);
 
     updateCacheSize();
@@ -44,7 +65,13 @@ export default function CacheProvider(props: CacheProviderProps) {
       unbindMaxCacheSizeChanged();
       unbindSizeChanged();
     };
-  }, [updateCacheSize, updateCacheDirectory, updateMaxCacheSize]);
+  }, [
+    updateCacheSize,
+    updateCacheDirectory,
+    updateMaxCacheSize,
+    handleCacheDirectoryChanged,
+    handleMaxCacheSizeChanged,
+  ]);
 
   const context = useMemo(() => {
     const { getCacheDirectory, getCacheSize, getMaxCacheSize, ...rest } = cacheAPI;

--- a/packages/gui/src/components/nfts/NFTCard.tsx
+++ b/packages/gui/src/components/nfts/NFTCard.tsx
@@ -77,7 +77,10 @@ function NFTCard(props: NFTCardProps) {
               sx={{ zIndex: 1, position: 'absolute', right: 2, top: 2 }}
             />
           )}
-          <NFTPreview id={nftId} disableInteractions={isOffer} ratio={ratio} preview />
+          {/* in selection mode the whole tile selects on click, so media
+              interactions (and the video loop button, which would cover the
+              selection checkbox) are disabled */}
+          <NFTPreview id={nftId} disableInteractions={isOffer || !!onSelect} ratio={ratio} preview />
         </CardActionArea>
         <CardActionArea onClick={() => canExpandDetails && handleClick()} component="div">
           <CardContent>

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -353,7 +353,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
         }}
       >
         {!canInteract && <IframePreventEvents />}
-        <SandboxedIframe hideUntilLoaded allowPointerEvents={!canInteract}>
+        <SandboxedIframe hideUntilLoaded allowPointerEvents={canInteract}>
           {previewContent}
         </SandboxedIframe>
         {blurPreview && (

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -210,7 +210,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
           }
         `;
 
-        const cachedURI = await getURI(preview.uri);
+        const cachedURI = await getURI(preview.uri, { maxSize: ignoreSizeLimit ? -1 : undefined });
         if (!cachedURI || !cachedURI.startsWith('cache://')) {
           setPreviewContent(undefined, signal);
           return;
@@ -237,7 +237,17 @@ export default function NFTPreview(props: NFTPreviewProps) {
         setError(e as Error, signal);
       }
     },
-    [preview, fit, getURI, previewFileType, disableInteractions, isDarkMode, setPreviewContent, setError],
+    [
+      preview,
+      fit,
+      getURI,
+      ignoreSizeLimit,
+      previewFileType,
+      disableInteractions,
+      isDarkMode,
+      setPreviewContent,
+      setError,
+    ],
   );
 
   useEffect(() => {

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -338,8 +338,13 @@ export default function NFTPreview(props: NFTPreviewProps) {
       );
     }
 
-    const canInteract =
-      !isPreview && !disableInteractions && (previewFileType === FileType.VIDEO || previewFileType === FileType.AUDIO);
+    const isPlayable = previewFileType === FileType.VIDEO || previewFileType === FileType.AUDIO;
+    const canInteract = !disableInteractions && isPlayable;
+    // In the gallery grid the media controls are directly clickable, while the
+    // rest of the tile keeps navigating to the detail view. The blockers below
+    // sit over the non-control area only, so clicks there fall through to the
+    // card while the native controls (play, seek, volume) stay exposed.
+    const showGridNavigationBlockers = isPreview && canInteract;
 
     return (
       <Box
@@ -356,6 +361,17 @@ export default function NFTPreview(props: NFTPreviewProps) {
         <SandboxedIframe hideUntilLoaded allowPointerEvents={canInteract}>
           {previewContent}
         </SandboxedIframe>
+        {showGridNavigationBlockers &&
+          (previewFileType === FileType.VIDEO ? (
+            // video controls render along the bottom edge of the tile
+            <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 48, zIndex: 2 }} />
+          ) : (
+            // the audio control bar renders centered vertically in the tile
+            <>
+              <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, height: 'calc(50% - 32px)', zIndex: 2 }} />
+              <Box sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 'calc(50% - 32px)', zIndex: 2 }} />
+            </>
+          ))}
         {blurPreview && (
           <Box
             sx={{

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -1,7 +1,7 @@
 import { Color, IconMessage, Loading, Flex, SandboxedIframe, usePersistState, useDarkMode } from '@chia-network/core';
 import { t, Trans } from '@lingui/macro';
-import { NotInterested } from '@mui/icons-material';
-import { alpha, Box } from '@mui/material';
+import { Loop as LoopIcon, NotInterested } from '@mui/icons-material';
+import { alpha, Box, IconButton, Tooltip } from '@mui/material';
 import React, { useMemo, useRef, Fragment, useCallback, useEffect, type ReactNode } from 'react';
 import styled from 'styled-components';
 
@@ -30,6 +30,7 @@ import useNFT from '../../hooks/useNFT';
 import useNFTImageFittingMode from '../../hooks/useNFTImageFittingMode';
 import useNFTMetadata from '../../hooks/useNFTMetadata';
 import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
+import { useNFTVideoLoopGlobal, useNFTVideoLoopForNFT } from '../../hooks/useNFTVideoLoop';
 import useStateAbort from '../../hooks/useStateAbort';
 import getFileExtension from '../../util/getFileExtension';
 import getNFTId from '../../util/getNFTId';
@@ -155,6 +156,19 @@ export default function NFTPreview(props: NFTPreviewProps) {
   });
 
   const { type: previewFileType, isLoading: isLoadingFileType } = useFileType(preview?.uri);
+  const [globalVideoLoop] = useNFTVideoLoopGlobal();
+  const [perVideoLoop, setPerVideoLoop] = useNFTVideoLoopForNFT(nftId);
+  const loopVideo = globalVideoLoop || perVideoLoop;
+
+  const handleToggleVideoLoop = useCallback(
+    (event: React.MouseEvent) => {
+      // the button sits inside clickable areas (grid card navigation, detail
+      // view fullscreen) — keep the click from reaching them
+      event.stopPropagation();
+      setPerVideoLoop(!perVideoLoop);
+    },
+    [perVideoLoop, setPerVideoLoop],
+  );
 
   const { isLoading: isLoadingNFT } = useNFT(nftId);
   const { metadata, isLoading: isLoadingMetadata } = useNFTMetadata(nftId);
@@ -220,7 +234,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
           <>
             <style>{style}</style>
             {previewFileType === FileType.VIDEO ? (
-              <video width="100%" height="100%" controls={!disableInteractions}>
+              <video width="100%" height="100%" controls={!disableInteractions} loop={loopVideo}>
                 <source src={cachedURI} />
               </video>
             ) : previewFileType === FileType.AUDIO ? (
@@ -244,6 +258,7 @@ export default function NFTPreview(props: NFTPreviewProps) {
       ignoreSizeLimit,
       previewFileType,
       disableInteractions,
+      loopVideo,
       isDarkMode,
       setPreviewContent,
       setError,
@@ -372,6 +387,42 @@ export default function NFTPreview(props: NFTPreviewProps) {
               <Box sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 'calc(50% - 32px)', zIndex: 2 }} />
             </>
           ))}
+        {previewFileType === FileType.VIDEO && canInteract && !blurPreview && (
+          <Tooltip
+            title={
+              globalVideoLoop ? (
+                <Trans>Looping is enabled for all videos in Settings</Trans>
+              ) : loopVideo ? (
+                <Trans>Looping on</Trans>
+              ) : (
+                <Trans>Loop video</Trans>
+              )
+            }
+            placement="left"
+          >
+            {/* wrapper keeps the tooltip working while the button is disabled */}
+            <Box sx={{ position: 'absolute', top: 8, right: 8, zIndex: 3 }}>
+              <IconButton
+                size="small"
+                disabled={globalVideoLoop}
+                onClick={handleToggleVideoLoop}
+                sx={{
+                  backgroundColor: alpha(Color.Neutral[900], 0.4),
+                  color: loopVideo ? Color.Green[400] : Color.Neutral[200],
+                  '&:hover': {
+                    backgroundColor: alpha(Color.Neutral[900], 0.6),
+                  },
+                  '&.Mui-disabled': {
+                    backgroundColor: alpha(Color.Neutral[900], 0.4),
+                    color: Color.Green[400],
+                  },
+                }}
+              >
+                <LoopIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Tooltip>
+        )}
         {blurPreview && (
           <Box
             sx={{
@@ -401,6 +452,9 @@ export default function NFTPreview(props: NFTPreviewProps) {
     isDarkMode,
     blurPreview,
     previewCompactIcon,
+    globalVideoLoop,
+    loopVideo,
+    handleToggleVideoLoop,
   ]);
 
   const hasFile = !!preview;

--- a/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
+++ b/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
@@ -13,7 +13,11 @@ import {
   ScrollbarVirtuoso,
 } from '@chia-network/core';
 import { t, Trans } from '@lingui/macro';
-import { FilterList as FilterListIcon, LibraryAddCheck as LibraryAddCheckIcon } from '@mui/icons-material';
+import {
+  FilterList as FilterListIcon,
+  LibraryAddCheck as LibraryAddCheckIcon,
+  Refresh as RefreshIcon,
+} from '@mui/icons-material';
 import {
   Divider,
   Chip,
@@ -36,6 +40,7 @@ import FileType from '../../../constants/FileType';
 import useFilteredNFTs from '../../../hooks/useFilteredNFTs';
 import useHideObjectionableContent from '../../../hooks/useHideObjectionableContent';
 import useNFTGalleryScrollPosition from '../../../hooks/useNFTGalleryScrollPosition';
+import useNFTProvider from '../../../hooks/useNFTProvider';
 import getNFTId from '../../../util/getNFTId';
 import LabelProgress from '../../helpers/LabelProgress';
 import NFTCard from '../NFTCard';
@@ -108,6 +113,8 @@ export default function NFTGallery() {
 
     statistics,
   } = useFilteredNFTs();
+
+  const { refetch } = useNFTProvider();
 
   const [scrollPosition, setScrollPosition] = useNFTGalleryScrollPosition();
   const scrollerRef = useRef<HTMLElement>(null);
@@ -284,6 +291,13 @@ export default function NFTGallery() {
                   <IconButton onClick={toggleShowFilters} color={showFilters ? 'primary' : undefined}>
                     <FilterListIcon color="info" />
                   </IconButton>
+                </Tooltip>
+                <Tooltip title={<Trans>Refresh NFTs</Trans>} placement="top">
+                  <span>
+                    <IconButton onClick={() => refetch()} disabled={isLoading}>
+                      <RefreshIcon color={isLoading ? 'disabled' : 'info'} />
+                    </IconButton>
+                  </span>
                 </Tooltip>
               </Flex>
             </Flex>

--- a/packages/gui/src/components/nfts/provider/NFTProvider.tsx
+++ b/packages/gui/src/components/nfts/provider/NFTProvider.tsx
@@ -28,6 +28,7 @@ export default function NFTProvider(props: NFTProviderProps) {
     isLoading,
     error,
     getNFT: getNFTData,
+    refetch,
     count,
     loaded,
     progress,
@@ -194,6 +195,7 @@ export default function NFTProvider(props: NFTProviderProps) {
       subscribeToChanges,
 
       invalidate: invalidateNFT,
+      refetch,
 
       // mutable state
       isLoading,
@@ -217,6 +219,7 @@ export default function NFTProvider(props: NFTProviderProps) {
       progress,
       subscribeToChanges,
       invalidateNFT,
+      refetch,
     ],
   );
 

--- a/packages/gui/src/components/nfts/provider/NFTProviderContext.ts
+++ b/packages/gui/src/components/nfts/provider/NFTProviderContext.ts
@@ -17,6 +17,7 @@ const NFTProviderContext = createContext<
       error: Error | undefined;
 
       invalidate: (id: string | undefined) => Promise<void>;
+      refetch: () => Promise<void>;
 
       subscribeToChanges: (callback: () => void) => () => void;
 

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTData.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTData.ts
@@ -282,6 +282,7 @@ export default function useNFTData(props: UseNFTDataProps) {
     nfts,
 
     getNFT,
+    refetch: refetchData,
 
     isLoading,
     error,

--- a/packages/gui/src/components/settings/LimitCacheSize.tsx
+++ b/packages/gui/src/components/settings/LimitCacheSize.tsx
@@ -1,4 +1,3 @@
-import { usePrefs } from '@chia-network/api-react';
 import { AlertDialog, ButtonLoading, Flex, Form, TextField, useOpenDialog } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import React, { useEffect } from 'react';
@@ -15,8 +14,6 @@ type FormData = {
 export default function LimitCacheSize() {
   const openDialog = useOpenDialog();
   const { maxCacheSize, setMaxCacheSize } = useCache();
-
-  const [, setCacheLimitSize] = usePrefs(`cacheLimitSize`, 0);
 
   const methods = useForm<FormData>({
     defaultValues: {
@@ -45,8 +42,6 @@ export default function LimitCacheSize() {
 
     const newValue = Number(values.maxCacheSize) * MB_SIZE;
 
-    // todo move it ti electron/main
-    setCacheLimitSize(newValue);
     await setMaxCacheSize(newValue);
 
     await openDialog(

--- a/packages/gui/src/components/settings/SettingsNFT.tsx
+++ b/packages/gui/src/components/settings/SettingsNFT.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import useCache from '../../hooks/useCache';
 import useHideObjectionableContent from '../../hooks/useHideObjectionableContent';
 import useNFTImageFittingMode from '../../hooks/useNFTImageFittingMode';
+import { useNFTVideoLoopGlobal } from '../../hooks/useNFTVideoLoop';
 
 import LimitCacheSize from './LimitCacheSize';
 
@@ -38,11 +39,16 @@ export default function SettingsGeneral() {
 
   const { cacheSize, clearCache, cacheDirectory, setCacheDirectory } = useCache();
   const [nftImageFittingMode, setNFTImageFittingMode] = useNFTImageFittingMode();
+  const [nftVideoLoop, setNFTVideoLoop] = useNFTVideoLoopGlobal();
   // const [, setCacheFolder] = usePrefs('cacheFolder', '');
   const openDialog = useOpenDialog();
 
   function handleScalePreviewImages(event: React.ChangeEvent<HTMLInputElement>) {
     setNFTImageFittingMode(event.target.checked ? 'contain' : 'cover');
+  }
+
+  function handleChangeVideoLoop(event: React.ChangeEvent<HTMLInputElement>) {
+    setNFTVideoLoop(event.target.checked);
   }
 
   async function clearNFTCache() {
@@ -115,6 +121,25 @@ export default function SettingsGeneral() {
         <Grid item style={{ width: '400px' }}>
           <SettingsText>
             <Trans>Images will be scaled to fill the NFT card and ignore their original proportions.</Trans>
+          </SettingsText>
+        </Grid>
+      </Grid>
+
+      <Grid container>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsTitle>
+            <Trans>Loop videos</Trans>
+          </SettingsTitle>
+        </Grid>
+        <Grid item container xs justifyContent="flex-end" marginTop="-6px">
+          <FormControlLabel control={<Switch checked={nftVideoLoop} onChange={handleChangeVideoLoop} />} />
+        </Grid>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsText>
+            <Trans>
+              All NFT videos will restart automatically when they finish playing. When disabled, looping can still be
+              turned on for individual videos from their detail page.
+            </Trans>
           </SettingsText>
         </Grid>
       </Grid>

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+type DownloadFile = typeof import('./utils/downloadFile').default;
+
+const mockDownloadFile = jest.fn<ReturnType<DownloadFile>, Parameters<DownloadFile>>();
+
+jest.mock('electron', () => ({
+  BrowserWindow: jest.fn(),
+  dialog: {
+    showOpenDialog: jest.fn(),
+  },
+}));
+
+jest.mock('./utils/downloadFile', () => ({
+  __esModule: true,
+  default: mockDownloadFile,
+  MAX_FILE_SIZE_EXCEEDED_ERROR: 'Maximum file size exceeded',
+}));
+
+jest.mock('./utils/ipcMainHandle', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const CacheManager = jest.requireActual<typeof import('./CacheManager')>('./CacheManager').default;
+
+describe('CacheManager eviction', () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    mockDownloadFile.mockReset();
+    cacheDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'chia-cache-manager-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  it('does not evict a just-downloaded file that fits within the configured total size', async () => {
+    const payload = Buffer.alloc(600, 7);
+    mockDownloadFile.mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    await expect(cacheManager.getCacheSize()).resolves.toBeLessThanOrEqual(1024);
+  });
+
+  it('treats a zero cache limit as unlimited when updating the setting', async () => {
+    const payload = Buffer.from('cached payload');
+    mockDownloadFile.mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+    await cacheManager.getContent('https://example.com/nft.png');
+
+    await cacheManager.setMaxCacheSize(0);
+
+    expect(cacheManager.maxCacheSize).toBe(0);
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -111,6 +111,40 @@ describe('CacheManager eviction', () => {
     await expect(fs.stat(path.join(cacheDirectory, 'aaaa-chiacache'))).rejects.toThrow('ENOENT');
   });
 
+  it('does not retry a timed-out download on the next access', async () => {
+    mockDownloadFile.mockRejectedValue(new Error('Request timed out after 30000ms of inactivity'));
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request timed out');
+    await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request timed out');
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries an aborted download on the next access', async () => {
+    const payload = Buffer.from('cached payload');
+    mockDownloadFile.mockRejectedValueOnce(new Error('Request aborted')).mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request aborted');
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(2);
+  });
+
   it('treats a zero cache limit as unlimited when updating the setting', async () => {
     const payload = Buffer.from('cached payload');
     mockDownloadFile.mockImplementation(async (_url, localPath) => {

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -57,6 +57,60 @@ describe('CacheManager eviction', () => {
     await expect(cacheManager.getCacheSize()).resolves.toBeLessThanOrEqual(1024);
   });
 
+  it('keeps a completed download cached when cache housekeeping fails', async () => {
+    const payload = Buffer.from('cached payload');
+    mockDownloadFile.mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    // A concurrent invalidation can delete files mid-scan and make the
+    // post-download size check fail — that must not poison the download.
+    jest
+      .spyOn(cacheManager, 'getCacheSize')
+      .mockRejectedValueOnce(new Error("ENOENT: no such file or directory, stat '/cache/other-chiacache'"));
+
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    await expect(cacheManager.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores files that vanish while the cache size is being measured', async () => {
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await fs.writeFile(path.join(cacheDirectory, 'aaaa-chiacache'), Buffer.alloc(100));
+    // a broken symlink stats like a file deleted between readdir and stat
+    await fs.symlink(path.join(cacheDirectory, 'missing-target'), path.join(cacheDirectory, 'bbbb-chiacache'));
+
+    await expect(cacheManager.getCacheSize()).resolves.toBe(100);
+  });
+
+  it('evicts without failing when a file vanishes during the eviction scan', async () => {
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await fs.writeFile(path.join(cacheDirectory, 'aaaa-chiacache'), Buffer.alloc(200));
+    await fs.symlink(path.join(cacheDirectory, 'missing-target'), path.join(cacheDirectory, 'bbbb-chiacache'));
+
+    await expect(cacheManager.setMaxCacheSize(100)).resolves.toBeUndefined();
+    await expect(fs.stat(path.join(cacheDirectory, 'aaaa-chiacache'))).rejects.toThrow('ENOENT');
+  });
+
   it('treats a zero cache limit as unlimited when updating the setting', async () => {
     const payload = Buffer.from('cached payload');
     mockDownloadFile.mockImplementation(async (_url, localPath) => {

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -1,8 +1,10 @@
-import { BrowserWindow, net, dialog, type Protocol } from 'electron';
+import { BrowserWindow, dialog, type Protocol } from 'electron';
 import { EventEmitter } from 'events';
 import crypto from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 
 import debug from 'debug';
 import isURL from 'validator/lib/isURL';
@@ -14,7 +16,7 @@ import CacheState from '../constants/CacheState';
 import limit from '../util/limit';
 
 import CacheAPI from './constants/CacheAPI';
-import downloadFile from './utils/downloadFile';
+import downloadFile, { MAX_FILE_SIZE_EXCEEDED_ERROR } from './utils/downloadFile';
 import ensureDirectoryExists from './utils/ensureDirectoryExists';
 import getChecksum from './utils/getChecksum';
 import ipcMainHandle from './utils/ipcMainHandle';
@@ -24,7 +26,51 @@ import sanitizeNumber from './utils/sanitizeNumber';
 
 const log = debug('chia-gui:CacheManager');
 
-const CACHE_PROTOCOL = 'cache';
+export const CACHE_PROTOCOL = 'cache';
+
+// A single-range `bytes=start-end` Range header, parsed against the file size.
+// 'ignore' means the header is absent or uses a form we do not support
+// (e.g. multiple ranges), in which case the full file is served with a 200.
+type ParsedRange = { start: number; end: number } | 'invalid' | 'ignore';
+
+function parseRangeHeader(rangeHeader: string | null, fileSize: number): ParsedRange {
+  if (!rangeHeader) {
+    return 'ignore';
+  }
+
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!match) {
+    return 'ignore';
+  }
+
+  const [, startString, endString] = match;
+
+  if (startString === '' && endString === '') {
+    return 'invalid';
+  }
+
+  if (startString === '') {
+    // suffix range: the last N bytes of the file
+    const suffixLength = Number.parseInt(endString, 10);
+    if (suffixLength === 0 || fileSize === 0) {
+      return 'invalid';
+    }
+
+    return { start: Math.max(fileSize - suffixLength, 0), end: fileSize - 1 };
+  }
+
+  const start = Number.parseInt(startString, 10);
+  if (start >= fileSize) {
+    return 'invalid';
+  }
+
+  const end = endString === '' ? fileSize - 1 : Math.min(Number.parseInt(endString, 10), fileSize - 1);
+  if (start > end) {
+    return 'invalid';
+  }
+
+  return { start, end };
+}
 
 async function safeUnlink(filePath: string) {
   try {
@@ -112,8 +158,11 @@ export default class CacheManager extends EventEmitter {
         });
       }
 
-      const response = await net.fetch(`file://${filePath}`);
-      if (!response.ok) {
+      let fileSize: number;
+      try {
+        const stats = await fs.stat(filePath);
+        fileSize = stats.size;
+      } catch (error) {
         return new Response('Not found', {
           status: 404,
           headers: {
@@ -122,18 +171,45 @@ export default class CacheManager extends EventEmitter {
         });
       }
 
-      const { headers } = cacheInfo;
-      const updatedHeaders = new Headers(response.headers);
+      const contentTypeHeader = cacheInfo.headers?.['content-type'];
+      const contentType =
+        (Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader) || 'application/octet-stream';
 
-      if (headers['content-type']) {
-        const contentType = Array.isArray(headers['content-type'])
-          ? headers['content-type'][0]
-          : headers['content-type'];
-        updatedHeaders.set('content-type', contentType);
+      const responseHeaders: Record<string, string> = {
+        'content-type': contentType,
+        'accept-ranges': 'bytes',
+      };
+
+      // Media elements seek by sending Range requests. Without 206 responses
+      // seeking is broken and MP4 files with the moov atom at the end of the
+      // file never start playing.
+      const range = parseRangeHeader(request.headers.get('range'), fileSize);
+
+      if (range === 'invalid') {
+        return new Response('Range Not Satisfiable', {
+          status: 416,
+          headers: {
+            'content-type': 'text/plain',
+            'content-range': `bytes */${fileSize}`,
+          },
+        });
       }
 
-      return new Response(response.body, {
-        headers: updatedHeaders,
+      if (range !== 'ignore') {
+        responseHeaders['content-length'] = String(range.end - range.start + 1);
+        responseHeaders['content-range'] = `bytes ${range.start}-${range.end}/${fileSize}`;
+
+        const partialStream = createReadStream(filePath, { start: range.start, end: range.end });
+        return new Response(Readable.toWeb(partialStream) as unknown as ReadableStream, {
+          status: 206,
+          headers: responseHeaders,
+        });
+      }
+
+      responseHeaders['content-length'] = String(fileSize);
+
+      return new Response(Readable.toWeb(createReadStream(filePath)) as unknown as ReadableStream, {
+        headers: responseHeaders,
       });
     });
   }
@@ -332,7 +408,12 @@ export default class CacheManager extends EventEmitter {
 
         if (cacheInfo.state === CacheState.ERROR) {
           log(`Url already downloaded with error: ${cacheInfo.error}`, url);
-          if (!['Response aborted', 'Request aborted'].includes(cacheInfo.error)) {
+
+          const isTransientError = ['Response aborted', 'Request aborted'].includes(cacheInfo.error);
+          // A persisted size-limit error is only retried when the caller lifts
+          // the limit, so oversized files are not re-downloaded on every visit.
+          const isSizeLimitLifted = cacheInfo.error === MAX_FILE_SIZE_EXCEEDED_ERROR && maxSize <= 0;
+          if (!isTransientError && !isSizeLimitLifted) {
             return cacheInfo;
           }
 

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -277,9 +277,6 @@ export default class CacheManager extends EventEmitter {
 
   public set maxCacheSize(newSize: number | string) {
     const value = sanitizeNumber(newSize);
-    if (value < 0) {
-      throw new Error('Cache size cannot be negative');
-    }
 
     this.#maxCacheSize = value;
 
@@ -439,7 +436,7 @@ export default class CacheManager extends EventEmitter {
           log('Checksum computed', url);
 
           // save headers to a local JSON file
-          const updatedCacheInfo = this.setCacheInfo(url, {
+          const updatedCacheInfo = await this.setCacheInfo(url, {
             state: CacheState.CACHED,
             headers,
             checksum,
@@ -448,10 +445,11 @@ export default class CacheManager extends EventEmitter {
           log('Cache info saved', url);
           // remove old files if the cache is full
           const currentCacheSize = await this.getCacheSize();
-          const stats = await fs.stat(cacheFilePath);
-          if (this.maxCacheSize && currentCacheSize + stats.size > this.maxCacheSize) {
-            const spaceNeeded = currentCacheSize + stats.size - this.maxCacheSize;
-            await this.removeOldestFiles(spaceNeeded);
+          if (this.maxCacheSize > 0 && currentCacheSize > this.maxCacheSize) {
+            // The current size already includes the file that was just
+            // downloaded. Keep that file available to the caller and evict
+            // older entries down to the configured total-size target.
+            await this.removeOldestFiles(this.maxCacheSize, cacheFilePath);
           }
           // todo just add size and save it locally
           this.emit('sizeChanged');
@@ -655,19 +653,27 @@ export default class CacheManager extends EventEmitter {
     this.cacheDirectory = newDirectory;
   }
 
-  private async removeOldestFiles(targetSize: number): Promise<void> {
+  private async removeOldestFiles(targetSize: number, preserveFilePath?: string): Promise<void> {
     const files = await fs.readdir(this.cacheDirectory);
     const filePaths = files
       .filter((file) => isChiaCacheFile(file) && !isChiaCacheInfoFile(file))
       .map((file) => path.join(this.cacheDirectory, file));
 
-    // get the file sizes
+    // Include the sidecar metadata in each entry's size so the eviction total
+    // uses the same accounting as getCacheSize().
     const fileStats = await Promise.all(
       filePaths.map(async (filePath) => {
         const stats = await fs.stat(filePath);
+        let infoSize = 0;
+        try {
+          infoSize = (await fs.stat(getInfoFilePath(filePath))).size;
+        } catch {
+          // A missing sidecar is cleaned up with the data file as usual.
+        }
+
         return {
           filePath,
-          size: stats.size,
+          size: stats.size + infoSize,
           mtime: stats.mtime,
         };
       }),
@@ -678,13 +684,17 @@ export default class CacheManager extends EventEmitter {
 
     // remove files until the total size is below the new max total size
     let totalSize = fileStats.reduce((sum, { size }) => sum + size, 0);
-    const filesToRemove = fileStats.filter(({ size }) => {
-      if (totalSize > targetSize) {
-        totalSize -= size;
-        return true;
+    const filesToRemove: typeof fileStats = [];
+    for (const fileStat of fileStats) {
+      if (totalSize <= targetSize) {
+        break;
       }
-      return false;
-    });
+
+      if (fileStat.filePath !== preserveFilePath) {
+        totalSize -= fileStat.size;
+        filesToRemove.push(fileStat);
+      }
+    }
 
     await Promise.all(
       filesToRemove.map(async ({ filePath }) => {
@@ -717,8 +727,10 @@ export default class CacheManager extends EventEmitter {
   }
 
   async setMaxCacheSize(maxCacheSize: number | string) {
-    this.maxCacheSize = sanitizeNumber(maxCacheSize);
-    await this.removeOldestFiles(this.maxCacheSize);
+    this.maxCacheSize = maxCacheSize;
+    if (this.maxCacheSize > 0) {
+      await this.removeOldestFiles(this.maxCacheSize);
+    }
   }
 
   async getCacheSize() {

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -246,8 +246,25 @@ export default class CacheManager extends EventEmitter {
       window.webContents.send(CacheAPI.ON_MAX_CACHE_SIZE_CHANGED, newSize);
     }
 
-    const onSizeChanged = async () => {
-      window.webContents.send(CacheAPI.ON_SIZE_CHANGED, await this.getCacheSize());
+    // Download and invalidation bursts emit sizeChanged per file, and every
+    // notification triggers a full cache-directory scan (here and again in the
+    // renderer), so coalesce bursts into one trailing notification.
+    let sizeChangedTimeout: NodeJS.Timeout | undefined;
+    const onSizeChanged = () => {
+      if (sizeChangedTimeout) {
+        return;
+      }
+      sizeChangedTimeout = setTimeout(async () => {
+        sizeChangedTimeout = undefined;
+        try {
+          const size = await this.getCacheSize();
+          if (!window.isDestroyed()) {
+            window.webContents.send(CacheAPI.ON_SIZE_CHANGED, size);
+          }
+        } catch {
+          // the next sizeChanged event delivers a fresh value
+        }
+      }, 500);
     };
 
     this.on('cacheDirectoryChanged', onCacheDirectoryChanged);
@@ -258,6 +275,10 @@ export default class CacheManager extends EventEmitter {
       this.off('cacheDirectoryChanged', onCacheDirectoryChanged);
       this.off('maxCacheSizeChanged', onMaxCacheSizeChanged);
       this.off('sizeChanged', onSizeChanged);
+      if (sizeChangedTimeout) {
+        clearTimeout(sizeChangedTimeout);
+        sizeChangedTimeout = undefined;
+      }
     };
 
     window.on('close', () => {
@@ -443,13 +464,19 @@ export default class CacheManager extends EventEmitter {
           });
 
           log('Cache info saved', url);
-          // remove old files if the cache is full
-          const currentCacheSize = await this.getCacheSize();
-          if (this.maxCacheSize > 0 && currentCacheSize > this.maxCacheSize) {
-            // The current size already includes the file that was just
-            // downloaded. Keep that file available to the caller and evict
-            // older entries down to the configured total-size target.
-            await this.removeOldestFiles(this.maxCacheSize, cacheFilePath);
+          try {
+            // remove old files if the cache is full
+            const currentCacheSize = await this.getCacheSize();
+            if (this.maxCacheSize > 0 && currentCacheSize > this.maxCacheSize) {
+              // The current size already includes the file that was just
+              // downloaded. Keep that file available to the caller and evict
+              // older entries down to the configured total-size target.
+              await this.removeOldestFiles(this.maxCacheSize, cacheFilePath);
+            }
+          } catch (housekeepingError) {
+            // The download and its cache info are already saved — a failure in
+            // cache bookkeeping must not overwrite that state with an error.
+            log(`Cache housekeeping failed: ${(housekeepingError as Error).message}`, url);
           }
           // todo just add size and save it locally
           this.emit('sizeChanged');
@@ -661,23 +688,30 @@ export default class CacheManager extends EventEmitter {
 
     // Include the sidecar metadata in each entry's size so the eviction total
     // uses the same accounting as getCacheSize().
-    const fileStats = await Promise.all(
-      filePaths.map(async (filePath) => {
-        const stats = await fs.stat(filePath);
-        let infoSize = 0;
-        try {
-          infoSize = (await fs.stat(getInfoFilePath(filePath))).size;
-        } catch {
-          // A missing sidecar is cleaned up with the data file as usual.
-        }
+    const fileStats = (
+      await Promise.all(
+        filePaths.map(async (filePath) => {
+          try {
+            const stats = await fs.stat(filePath);
+            let infoSize = 0;
+            try {
+              infoSize = (await fs.stat(getInfoFilePath(filePath))).size;
+            } catch {
+              // A missing sidecar is cleaned up with the data file as usual.
+            }
 
-        return {
-          filePath,
-          size: stats.size + infoSize,
-          mtime: stats.mtime,
-        };
-      }),
-    );
+            return {
+              filePath,
+              size: stats.size + infoSize,
+              mtime: stats.mtime,
+            };
+          } catch {
+            // Deleted by invalidation while scanning — nothing left to evict.
+            return undefined;
+          }
+        }),
+      )
+    ).filter((entry): entry is { filePath: string; size: number; mtime: Date } => entry !== undefined);
 
     // sort the file paths based on their last modified time (oldest first)
     fileStats.sort((a, b) => a.mtime.getTime() - b.mtime.getTime());
@@ -739,8 +773,17 @@ export default class CacheManager extends EventEmitter {
       .filter((filename) => isChiaCacheFile(filename))
       .map((filename) => path.join(this.cacheDirectory, filename));
 
-    // Get the file sizes and calculate the total size
-    const fileSizes = await Promise.all(filePaths.map(async (filePath) => (await fs.stat(filePath)).size));
+    // Invalidation and eviction delete files while this scan runs — a file
+    // that vanished between readdir and stat no longer occupies space.
+    const fileSizes = await Promise.all(
+      filePaths.map(async (filePath) => {
+        try {
+          return (await fs.stat(filePath)).size;
+        } catch {
+          return 0;
+        }
+      }),
+    );
     const totalSize = fileSizes.reduce((sum, size) => sum + size, 0);
 
     return totalSize;

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -127,7 +127,10 @@ export default class CacheManager extends EventEmitter {
 
     this.cacheDirectory = cacheDirectory;
     this.maxCacheSize = maxCacheSize;
-    this.#downloadLimit = limit(concurrency);
+    // LIFO: downloads for what the user is currently viewing (an offer
+    // preview, a just-opened detail page) are requested last and must not
+    // wait behind a long gallery-wide rebuild of earlier requests.
+    this.#downloadLimit = limit(concurrency, { lifo: true });
 
     this.setMaxListeners(50);
 

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -10,6 +10,7 @@ import {
   Notification,
   type MenuItemConstructorOptions,
   nativeTheme,
+  protocol,
 } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -29,7 +30,7 @@ import { WcError, WcErrorCode, encodeWcErrorForIpc } from '../@types/WcError';
 import AppIcon from '../assets/img/chia64x64.png';
 import { i18n } from '../config/locales';
 
-import CacheManager from './CacheManager';
+import CacheManager, { CACHE_PROTOCOL } from './CacheManager';
 import { checkNFTOwnership } from './api/checkNFTOwnership';
 import { getKeyDetails } from './api/getKeyDetails';
 import { getNetworkInfo } from './api/getNetworkInfo';
@@ -93,6 +94,22 @@ type ConfirmDialogResult = {
 
 app.disableHardwareAcceleration();
 app.commandLine.appendSwitch('disable-http-cache');
+
+// The cache: scheme serves NFT media to <img>/<video>/<audio> tags. Media
+// elements expect protocols to buffer their responses unless the scheme is
+// registered with stream: true, so without this video and audio playback
+// stalls. Must be called before the app ready event.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: CACHE_PROTOCOL,
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+    },
+  },
+]);
 
 const appIcon = nativeImage.createFromPath(path.join(__dirname, AppIcon));
 

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -118,9 +118,16 @@ const prefs = readPrefs();
 const defaultCacheFolder = path.join(app.getPath('cache'), app.getName());
 const cacheDirectory: string = prefs.cacheFolder || defaultCacheFolder;
 
+// `cacheLimitSize` is the legacy preference key older versions of the
+// settings UI stored the value under. Invalid values are ignored because the
+// CacheManager constructor throws on non-positive sizes.
+const storedMaxCacheSize: number | undefined = [prefs.maxCacheSize, prefs.cacheLimitSize].find(
+  (size) => typeof size === 'number' && Number.isFinite(size) && size > 0,
+);
+
 const cacheManager = new CacheManager({
   cacheDirectory,
-  maxCacheSize: prefs.maxCacheSize,
+  maxCacheSize: storedMaxCacheSize,
 });
 
 // Hoisted so IPC handlers registered below can close over them; assigned in

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -120,9 +120,9 @@ const cacheDirectory: string = prefs.cacheFolder || defaultCacheFolder;
 
 // `cacheLimitSize` is the legacy preference key older versions of the
 // settings UI stored the value under. Invalid values are ignored because the
-// CacheManager constructor throws on non-positive sizes.
+// CacheManager constructor rejects negative sizes; zero means unlimited.
 const storedMaxCacheSize: number | undefined = [prefs.maxCacheSize, prefs.cacheLimitSize].find(
-  (size) => typeof size === 'number' && Number.isFinite(size) && size > 0,
+  (size) => typeof size === 'number' && Number.isFinite(size) && size >= 0,
 );
 
 const cacheManager = new CacheManager({

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -63,10 +63,12 @@ class WriteStreamPromise {
   }
 }
 
+export const MAX_FILE_SIZE_EXCEEDED_ERROR = 'Maximum file size exceeded';
+
 type DownloadFileOptions = {
   timeout?: number;
   signal?: AbortSignal;
-  maxSize?: number;
+  maxSize?: number; // values <= 0 disable the size limit
   onProgress?: (progress: number, size: number, downloadedSize: number) => void;
   overrideFile?: boolean;
 };
@@ -84,11 +86,26 @@ export default async function downloadFile(
   const request = net.request(url);
   const outputStream = new WriteStreamPromise(tempFilePath, overrideFile);
 
+  // set when we abort the request ourselves, so abort events can be reported
+  // with the real reason instead of a generic aborted error
+  let abortError: Error | undefined;
+
   function abortRequest() {
     request.abort();
   }
 
   let timeoutId: NodeJS.Timeout | null = null;
+
+  // the timeout is an inactivity timeout - it is reset every time data
+  // arrives, so slow hosts serving large files (videos) are not cut off mid
+  // transfer while a stalled connection still fails fast
+  function resetTimeout() {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(abortRequest, timeout);
+  }
 
   return new Promise<Headers>((resolve, reject) => {
     let downloadedSize = 0;
@@ -161,7 +178,8 @@ export default async function downloadFile(
         const size = Number.parseInt(contentLength, 10);
         if (!Number.isNaN(size)) {
           fileSize = size;
-          if (size > maxSize) {
+          if (maxSize > 0 && size > maxSize) {
+            abortError = new Error(MAX_FILE_SIZE_EXCEEDED_ERROR);
             request.abort();
             return;
           }
@@ -170,8 +188,10 @@ export default async function downloadFile(
 
       response.on('data', (chunk) => {
         downloadedSize += chunk.byteLength;
+        resetTimeout();
 
-        if (downloadedSize > maxSize) {
+        if (maxSize > 0 && downloadedSize > maxSize) {
+          abortError = new Error(MAX_FILE_SIZE_EXCEEDED_ERROR);
           request.abort();
           return;
         }
@@ -182,7 +202,7 @@ export default async function downloadFile(
 
         // send progress event only when we know the file size
         if (onProgress && fileSize !== undefined && fileSize > 0) {
-          const progress = Math.max((downloadedSize / fileSize) * 100, 100);
+          const progress = Math.min((downloadedSize / fileSize) * 100, 100);
           onProgress(progress, fileSize, downloadedSize);
         }
       });
@@ -192,7 +212,7 @@ export default async function downloadFile(
       });
 
       response.on('aborted', () => {
-        resolvePromise(false, new Error('Response aborted'));
+        resolvePromise(false, abortError ?? new Error('Response aborted'));
       });
 
       response.on('end', () => {
@@ -201,7 +221,7 @@ export default async function downloadFile(
     });
 
     request.on('abort', () => {
-      resolvePromise(false, new Error('Request aborted'));
+      resolvePromise(false, abortError ?? new Error('Request aborted'));
     });
 
     request.on('error', (error = new Error('Unknown request error')) => {
@@ -212,7 +232,7 @@ export default async function downloadFile(
       signal.addEventListener('abort', abortRequest);
     }
 
-    timeoutId = setTimeout(abortRequest, timeout);
+    resetTimeout();
 
     request.end();
   });

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -67,6 +67,7 @@ export const MAX_FILE_SIZE_EXCEEDED_ERROR = 'Maximum file size exceeded';
 
 type DownloadFileOptions = {
   timeout?: number;
+  maxDuration?: number; // absolute cap on the whole transfer
   signal?: AbortSignal;
   maxSize?: number; // values <= 0 disable the size limit
   onProgress?: (progress: number, size: number, downloadedSize: number) => void;
@@ -76,7 +77,14 @@ type DownloadFileOptions = {
 export default async function downloadFile(
   url: string,
   localPath: string,
-  { timeout = 30_000, signal, maxSize = 100 * 1024 * 1024, onProgress, overrideFile = false }: DownloadFileOptions = {},
+  {
+    timeout = 30_000,
+    maxDuration = 30 * 60 * 1000,
+    signal,
+    maxSize = 100 * 1024 * 1024,
+    onProgress,
+    overrideFile = false,
+  }: DownloadFileOptions = {},
 ): Promise<Headers> {
   if (!isValidURL(url)) {
     throw new Error('Invalid URL');
@@ -107,6 +115,10 @@ export default async function downloadFile(
     timeoutId = setTimeout(abortRequest, timeout);
   }
 
+  // absolute deadline for the whole transfer — the inactivity timeout alone
+  // would let a host trickling bytes hold a download slot forever
+  const maxDurationTimeoutId = setTimeout(abortRequest, maxDuration);
+
   return new Promise<Headers>((resolve, reject) => {
     let downloadedSize = 0;
 
@@ -131,6 +143,8 @@ export default async function downloadFile(
           clearTimeout(timeoutId);
           timeoutId = null;
         }
+
+        clearTimeout(maxDurationTimeoutId);
 
         await outputStream.close();
 

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -102,6 +102,14 @@ export default async function downloadFile(
     request.abort();
   }
 
+  // Timeouts must not report the generic aborted error: the cache retries
+  // aborted downloads on every access, so a stalled host would be retried
+  // (and stall again) forever instead of settling as a failed download.
+  function abortWithError(error: Error) {
+    abortError = error;
+    request.abort();
+  }
+
   let timeoutId: NodeJS.Timeout | null = null;
 
   // the timeout is an inactivity timeout - it is reset every time data
@@ -112,12 +120,18 @@ export default async function downloadFile(
       clearTimeout(timeoutId);
     }
 
-    timeoutId = setTimeout(abortRequest, timeout);
+    timeoutId = setTimeout(
+      () => abortWithError(new Error(`Request timed out after ${timeout}ms of inactivity`)),
+      timeout,
+    );
   }
 
   // absolute deadline for the whole transfer — the inactivity timeout alone
   // would let a host trickling bytes hold a download slot forever
-  const maxDurationTimeoutId = setTimeout(abortRequest, maxDuration);
+  const maxDurationTimeoutId = setTimeout(
+    () => abortWithError(new Error(`Request exceeded the ${maxDuration}ms download deadline`)),
+    maxDuration,
+  );
 
   return new Promise<Headers>((resolve, reject) => {
     let downloadedSize = 0;

--- a/packages/gui/src/electron/utils/sanitizeNumber.ts
+++ b/packages/gui/src/electron/utils/sanitizeNumber.ts
@@ -1,14 +1,8 @@
 export default function sanitizeNumber(input: number | string): number {
-  let size: number;
+  const size = typeof input === 'string' ? Number(input) : input;
 
-  if (typeof input === 'string') {
-    size = parseInt(input, 10);
-  } else {
-    size = input;
-  }
-
-  if (Number.isNaN(size) || size <= 0) {
-    throw new Error('Invalid maxTotalSize value. It must be a positive number.');
+  if ((typeof input === 'string' && input.trim() === '') || !Number.isFinite(size) || size < 0) {
+    throw new Error('Invalid maxTotalSize value. It must be a non-negative finite number.');
   }
 
   return size;

--- a/packages/gui/src/hooks/useNFTCoinEvents.ts
+++ b/packages/gui/src/hooks/useNFTCoinEvents.ts
@@ -23,11 +23,19 @@ export default function useNFTCoinEvents() {
     [events /* immutable */],
   );
 
-  // Subscribe to all events related to NFTs
-  useNFTCoinAdded((data) => handleNFTEvent('add', data.walletId));
-  useNFTCoinRemoved((data) => handleNFTEvent('remove', data.walletId));
-  useNFTCoinUpdated((data) => handleNFTEvent('updated', data.walletId));
-  useNFTCoinDIDSet((data) => handleNFTEvent('didset', data.walletId));
+  // Subscribe to all events related to NFTs. The callbacks must be stable:
+  // useSubscribeToEvent resubscribes whenever the callback identity changes,
+  // and a wallet event arriving between the unsubscribe and the new subscribe
+  // is silently lost, leaving the gallery stale until a remount.
+  const handleCoinAdded = useCallback((data: any) => handleNFTEvent('add', data.walletId), [handleNFTEvent]);
+  const handleCoinRemoved = useCallback((data: any) => handleNFTEvent('remove', data.walletId), [handleNFTEvent]);
+  const handleCoinUpdated = useCallback((data: any) => handleNFTEvent('updated', data.walletId), [handleNFTEvent]);
+  const handleCoinDIDSet = useCallback((data: any) => handleNFTEvent('didset', data.walletId), [handleNFTEvent]);
+
+  useNFTCoinAdded(handleCoinAdded);
+  useNFTCoinRemoved(handleCoinRemoved);
+  useNFTCoinUpdated(handleCoinUpdated);
+  useNFTCoinDIDSet(handleCoinDIDSet);
 
   const subscribe = useCallback(
     (callback: (event?: Event) => void) => {

--- a/packages/gui/src/hooks/useNFTVideoLoop.tsx
+++ b/packages/gui/src/hooks/useNFTVideoLoop.tsx
@@ -1,0 +1,44 @@
+import { usePrefs } from '@chia-network/api-react';
+import { useCallback } from 'react';
+
+// Global preference: when enabled, every NFT video loops, regardless of the
+// per-video preference. When disabled, looping is controlled per video.
+export function useNFTVideoLoopGlobal(): [boolean, (loopVideos: boolean) => void] {
+  return usePrefs<boolean>('nftVideoLoop', false);
+}
+
+type NFTVideoLoopMap = Record<string, boolean>;
+
+// Per-video preference, keyed by NFT id. Only enabled videos are stored, so
+// the preferences file stays clean.
+export function useNFTVideoLoopForNFT(nftId: string): [boolean, (loopVideo: boolean) => void] {
+  const [loopMap, setLoopMap] = usePrefs<NFTVideoLoopMap>('nftVideoLoopByNftId', {});
+
+  const loop = !!loopMap?.[nftId];
+
+  const setLoop = useCallback(
+    (loopVideo: boolean) => {
+      setLoopMap((currentMap) => {
+        const nextMap = { ...currentMap };
+        if (loopVideo) {
+          nextMap[nftId] = true;
+        } else {
+          delete nextMap[nftId];
+        }
+        return nextMap;
+      });
+    },
+    [nftId, setLoopMap],
+  );
+
+  return [loop, setLoop];
+}
+
+// The effective looping state for one NFT video: the global preference forces
+// looping on when set, but never disables a video's own loop preference.
+export default function useNFTVideoLoop(nftId: string): boolean {
+  const [globalLoop] = useNFTVideoLoopGlobal();
+  const [videoLoop] = useNFTVideoLoopForNFT(nftId);
+
+  return globalLoop || videoLoop;
+}

--- a/packages/gui/src/util/limit.test.ts
+++ b/packages/gui/src/util/limit.test.ts
@@ -1,0 +1,59 @@
+import limit from './limit';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('limit', () => {
+  it('runs queued tasks in FIFO order by default', async () => {
+    const add = limit(1);
+    const first = deferred();
+    const order: string[] = [];
+
+    const tasks = [
+      add(async () => {
+        await first.promise;
+        order.push('a');
+      }),
+      add(async () => {
+        order.push('b');
+      }),
+      add(async () => {
+        order.push('c');
+      }),
+    ];
+
+    first.resolve();
+    await Promise.all(tasks);
+
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+
+  it('runs the most recently queued task first in LIFO mode', async () => {
+    const add = limit(1, { lifo: true });
+    const first = deferred();
+    const order: string[] = [];
+
+    const tasks = [
+      add(async () => {
+        await first.promise;
+        order.push('a');
+      }),
+      add(async () => {
+        order.push('b');
+      }),
+      add(async () => {
+        order.push('c');
+      }),
+    ];
+
+    first.resolve();
+    await Promise.all(tasks);
+
+    expect(order).toEqual(['a', 'c', 'b']);
+  });
+});

--- a/packages/gui/src/util/limit.ts
+++ b/packages/gui/src/util/limit.ts
@@ -1,4 +1,6 @@
-export default function limit(concurrency: number) {
+export default function limit(concurrency: number, options: { lifo?: boolean } = {}) {
+  const { lifo = false } = options;
+
   const queue: {
     func: Function;
     resolve: (value: any) => void;
@@ -13,7 +15,10 @@ export default function limit(concurrency: number) {
 
     active++;
 
-    const item = queue.shift();
+    // LIFO runs the most recently requested task first, so work triggered by
+    // what the user is currently looking at is not starved by a long backlog
+    // of earlier background requests.
+    const item = lifo ? queue.pop() : queue.shift();
     if (!item) {
       return;
     }


### PR DESCRIPTION
Part **2 of 3** of the split of #2993. **These three PRs are meant to be applied together, in order**: this PR is stacked on #3008 (cache & download infrastructure), so its diff includes those commits until #3008 merges — **review only the 4 commits listed below**. Part 3 (#3010, preview verification & hardening) stacks on this PR.

## What this PR changes and why

Renderer-side video/audio UX: with basic playback fixed at the pipeline level in #3008, these commits make the player actually usable and bring media into the gallery.

### Fix unclickable video/audio controls in NFT detail view
The detail view rendered an overlay that swallowed pointer events on the native media controls (a leftover of #2681's `allowPointerEvents` logic, which was inverted). Controls — play, seek, volume — now receive clicks.

### Add NFT gallery refresh button and inline grid playback
- A refresh button on the gallery toolbar re-fetches the NFT list on demand.
- Wallet NFT coin-event subscriptions use stable callbacks: `useSubscribeToEvent` resubscribes whenever the callback identity changes, and an event arriving between the unsubscribe and resubscribe was silently lost, leaving the gallery stale until remount.
- Videos in the gallery grid can play inline instead of only in the detail view.

### Add NFT video looping as global and per-video setting
NFT videos previously played once and stopped (`<video>` never set `loop`). New `useNFTVideoLoop` hook backed by two prefs: a global default (`nftVideoLoop`, with a Settings > NFT toggle) and per-NFT overrides (`nftVideoLoopByNftId`). The per-video control lives on the player itself: the native controls' overflow menu is rendered by Chromium inside the sandboxed iframe and cannot be extended, so a loop icon button is overlaid on the player (grid and detail view), shown active but disabled while the global setting is on.

### Disable media interactions during gallery multi-select
In multi-select mode the loop toggle rendered on top of the selection checkbox and swallowed its clicks; media interactions are disabled while selecting so the whole tile selects on click again.

## Testing
- Full jest suite green at this branch; `tsc --noEmit` error count equal to main's baseline; eslint/prettier clean.
- Manually validated on a live wallet: detail-view control clickability, inline grid playback, loop toggle persistence (global and per-NFT), refresh button, and multi-select selection behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T88GQEqcbujpAKLZy3sKoq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron cache protocol, download/eviction logic, and NFT list refresh paths; mostly UX and reliability, with moderate blast radius if cache or refetch regresses.
> 
> **Overview**
> Improves **NFT video and audio UX** in the gallery and detail views: native controls are clickable again (`allowPointerEvents` fixed), grid tiles support **inline playback** with overlay blockers so clicks outside controls still open the NFT, and **multi-select** disables media interactions so the loop button does not block the checkbox.
> 
> Adds **video looping** via new `useNFTVideoLoop` prefs—a global **Settings > NFT** toggle (`nftVideoLoop`) and per-NFT overrides (`nftVideoLoopByNftId`) with an on-player loop icon (disabled when global loop is on).
> 
> Exposes **`refetch`** on the NFT provider and adds a **Refresh NFTs** toolbar button; **stable wallet coin-event callbacks** in `useNFTCoinEvents` avoid missed events between resubscribes that left the gallery stale.
> 
> **Cache-related changes** (stacked infrastructure): `cache:` protocol serves **HTTP Range / 206** for seeking and MP4 playback; download timeouts, eviction, and preference persistence (`CacheProvider` writes `maxCacheSize` / `cacheFolder` from the renderer); LIFO download queue prioritizes current views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6592dea4e0043e1e0542a32f68ef1b8ab8b10db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->