### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that reduces token permissions; no application or security logic changes.
> 
> **Overview**
> Adds an explicit **`permissions: contents: read`** block to the **Check commit signing** workflow so the job only gets read access to repository contents instead of inheriting broader default GITHUB_TOKEN scopes.
> 
> This matches the pattern used in other workflows (e.g. dependency review) and is typical for managed/repo-content-updater workflow hygiene.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 705a85e863d82577f534700e93c39aef9c14c3e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->