### PR TITLE
[CHIA-4325] Increased nft offer limit to 20 from 10

### DIFF
--- a/packages/gui/src/components/nfts/NFTContextualActions.tsx
+++ b/packages/gui/src/components/nfts/NFTContextualActions.tsx
@@ -25,6 +25,7 @@ import React, { useMemo, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useCopyToClipboard } from 'react-use';
 
+import OfferBuilderNFTMax from '../../constants/OfferBuilderNFTMax';
 import useBurnAddress from '../../hooks/useBurnAddress';
 import useHiddenNFTs from '../../hooks/useHiddenNFTs';
 import useNFTs from '../../hooks/useNFTs';
@@ -120,7 +121,8 @@ function NFTCreateOfferContextualAction(props: NFTCreateOfferContextualActionPro
   const navigate = useNavigate();
   const [, setSelectedNFTIds] = useLocalStorage('gallery-selected-nfts', []);
   const selectedNft: NFTInfo | undefined = selection?.items[0];
-  const disabled = !selection?.items?.length || selectedNft?.pendingTransaction || selection?.items?.length > 10;
+  const disabled =
+    !selection?.items?.length || selectedNft?.pendingTransaction || selection?.items?.length > OfferBuilderNFTMax;
 
   if (!selectedNft) return null;
 

--- a/packages/gui/src/components/offers2/OfferBuilderNFTSection.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderNFTSection.tsx
@@ -4,6 +4,8 @@ import { Trans } from '@lingui/macro';
 import React from 'react';
 import { useFieldArray } from 'react-hook-form';
 
+import OfferBuilderNFTMax from '../../constants/OfferBuilderNFTMax';
+
 import OfferBuilderNFT from './OfferBuilderNFT';
 import OfferBuilderSection from './OfferBuilderSection';
 
@@ -17,7 +19,7 @@ export type OfferBuilderNFTSectionProps = {
 };
 
 export default function OfferBuilderNFTSection(props: OfferBuilderNFTSectionProps) {
-  const { name, offering, muted, viewer, isMyOffer = false, max = 20 } = props;
+  const { name, offering, muted, viewer, isMyOffer = false, max = OfferBuilderNFTMax } = props;
 
   const { fields, append, remove } = useFieldArray({
     name,

--- a/packages/gui/src/components/offers2/OfferBuilderNFTSection.tsx
+++ b/packages/gui/src/components/offers2/OfferBuilderNFTSection.tsx
@@ -17,7 +17,7 @@ export type OfferBuilderNFTSectionProps = {
 };
 
 export default function OfferBuilderNFTSection(props: OfferBuilderNFTSectionProps) {
-  const { name, offering, muted, viewer, isMyOffer = false, max = 10 } = props;
+  const { name, offering, muted, viewer, isMyOffer = false, max = 20 } = props;
 
   const { fields, append, remove } = useFieldArray({
     name,

--- a/packages/gui/src/constants/OfferBuilderNFTMax.ts
+++ b/packages/gui/src/constants/OfferBuilderNFTMax.ts
@@ -1,0 +1,3 @@
+const OfferBuilderNFTMax = 20;
+
+export default OfferBuilderNFTMax;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only limit change with no auth or blockchain logic changes; verify backend/wallet still accepts offers with up to 20 NFTs if that was previously capped at 10 elsewhere.
> 
> **Overview**
> Raises the maximum number of NFTs in a single offer from **10** to **20** and centralizes that limit in a new `OfferBuilderNFTMax` constant.
> 
> The gallery **Create Offer** action now disables when more than 20 NFTs are selected (previously 10). The offer builder NFT section uses the same constant as its default `max`, so users can add up to 20 NFT rows in the builder UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba66e160ab9179c66defafee2fd21fad01dbd3c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->