### PR TITLE
Stop daemon broadcast events from rejecting pending wallet_ui requests

### DIFF
--- a/packages/gui/src/electron/api/sendCommand.test.ts
+++ b/packages/gui/src/electron/api/sendCommand.test.ts
@@ -281,6 +281,71 @@ describe('sendCommand', () => {
     expect(rawMessage).not.toContain('9007199254740993n');
   });
 
+  it('ignores broadcast events with long-precision floats while a command is pending', async () => {
+    await startServer((socket, message) => {
+      if (message.command === 'register_service') {
+        socket.send(JSONBig.stringify({ request_id: message.request_id, data: { success: true } }));
+        return;
+      }
+
+      // Raw frame mimicking a chia_harvester farming_info broadcast: the
+      // lookup time float is longer than 15 characters, which used to make
+      // the useNativeBigInt parser throw and reject the pending request.
+      socket.send(
+        '{"ack":false,"command":"farming_info","data":{"challenge_hash":"0xabc","total_plots":1000,"time":1.7656183690123726},"destination":"wallet_ui","origin":"chia_harvester","request_id":"broadcast"}',
+      );
+      socket.send(JSONBig.stringify({ request_id: message.request_id, data: { success: true, value: 'done' } }));
+    });
+    const sendCommand = loadSendCommand();
+
+    await expect(sendCommand('get_offer_summary', 'chia_wallet')).resolves.toMatchObject({ value: 'done' });
+  });
+
+  it('resolves a matched response that contains long-precision floats', async () => {
+    await startServer((socket, message) => {
+      if (message.command === 'register_service') {
+        socket.send(JSONBig.stringify({ request_id: message.request_id, data: { success: true } }));
+        return;
+      }
+
+      socket.send(`{"request_id":"${message.request_id}","data":{"success":true,"fee_rate":1.7656183690123726}}`);
+    });
+    const sendCommand = loadSendCommand();
+
+    const response = await sendCommand<{ fee_rate: unknown }>('get_fee_estimate', 'chia_full_node');
+
+    expect(String(response.fee_rate)).toBe('1.7656183690123726');
+  });
+
+  it('ignores frames that are not valid JSON while a command is pending', async () => {
+    await startServer((socket, message) => {
+      if (message.command === 'register_service') {
+        socket.send(JSONBig.stringify({ request_id: message.request_id, data: { success: true } }));
+        return;
+      }
+
+      socket.send('not json');
+      socket.send(JSONBig.stringify({ request_id: message.request_id, data: { success: true, value: 'done' } }));
+    });
+    const sendCommand = loadSendCommand();
+
+    await expect(sendCommand('get_wallets', 'chia_wallet')).resolves.toMatchObject({ value: 'done' });
+  });
+
+  it('ignores broadcast events with long-precision floats during service registration', async () => {
+    await startServer((socket, message) => {
+      if (message.command === 'register_service') {
+        socket.send(
+          '{"ack":false,"command":"farming_info","data":{"time":1.2395747610135004},"destination":"wallet_ui","origin":"chia_harvester","request_id":"broadcast"}',
+        );
+      }
+      socket.send(JSONBig.stringify({ request_id: message.request_id, data: { success: true, value: 'done' } }));
+    });
+    const sendCommand = loadSendCommand();
+
+    await expect(sendCommand('get_network_info', 'chia_wallet')).resolves.toMatchObject({ value: 'done' });
+  });
+
   it('rejects daemon command errors', async () => {
     await startServer((socket, message) => {
       socket.send(

--- a/packages/gui/src/electron/api/sendCommand.ts
+++ b/packages/gui/src/electron/api/sendCommand.ts
@@ -6,6 +6,26 @@ import { loadConfig } from '../utils/loadConfig';
 const REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const JSONBigNative = JSONBig({ useNativeBigInt: true });
 
+// The wallet_ui socket also receives daemon broadcast events (farming_info,
+// get_fee_estimate, get_connections, ...). json-bigint with useNativeBigInt
+// passes any number literal longer than 15 characters to BigInt(), which
+// throws on the long-precision floats those events carry, so fall back to the
+// BigNumber-based parser before giving up on a frame. Returns undefined for
+// frames that are not valid JSON at all.
+function parseIncomingMessage(data: Buffer): any | undefined {
+  const text = data.toString();
+
+  try {
+    return JSONBigNative.parse(text);
+  } catch {
+    try {
+      return JSONBig.parse(text);
+    } catch {
+      return undefined;
+    }
+  }
+}
+
 let socketPromise: Promise<WebSocket> | undefined;
 
 async function connect(): Promise<WebSocket> {
@@ -37,12 +57,12 @@ async function connect(): Promise<WebSocket> {
     });
 
     function handleMessage(data: Buffer) {
-      try {
-        const response = JSONBigNative.parse(data.toString());
-        if (response.request_id !== requestId) {
-          return;
-        }
+      const response = parseIncomingMessage(data);
+      if (!response || response.request_id !== requestId) {
+        return;
+      }
 
+      try {
         if (!response.data.success) {
           throw new Error(`Daemon service is not registered`);
         }
@@ -167,12 +187,12 @@ export async function sendCommand<TResponse extends Record<string, unknown>>(
     }
 
     function handleMessage(data: Buffer) {
-      try {
-        const response = JSONBigNative.parse(data.toString());
-        if (response.request_id !== requestId) {
-          return;
-        }
+      const response = parseIncomingMessage(data);
+      if (!response || response.request_id !== requestId) {
+        return;
+      }
 
+      try {
         if (!response.data.success) {
           throw new Error(response.data.error);
         }


### PR DESCRIPTION
### Problem

Accepting an offer in the Offers tab can fail with an error dialog like:

```
Error: Cannot convert 1.7656183690123726 to a BigInt
```

The offer is never sent to the wallet (no spend is pushed). On farms with slower plot lookups this happens on nearly every accept attempt.

### Root cause

`packages/gui/src/electron/api/sendCommand.ts` registers its daemon socket as service `wallet_ui`, so the daemon forwards **every broadcast event** to it (`farming_info`, `get_fee_estimate`, `get_connections`, …) in addition to RPC responses.

Its `handleMessage` parsed **every** incoming frame with `JSONBig({ useNativeBigInt: true })` *before* checking `request_id`. json-bigint's parser passes any number literal longer than 15 characters to `BigInt()` — even when it contains a decimal point ([json-bigint `lib/parse.js`, the `string.length > 15` branch]). A harvester `farming_info` lookup time such as `1.7656183690123726` therefore throws `SyntaxError: Cannot convert 1.7656183690123726 to a BigInt`, and the `catch` rejected whichever request happened to be pending.

The user-visible failure chain: Offers-tab accept → `take_offer` intercepted by the main-process confirmation layer (`onSend` in `main.tsx`) → `parseCommandDisplay` → `getOfferSummary` → `sendCommand('get_offer_summary')` → an unrelated broadcast with a long-precision float lands during the round trip → the pending request is rejected → `onSend` throws → the bridge synthesizes an error response → the renderer shows the BigInt error and `take_offer` is never transmitted.

Verified against a live mainnet daemon: a 30-second passive `wallet_ui` listener observed multiple poison frames (`chia_harvester farming_info` with `time` floats of 1.2–1.8 s, `chia_full_node get_fee_estimate`, `chia_farmer get_connections` float timestamps), so the race window is hit almost every time on affected setups.

The same flaw exists in `connect()`'s `register_service` handler, where a poison frame during the handshake tears down the socket.

### Fix

Parse incoming frames with the native-bigint parser first, fall back to the BigNumber-based parser (json-bigint's default, which handles long-precision floats fine) when it throws, and ignore frames that are not valid JSON at all instead of rejecting the pending request. Matched responses keep their existing native-bigint behavior for large integers.

### Tests

Four new regression tests in `sendCommand.test.ts` (all four fail against the previous implementation):

- ignores a `farming_info`-style broadcast with a >15-char float while a command is pending
- resolves a matched response that itself contains long-precision floats
- ignores frames that are not valid JSON while a command is pending
- ignores poison broadcasts during `register_service`

Existing tests, including "parses unsafe integer response values as native bigints", still pass (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jfMfuGTvCmMyL7EM92dmj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Electron daemon IPC parsing for all wallet commands; behavior is intentional but any mismatch in request_id handling or fallback parsing could affect RPC reliability.
> 
> **Overview**
> Fixes intermittent **offer accept** failures (`Cannot convert … to a BigInt`) when unrelated daemon **broadcast** frames arrive while a `wallet_ui` command is in flight.
> 
> Incoming WebSocket frames are parsed via a new **`parseIncomingMessage`**: try native-bigint `json-bigint` first, **fall back** to the default BigNumber parser when long-precision **floats** trip `BigInt()`, and **drop** non-JSON frames instead of rejecting the pending RPC. The same logic applies during **`register_service`**.
> 
> Four regression tests cover poison broadcasts, matched responses with long floats, invalid JSON, and registration-time broadcasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54db007edd7a91f1ca7ccdb22914070be6ad6661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->