### PR TITLE
[CHIA-4324] NFT media pipeline 5: download timeout recovery, bounded confirmation previews, buffer cleanup

### DIFF
--- a/packages/gui/src/components/nfts/NFTHashStatus.tsx
+++ b/packages/gui/src/components/nfts/NFTHashStatus.tsx
@@ -37,19 +37,18 @@ export default function NFTHashStatus(props: NFTHashStatusProps) {
   const failedFetch = preview ? nftPreview?.failedFetch : data?.failedFetch;
 
   const isValidURI = useMemo(() => {
-    if (!nftPreview || !('originalUri' in nftPreview)) {
+    const uri = nftPreview?.uri;
+    if (!uri) {
+      // nothing to validate — other branches cover the missing-preview cases
       return true;
     }
 
-    if (nftPreview.uri) {
-      // While the user has IPFS gateway fetching enabled, ipfs:// URIs are
-      // served through an HTTPS gateway by the cache layer, so validate the
-      // gateway form instead of flagging them as invalid. With the option
-      // off they are not fetchable and stay flagged.
-      return isValidURL(ipfsGateway ? ipfsToGatewayUrl(nftPreview.uri) : nftPreview.uri);
-    }
-
-    return false;
+    // While the user has IPFS gateway fetching enabled, ipfs:// URIs are
+    // served through an HTTPS gateway by the cache layer, so validate the
+    // gateway form instead of flagging them as invalid. With the option off
+    // they are not fetchable and stay flagged — unless the file already
+    // verified from the cache, which the message branches above this check.
+    return isValidURL(ipfsGateway ? ipfsToGatewayUrl(uri) : uri);
   }, [nftPreview, ipfsGateway]);
 
   const icon = useMemo(() => {

--- a/packages/gui/src/components/nfts/NFTHashStatus.tsx
+++ b/packages/gui/src/components/nfts/NFTHashStatus.tsx
@@ -6,6 +6,7 @@ import { Chip, Typography } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import React, { useMemo } from 'react';
 
+import useIpfsGateway from '../../hooks/useIpfsGateway';
 import useNFT from '../../hooks/useNFT';
 import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
 import ipfsToGatewayUrl from '../../util/ipfs';
@@ -28,6 +29,7 @@ export default function NFTHashStatus(props: NFTHashStatusProps) {
   });
 
   const { nft, isLoading: isLoadingNFT, error: errorNFT } = useNFT(nftId);
+  const [ipfsGateway] = useIpfsGateway();
 
   const isLoading = isLoadingNFTVerifyHash || isLoadingNFT;
   const isVerified = preview ? nftPreview?.isVerified : data?.isVerified;
@@ -40,13 +42,15 @@ export default function NFTHashStatus(props: NFTHashStatusProps) {
     }
 
     if (nftPreview.uri) {
-      // ipfs:// URIs are served through an HTTPS gateway by the cache layer,
-      // so validate the gateway form instead of flagging them as invalid.
-      return isValidURL(ipfsToGatewayUrl(nftPreview.uri));
+      // While the user has IPFS gateway fetching enabled, ipfs:// URIs are
+      // served through an HTTPS gateway by the cache layer, so validate the
+      // gateway form instead of flagging them as invalid. With the option
+      // off they are not fetchable and stay flagged.
+      return isValidURL(ipfsGateway ? ipfsToGatewayUrl(nftPreview.uri) : nftPreview.uri);
     }
 
     return false;
-  }, [nftPreview]);
+  }, [nftPreview, ipfsGateway]);
 
   const icon = useMemo(() => {
     if (hideIcon) {

--- a/packages/gui/src/components/nfts/NFTHashStatus.tsx
+++ b/packages/gui/src/components/nfts/NFTHashStatus.tsx
@@ -8,6 +8,7 @@ import React, { useMemo } from 'react';
 
 import useNFT from '../../hooks/useNFT';
 import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
+import ipfsToGatewayUrl from '../../util/ipfs';
 
 export type NFTHashStatusProps = {
   nftId: string;
@@ -39,7 +40,9 @@ export default function NFTHashStatus(props: NFTHashStatusProps) {
     }
 
     if (nftPreview.uri) {
-      return isValidURL(nftPreview.uri);
+      // ipfs:// URIs are served through an HTTPS gateway by the cache layer,
+      // so validate the gateway form instead of flagging them as invalid.
+      return isValidURL(ipfsToGatewayUrl(nftPreview.uri));
     }
 
     return false;

--- a/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
@@ -174,12 +174,20 @@ export default function useMetadataData(props: UseMetadataDataProps) {
     // metadata fetch stayed cached here and its NFT kept looking broken
     // after enabling the option, until a full app reload. Only failures are
     // retried: successfully fetched metadata is hash-verified content and
-    // unaffected by how it was fetched.
+    // unaffected by how it was fetched. A fetch that is still in flight
+    // started under the old preference and may fail because of it — after
+    // this effect has run, nothing else would retry that failure — so it is
+    // retried on rejection; a result that arrives successfully is kept.
     metadatasOnDemand.forEach((metadataOnDemand, nftId) => {
-      if (metadataOnDemand.error) {
+      const retry = () =>
         invalidate(nftId).catch((e) => {
           log(`Error retrying metadata for nftId: ${nftId}`, e);
         });
+
+      if (metadataOnDemand.error) {
+        retry();
+      } else if (metadataOnDemand.promise) {
+        metadataOnDemand.promise.catch(retry);
       }
     });
   }, [ipfsGateway, invalidate /* immutable */, metadatasOnDemand /* immutable */]);

--- a/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
@@ -2,12 +2,13 @@ import { EventEmitter } from 'events';
 
 import { type NFTInfo } from '@chia-network/api';
 import debug from 'debug';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import type Metadata from '../../../../@types/Metadata';
 import type MetadataOnDemand from '../../../../@types/MetadataOnDemand';
 import type MetadataState from '../../../../@types/MetadataState';
 import useFetchAndProcessMetadata from '../../../../hooks/useFetchAndProcessMetadata';
+import useIpfsGateway from '../../../../hooks/useIpfsGateway';
 import getNFTId from '../../../../util/getNFTId';
 
 const log = debug('chia-gui:NFTProvider:useMetadataData');
@@ -158,6 +159,30 @@ export default function useMetadataData(props: UseMetadataDataProps) {
     },
     [getMetadata /* immutable */, metadatasOnDemand /* immutable */],
   );
+
+  const [ipfsGateway] = useIpfsGateway();
+  const lastIpfsGatewayRef = useRef(ipfsGateway);
+
+  useEffect(() => {
+    if (lastIpfsGatewayRef.current === ipfsGateway) {
+      return;
+    }
+    lastIpfsGatewayRef.current = ipfsGateway;
+
+    // Flipping the gateway option changes which URIs the main process will
+    // fetch, so cached failures are stale — without this, a failed ipfs
+    // metadata fetch stayed cached here and its NFT kept looking broken
+    // after enabling the option, until a full app reload. Only failures are
+    // retried: successfully fetched metadata is hash-verified content and
+    // unaffected by how it was fetched.
+    metadatasOnDemand.forEach((metadataOnDemand, nftId) => {
+      if (metadataOnDemand.error) {
+        invalidate(nftId).catch((e) => {
+          log(`Error retrying metadata for nftId: ${nftId}`, e);
+        });
+      }
+    });
+  }, [ipfsGateway, invalidate /* immutable */, metadatasOnDemand /* immutable */]);
 
   // immutable function
   const subscribeToMetadataChanges = useCallback(

--- a/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
@@ -178,7 +178,12 @@ export default function useMetadataData(props: UseMetadataDataProps) {
     // started under the old preference and may fail because of it — after
     // this effect has run, nothing else would retry that failure — so it is
     // retried on rejection; a result that arrives successfully is kept.
-    metadatasOnDemand.forEach((metadataOnDemand, nftId) => {
+    //
+    // Iterate a snapshot: retrying an errored entry re-inserts its key with a
+    // fresh in-flight promise synchronously, and Map.forEach revisits keys
+    // re-added during the pass — the live map would attach a rejection retry
+    // to the very fetch this effect just started, double-fetching a failure.
+    Array.from(metadatasOnDemand.entries()).forEach(([nftId, metadataOnDemand]) => {
       const retry = () =>
         invalidate(nftId).catch((e) => {
           log(`Error retrying metadata for nftId: ${nftId}`, e);
@@ -187,7 +192,16 @@ export default function useMetadataData(props: UseMetadataDataProps) {
       if (metadataOnDemand.error) {
         retry();
       } else if (metadataOnDemand.promise) {
-        metadataOnDemand.promise.catch(retry);
+        metadataOnDemand.promise.catch((e) => {
+          // Retry only the failure this handler saw. The fetch's own catch
+          // stores its rejection as the entry's error, so anything else here
+          // means the entry has moved on — a stacked handler from another
+          // toggle already retried it, or a newer fetch succeeded — and a
+          // retry would discard that state and fetch again for nothing.
+          if (metadatasOnDemand.get(nftId)?.error === e) {
+            retry();
+          }
+        });
       }
     });
   }, [ipfsGateway, invalidate /* immutable */, metadatasOnDemand /* immutable */]);

--- a/packages/gui/src/components/settings/SettingsNFT.tsx
+++ b/packages/gui/src/components/settings/SettingsNFT.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import useAllowUnverifiedNFTPreviews from '../../hooks/useAllowUnverifiedNFTPreviews';
 import useCache from '../../hooks/useCache';
 import useHideObjectionableContent from '../../hooks/useHideObjectionableContent';
+import useIpfsGateway from '../../hooks/useIpfsGateway';
 import useNFTImageFittingMode from '../../hooks/useNFTImageFittingMode';
 import { useNFTVideoLoopGlobal } from '../../hooks/useNFTVideoLoop';
 
@@ -41,6 +42,7 @@ export default function SettingsGeneral() {
   const { cacheSize, clearCache, cacheDirectory, setCacheDirectory } = useCache();
   const [nftImageFittingMode, setNFTImageFittingMode] = useNFTImageFittingMode();
   const [nftVideoLoop, setNFTVideoLoop] = useNFTVideoLoopGlobal();
+  const [ipfsGateway, setIpfsGateway] = useIpfsGateway();
   const [allowUnverifiedPreviews, setAllowUnverifiedPreviews] = useAllowUnverifiedNFTPreviews();
   // const [, setCacheFolder] = usePrefs('cacheFolder', '');
   const openDialog = useOpenDialog();
@@ -51,6 +53,10 @@ export default function SettingsGeneral() {
 
   function handleChangeVideoLoop(event: React.ChangeEvent<HTMLInputElement>) {
     setNFTVideoLoop(event.target.checked);
+  }
+
+  function handleChangeIpfsGateway(event: React.ChangeEvent<HTMLInputElement>) {
+    setIpfsGateway(event.target.checked);
   }
 
   function handleChangeAllowUnverifiedPreviews(event: React.ChangeEvent<HTMLInputElement>) {
@@ -145,6 +151,26 @@ export default function SettingsGeneral() {
             <Trans>
               All NFT videos will restart automatically when they finish playing. When disabled, looping can still be
               turned on for individual videos from their detail page.
+            </Trans>
+          </SettingsText>
+        </Grid>
+      </Grid>
+
+      <Grid container>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsTitle>
+            <Trans>Fetch IPFS content through a gateway</Trans>
+          </SettingsTitle>
+        </Grid>
+        <Grid item container xs justifyContent="flex-end" marginTop="-6px">
+          <FormControlLabel control={<Switch checked={ipfsGateway} onChange={handleChangeIpfsGateway} />} />
+        </Grid>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsText>
+            <Trans>
+              NFT files published with ipfs:// addresses will be downloaded through the public ipfs.io HTTPS gateway.
+              The requested URL differs from the address recorded on chain, but downloaded content is still verified
+              against the NFT's on-chain hash. When disabled, ipfs:// files are not fetched.
             </Trans>
           </SettingsText>
         </Grid>

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -17,6 +17,7 @@ jest.mock('./utils/downloadFile', () => ({
   __esModule: true,
   default: mockDownloadFile,
   MAX_FILE_SIZE_EXCEEDED_ERROR: 'Maximum file size exceeded',
+  isDownloadTimeoutError: jest.requireActual('./utils/downloadFile').isDownloadTimeoutError,
 }));
 
 jest.mock('./utils/ipcMainHandle', () => ({
@@ -123,6 +124,33 @@ describe('CacheManager eviction', () => {
     await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request timed out');
     await expect(cacheManager.getContent('https://example.com/nft.png')).rejects.toThrow('Request timed out');
     expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a timeout persisted by a previous session', async () => {
+    const payload = Buffer.from('cached payload');
+    mockDownloadFile.mockRejectedValue(new Error('Request timed out after 30000ms of inactivity'));
+
+    const firstSession = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await firstSession.init();
+    await expect(firstSession.getContent('https://example.com/nft.png')).rejects.toThrow('Request timed out');
+
+    mockDownloadFile.mockReset();
+    mockDownloadFile.mockImplementation(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return {
+        'content-type': 'image/png',
+      };
+    });
+
+    const secondSession = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await secondSession.init();
+    await expect(secondSession.getContent('https://example.com/nft.png')).resolves.toEqual(payload);
   });
 
   it('retries an aborted download on the next access', async () => {

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -15,7 +15,7 @@ import CacheState from '../constants/CacheState';
 import limit from '../util/limit';
 
 import CacheAPI from './constants/CacheAPI';
-import downloadFile, { MAX_FILE_SIZE_EXCEEDED_ERROR } from './utils/downloadFile';
+import downloadFile, { MAX_FILE_SIZE_EXCEEDED_ERROR, isDownloadTimeoutError } from './utils/downloadFile';
 import ensureDirectoryExists from './utils/ensureDirectoryExists';
 import getChecksum from './utils/getChecksum';
 import ipcMainHandle from './utils/ipcMainHandle';
@@ -113,6 +113,11 @@ export default class CacheManager extends EventEmitter {
       abort: () => void;
     }
   > = new Map();
+
+  // URLs whose download timed out during this session. A persisted timeout is
+  // retried once per session — the set keeps a stalled host from being retried
+  // (and holding a download slot) on every access within the same session.
+  private timedOutUrls: Set<string> = new Set();
 
   constructor(
     options: {
@@ -449,10 +454,14 @@ export default class CacheManager extends EventEmitter {
           log(`Url already downloaded with error: ${cacheInfo.error}`, url);
 
           const isTransientError = ['Response aborted', 'Request aborted'].includes(cacheInfo.error);
+          // A persisted timeout settles for the rest of the session, but is
+          // retried in later sessions — a one-off network problem must not
+          // disable the preview until the whole cache is cleared.
+          const isRetriableTimeout = isDownloadTimeoutError(cacheInfo.error) && !this.timedOutUrls.has(url);
           // A persisted size-limit error is only retried when the caller lifts
           // the limit, so oversized files are not re-downloaded on every visit.
           const isSizeLimitLifted = cacheInfo.error === MAX_FILE_SIZE_EXCEEDED_ERROR && maxSize <= 0;
-          if (!isTransientError && !isSizeLimitLifted) {
+          if (!isTransientError && !isRetriableTimeout && !isSizeLimitLifted) {
             return cacheInfo;
           }
 
@@ -517,6 +526,10 @@ export default class CacheManager extends EventEmitter {
         }
 
         const currentError = (error as Error) ?? new Error('Unknown fetchRemoteContent error');
+
+        if (isDownloadTimeoutError(currentError.message)) {
+          this.timedOutUrls.add(url);
+        }
 
         return await this.setCacheInfo(url, {
           state: CacheState.ERROR,

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -7,7 +7,6 @@ import path from 'node:path';
 import { Readable } from 'node:stream';
 
 import debug from 'debug';
-import isURL from 'validator/lib/isURL';
 
 import type CacheInfo from '../@types/CacheInfo';
 import type CacheInfoBase from '../@types/CacheInfoBase';
@@ -435,7 +434,7 @@ export default class CacheManager extends EventEmitter {
 
         const normalizedURL = decodeURI(url) === url ? encodeURI(url) : url;
 
-        if (!isURL(normalizedURL)) {
+        if (!isValidURL(normalizedURL)) {
           throw new Error(`Invalid URL: ${normalizedURL}`);
         }
 

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -19,6 +19,7 @@ import downloadFile, { MAX_FILE_SIZE_EXCEEDED_ERROR } from './utils/downloadFile
 import ensureDirectoryExists from './utils/ensureDirectoryExists';
 import getChecksum from './utils/getChecksum';
 import ipcMainHandle from './utils/ipcMainHandle';
+import { IpfsGatewayDisabledError } from './utils/ipfsGateway';
 import isValidURL from './utils/isValidURL';
 import sanitizeFilename from './utils/sanitizeFilename';
 import sanitizeNumber from './utils/sanitizeNumber';
@@ -506,6 +507,15 @@ export default class CacheManager extends EventEmitter {
 
         return await this.#downloadLimit<CacheInfo>(() => limitedRemoteFileDownload());
       } catch (error) {
+        // Not a property of the URL, just of the current preference: while
+        // the IPFS gateway option is off the fetch is refused before it
+        // starts. Persisting that as a cache error would keep the entry
+        // poisoned after the user turns the option on, so it propagates
+        // instead — already-cached content was served above regardless.
+        if (error instanceof IpfsGatewayDisabledError) {
+          throw error;
+        }
+
         const currentError = (error as Error) ?? new Error('Unknown fetchRemoteContent error');
 
         return await this.setCacheInfo(url, {

--- a/packages/gui/src/electron/api/nftGetMetadata.test.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.test.ts
@@ -11,6 +11,13 @@ jest.mock('../utils/fetchBuffer', () => ({
     jest.requireActual<typeof import('../utils/fetchBuffer')>('../utils/fetchBuffer').MaxSizeExceededError,
 }));
 
+const mockMaybeIpfsToGatewayUrl = jest.fn<string, [string]>();
+
+jest.mock('../utils/ipfsGateway', () => ({
+  __esModule: true,
+  default: mockMaybeIpfsToGatewayUrl,
+}));
+
 const mockAllowUnverifiedNftPreviews = jest.fn<boolean, []>();
 
 jest.mock('../utils/allowUnverifiedNftPreviews', () => ({
@@ -19,6 +26,8 @@ jest.mock('../utils/allowUnverifiedNftPreviews', () => ({
 }));
 
 const { MaxSizeExceededError } = jest.requireActual<typeof import('../utils/fetchBuffer')>('../utils/fetchBuffer');
+
+const ipfsToGatewayUrl = jest.requireActual<typeof import('../../util/ipfs')>('../../util/ipfs').default;
 
 const { nftGetImageDataUrl, nftGetMetadata } =
   jest.requireActual<typeof import('./nftGetMetadata')>('./nftGetMetadata');
@@ -66,6 +75,9 @@ describe('nftGetMetadata', () => {
 describe('nftGetImageDataUrl', () => {
   beforeEach(() => {
     mockFetchBuffer.mockReset();
+    mockMaybeIpfsToGatewayUrl.mockReset();
+    // gateway option off: URLs pass through untranslated
+    mockMaybeIpfsToGatewayUrl.mockImplementation((url) => url);
     mockAllowUnverifiedNftPreviews.mockReset();
     mockAllowUnverifiedNftPreviews.mockReturnValue(false);
   });
@@ -124,8 +136,9 @@ describe('nftGetImageDataUrl', () => {
     );
   });
 
-  it('falls back to the gateway URL for an oversized ipfs image when unverified previews are enabled', async () => {
+  it('falls back to the gateway URL for an oversized ipfs image when both options are on', async () => {
     mockAllowUnverifiedNftPreviews.mockReturnValue(true);
+    mockMaybeIpfsToGatewayUrl.mockImplementation(ipfsToGatewayUrl);
     mockFetchBuffer.mockRejectedValue(
       new MaxSizeExceededError({
         'content-type': 'image/gif',
@@ -137,6 +150,31 @@ describe('nftGetImageDataUrl', () => {
     await expect(nftGetImageDataUrl('ipfs://bafybeigdyrztest/large.gif', '00')).resolves.toBe(
       'https://ipfs.io/ipfs/bafybeigdyrztest/large.gif',
     );
+  });
+
+  it('omits the preview for an oversized ipfs image while the gateway option is off', async () => {
+    mockAllowUnverifiedNftPreviews.mockReturnValue(true);
+    mockFetchBuffer.mockRejectedValue(
+      new MaxSizeExceededError({
+        'content-type': 'image/gif',
+      }),
+    );
+
+    // an untranslated ipfs URI would be blocked by the dialog CSP, so no
+    // preview is returned at all even though unverified previews are allowed
+    await expect(nftGetImageDataUrl('ipfs://bafybeigdyrztest/large.gif', '00')).resolves.toBeUndefined();
+  });
+
+  it('omits the preview for an oversized ipfs image while unverified previews are off', async () => {
+    mockMaybeIpfsToGatewayUrl.mockImplementation(ipfsToGatewayUrl);
+    mockFetchBuffer.mockRejectedValue(
+      new MaxSizeExceededError({
+        'content-type': 'image/gif',
+      }),
+    );
+
+    // the gateway option alone does not opt into unverified fallbacks
+    await expect(nftGetImageDataUrl('ipfs://bafybeigdyrztest/large.gif', '00')).resolves.toBeUndefined();
   });
 
   it('rejects an oversized response that is not an image even when unverified previews are enabled', async () => {

--- a/packages/gui/src/electron/api/nftGetMetadata.test.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.test.ts
@@ -124,6 +124,21 @@ describe('nftGetImageDataUrl', () => {
     );
   });
 
+  it('falls back to the gateway URL for an oversized ipfs image when unverified previews are enabled', async () => {
+    mockAllowUnverifiedNftPreviews.mockReturnValue(true);
+    mockFetchBuffer.mockRejectedValue(
+      new MaxSizeExceededError({
+        'content-type': 'image/gif',
+      }),
+    );
+
+    // the dialog CSP only allows https: and data: images, so the raw ipfs
+    // URI would render as a broken image
+    await expect(nftGetImageDataUrl('ipfs://bafybeigdyrztest/large.gif', '00')).resolves.toBe(
+      'https://ipfs.io/ipfs/bafybeigdyrztest/large.gif',
+    );
+  });
+
   it('rejects an oversized response that is not an image even when unverified previews are enabled', async () => {
     mockAllowUnverifiedNftPreviews.mockReturnValue(true);
     mockFetchBuffer.mockRejectedValue(

--- a/packages/gui/src/electron/api/nftGetMetadata.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 
 import type Headers from '../../@types/Headers';
 import compareChecksums from '../../util/compareChecksums';
+import ipfsToGatewayUrl from '../../util/ipfs';
 import allowUnverifiedNftPreviews from '../utils/allowUnverifiedNftPreviews';
 import fetchBuffer, { MaxSizeExceededError } from '../utils/fetchBuffer';
 
@@ -103,8 +104,10 @@ export async function nftGetImageDataUrl(
     // behavior for these files. Off by default: the response's size and type
     // claims are attacker-controlled, so the fallback can be triggered
     // deliberately to place unverified content in a confirmation dialog.
+    // The CSP does not allow the ipfs: scheme either, so ipfs URIs fall back
+    // to their gateway form.
     if (error instanceof MaxSizeExceededError && getImageContentType(error.headers) && allowUnverifiedNftPreviews()) {
-      return imageUri;
+      return ipfsToGatewayUrl(imageUri);
     }
 
     // image previews are best effort — the confirmation dialog has a fallback

--- a/packages/gui/src/electron/api/nftGetMetadata.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.ts
@@ -2,9 +2,10 @@ import crypto from 'node:crypto';
 
 import type Headers from '../../@types/Headers';
 import compareChecksums from '../../util/compareChecksums';
-import ipfsToGatewayUrl from '../../util/ipfs';
+import { isIpfsUrl } from '../../util/ipfs';
 import allowUnverifiedNftPreviews from '../utils/allowUnverifiedNftPreviews';
 import fetchBuffer, { MaxSizeExceededError } from '../utils/fetchBuffer';
+import maybeIpfsToGatewayUrl from '../utils/ipfsGateway';
 
 const METADATA_TIMEOUT = 10_000;
 const METADATA_MAX_SIZE = 5 * 1024 * 1024;
@@ -105,9 +106,11 @@ export async function nftGetImageDataUrl(
     // claims are attacker-controlled, so the fallback can be triggered
     // deliberately to place unverified content in a confirmation dialog.
     // The CSP does not allow the ipfs: scheme either, so ipfs URIs fall back
-    // to their gateway form.
+    // to their gateway form, and only when the user has also enabled the
+    // gateway — otherwise they get no preview rather than a CSP-blocked URL.
     if (error instanceof MaxSizeExceededError && getImageContentType(error.headers) && allowUnverifiedNftPreviews()) {
-      return ipfsToGatewayUrl(imageUri);
+      const directUrl = maybeIpfsToGatewayUrl(imageUri);
+      return isIpfsUrl(directUrl) ? undefined : directUrl;
     }
 
     // image previews are best effort — the confirmation dialog has a fallback

--- a/packages/gui/src/electron/api/nftGetMetadata.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.ts
@@ -41,8 +41,9 @@ function hasExpectedChecksum(data: Buffer, expectedHash: string): boolean {
 export async function nftGetMetadata(
   metadataUri: string,
   expectedHash: string | undefined,
+  timeoutBudget: number = Number.POSITIVE_INFINITY,
 ): Promise<NftMetadata | undefined> {
-  if (!expectedHash) {
+  if (!expectedHash || timeoutBudget <= 0) {
     return undefined;
   }
 
@@ -51,7 +52,7 @@ export async function nftGetMetadata(
       headers: {
         Accept: 'application/json',
       },
-      timeout: METADATA_TIMEOUT,
+      timeout: Math.min(METADATA_TIMEOUT, timeoutBudget),
       maxSize: METADATA_MAX_SIZE,
     });
 
@@ -74,8 +75,9 @@ export async function nftGetMetadata(
 export async function nftGetImageDataUrl(
   imageUri: string,
   expectedHash: string | undefined,
+  timeoutBudget: number = Number.POSITIVE_INFINITY,
 ): Promise<string | undefined> {
-  if (!expectedHash) {
+  if (!expectedHash || timeoutBudget <= 0) {
     return undefined;
   }
 
@@ -84,7 +86,7 @@ export async function nftGetImageDataUrl(
       headers: {
         Accept: 'image/*',
       },
-      timeout: IMAGE_TIMEOUT,
+      timeout: Math.min(IMAGE_TIMEOUT, timeoutBudget),
       maxSize: IMAGE_MAX_SIZE,
     });
 

--- a/packages/gui/src/electron/api/nftGetMetadata.ts
+++ b/packages/gui/src/electron/api/nftGetMetadata.ts
@@ -20,7 +20,7 @@ export type NftMetadata = Record<string, unknown> & {
 };
 
 function checksum(data: Buffer): string {
-  return crypto.createHash('sha256').update(data.toString('latin1'), 'latin1').digest('hex');
+  return crypto.createHash('sha256').update(data).digest('hex');
 }
 
 function getImageContentType(headers: Headers): string | undefined {

--- a/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.test.ts
@@ -210,7 +210,7 @@ describe('parseCommandDisplay', () => {
       },
     });
     expect(mockNftGetInfo).toHaveBeenCalledWith(nftLauncherId);
-    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith('https://example.com/nft.png', 'data-hash');
+    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith('https://example.com/nft.png', 'data-hash', expect.any(Number));
   });
 
   it('uses the metadata preview image for a video NFT instead of the video data uri', async () => {
@@ -256,8 +256,16 @@ describe('parseCommandDisplay', () => {
         ],
       },
     });
-    expect(mockNftGetMetadata).toHaveBeenCalledWith('https://example.com/nft.json', 'metadata-hash');
-    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith('https://example.com/nft-preview.png', 'preview-image-hash');
+    expect(mockNftGetMetadata).toHaveBeenCalledWith(
+      'https://example.com/nft.json',
+      'metadata-hash',
+      expect.any(Number),
+    );
+    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith(
+      'https://example.com/nft-preview.png',
+      'preview-image-hash',
+      expect.any(Number),
+    );
   });
 
   it('tries later metadata URIs when an earlier fallback cannot be verified', async () => {
@@ -277,9 +285,34 @@ describe('parseCommandDisplay', () => {
     ).resolves.toBe('data:image/png;base64,cHJldmlldw==');
 
     expect(mockNftGetMetadata.mock.calls).toEqual([
-      ['https://example.com/unavailable.json', 'metadata-hash'],
-      ['https://example.com/verified.json', 'metadata-hash'],
+      ['https://example.com/unavailable.json', 'metadata-hash', expect.any(Number)],
+      ['https://example.com/verified.json', 'metadata-hash', expect.any(Number)],
     ]);
+  });
+
+  it('stops trying preview fallbacks once the overall resolution budget is spent', async () => {
+    let now = 1_700_000_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      mockNftGetMetadata.mockImplementation(async () => {
+        now += 25_000; // a slow host consumes the whole budget
+        return undefined;
+      });
+
+      await expect(
+        resolveNftPreviewUrl(
+          [],
+          undefined,
+          ['https://example.com/slow.json', 'https://example.com/never-tried.json'],
+          'metadata-hash',
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(mockNftGetMetadata).toHaveBeenCalledTimes(1);
+      expect(mockNftGetImageDataUrl).not.toHaveBeenCalled();
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('does not fetch confirmation previews that have no expected on-chain hash', async () => {
@@ -327,7 +360,11 @@ describe('parseCommandDisplay', () => {
     const line = result.walletDelta!.spending[0] as { kind: string; previewUrl?: string };
     expect(line.kind).toBe('nft');
     expect(line.previewUrl).toBeUndefined();
-    expect(mockNftGetMetadata).toHaveBeenCalledWith('https://example.com/nft.json', 'metadata-hash');
+    expect(mockNftGetMetadata).toHaveBeenCalledWith(
+      'https://example.com/nft.json',
+      'metadata-hash',
+      expect.any(Number),
+    );
   });
 
   it('uses an extensionless data uri as preview when metadata has no preview image', async () => {
@@ -370,7 +407,11 @@ describe('parseCommandDisplay', () => {
       },
     });
     expect(mockNftGetMetadata).not.toHaveBeenCalled();
-    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith('https://ipfs.example.com/bafybeigdyrztest', 'data-hash');
+    expect(mockNftGetImageDataUrl).toHaveBeenCalledWith(
+      'https://ipfs.example.com/bafybeigdyrztest',
+      'data-hash',
+      expect.any(Number),
+    );
   });
 
   it('shows the take-offer fungible total with NFT creator royalties', async () => {

--- a/packages/gui/src/electron/commands/parseCommandDisplay.ts
+++ b/packages/gui/src/electron/commands/parseCommandDisplay.ts
@@ -49,16 +49,31 @@ function hexToNftId(hex: string): string {
   }
 }
 
-async function resolveVerifiedImage(uris: string[], expectedHash: string | undefined): Promise<string | undefined> {
+// The confirmation dialog is not shown until preview resolution settles, so
+// every URI fallback for one NFT shares a single deadline — a long list of
+// dead or slow hosts must not hold the security dialog off screen for the
+// full per-fetch timeout each.
+const NFT_PREVIEW_RESOLUTION_BUDGET_MS = 20_000;
+
+async function resolveVerifiedImage(
+  uris: string[],
+  expectedHash: string | undefined,
+  deadline: number,
+): Promise<string | undefined> {
   if (!expectedHash) {
     return undefined;
   }
 
   for (const uri of uris) {
+    const timeLeft = deadline - Date.now();
+    if (timeLeft <= 0) {
+      return undefined;
+    }
+
     if (isValidURL(uri)) {
       // URI lists are ordered fallbacks for the same content.
       // eslint-disable-next-line no-await-in-loop -- Fallbacks must be tried in their declared order.
-      const dataUrl = await nftGetImageDataUrl(uri, expectedHash);
+      const dataUrl = await nftGetImageDataUrl(uri, expectedHash, timeLeft);
       if (dataUrl) {
         return dataUrl;
       }
@@ -78,11 +93,13 @@ export async function resolveNftPreviewUrl(
   metadataUris: string[],
   metadataHash: string | undefined,
 ): Promise<string | undefined> {
+  const deadline = Date.now() + NFT_PREVIEW_RESOLUTION_BUDGET_MS;
   const validDataUris = dataUris.filter((uri) => isValidURL(uri));
 
   const imageDataUrl = await resolveVerifiedImage(
     validDataUris.filter((uri) => getFileType(uri) === FileType.IMAGE),
     dataHash,
+    deadline,
   );
   if (imageDataUrl) {
     return imageDataUrl;
@@ -90,15 +107,21 @@ export async function resolveNftPreviewUrl(
 
   if (metadataHash) {
     for (const metadataUri of metadataUris) {
+      const timeLeft = deadline - Date.now();
+      if (timeLeft <= 0) {
+        break;
+      }
+
       if (isValidURL(metadataUri)) {
         // Metadata URIs are ordered fallbacks for the same on-chain hash.
         // eslint-disable-next-line no-await-in-loop -- Fallbacks must be tried in their declared order.
-        const metadata = await nftGetMetadata(metadataUri, metadataHash);
+        const metadata = await nftGetMetadata(metadataUri, metadataHash, timeLeft);
         if (metadata) {
           // eslint-disable-next-line no-await-in-loop -- Resolve each verified metadata fallback before moving on.
           const previewDataUrl = await resolveVerifiedImage(
             metadata.preview_image_uris ?? [],
             metadata.preview_image_hash,
+            deadline,
           );
           if (previewDataUrl) {
             return previewDataUrl;
@@ -114,6 +137,7 @@ export async function resolveNftPreviewUrl(
   return resolveVerifiedImage(
     validDataUris.filter((uri) => getFileType(uri) === FileType.UNKNOWN),
     dataHash,
+    deadline,
   );
 }
 

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -29,6 +29,7 @@ import type { PermissionsNotificationPayload } from '../@types/PermissionsServic
 import { WcError, WcErrorCode, encodeWcErrorForIpc } from '../@types/WcError';
 import AppIcon from '../assets/img/chia64x64.png';
 import { i18n } from '../config/locales';
+import ipfsToGatewayUrl from '../util/ipfs';
 
 import CacheManager, { CACHE_PROTOCOL } from './CacheManager';
 import { checkNFTOwnership } from './api/checkNFTOwnership';
@@ -575,7 +576,9 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
         return;
       }
 
-      mainWindow.webContents.downloadURL(urlLocal);
+      // Chromium's downloader cannot fetch the ipfs: scheme; download ipfs
+      // URIs through the HTTPS gateway like every other network path.
+      mainWindow.webContents.downloadURL(ipfsToGatewayUrl(urlLocal));
     });
 
     ipcMainHandle(AppAPI.START_MULTIPLE_DOWNLOAD, async (tasks: { url: string; filename: string }[]) => {

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -29,7 +29,6 @@ import type { PermissionsNotificationPayload } from '../@types/PermissionsServic
 import { WcError, WcErrorCode, encodeWcErrorForIpc } from '../@types/WcError';
 import AppIcon from '../assets/img/chia64x64.png';
 import { i18n } from '../config/locales';
-import ipfsToGatewayUrl from '../util/ipfs';
 
 import CacheManager, { CACHE_PROTOCOL } from './CacheManager';
 import { checkNFTOwnership } from './api/checkNFTOwnership';
@@ -62,6 +61,7 @@ import { dispatchPairRequest } from './utils/dispatchPairRequest';
 import downloadFile from './utils/downloadFile';
 import fetchJSON from './utils/fetchJSON';
 import ipcMainHandle from './utils/ipcMainHandle';
+import maybeIpfsToGatewayUrl from './utils/ipfsGateway';
 import isValidURL from './utils/isValidURL';
 import { loadConfig, checkConfigFileExists } from './utils/loadConfig';
 import { getDefaultLogPath, LogPathValidationError, resolveTrustedLogPath } from './utils/logPath';
@@ -576,9 +576,10 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
         return;
       }
 
-      // Chromium's downloader cannot fetch the ipfs: scheme; download ipfs
-      // URIs through the HTTPS gateway like every other network path.
-      mainWindow.webContents.downloadURL(ipfsToGatewayUrl(urlLocal));
+      // Chromium's downloader cannot fetch the ipfs: scheme; when the user
+      // has enabled the gateway, download ipfs URIs through it like every
+      // other network path.
+      mainWindow.webContents.downloadURL(maybeIpfsToGatewayUrl(urlLocal));
     });
 
     ipcMainHandle(AppAPI.START_MULTIPLE_DOWNLOAD, async (tasks: { url: string; filename: string }[]) => {

--- a/packages/gui/src/electron/main.tsx
+++ b/packages/gui/src/electron/main.tsx
@@ -29,6 +29,7 @@ import type { PermissionsNotificationPayload } from '../@types/PermissionsServic
 import { WcError, WcErrorCode, encodeWcErrorForIpc } from '../@types/WcError';
 import AppIcon from '../assets/img/chia64x64.png';
 import { i18n } from '../config/locales';
+import { isIpfsUrl } from '../util/ipfs';
 
 import CacheManager, { CACHE_PROTOCOL } from './CacheManager';
 import { checkNFTOwnership } from './api/checkNFTOwnership';
@@ -578,8 +579,15 @@ if (ensureSingleInstance() && ensureCorrectEnvironment()) {
 
       // Chromium's downloader cannot fetch the ipfs: scheme; when the user
       // has enabled the gateway, download ipfs URIs through it like every
-      // other network path.
-      mainWindow.webContents.downloadURL(maybeIpfsToGatewayUrl(urlLocal));
+      // other network path. With the option off there is nothing the
+      // downloader could fetch, so the request is dropped instead of handing
+      // Chromium a URL it silently fails on.
+      const downloadUrl = maybeIpfsToGatewayUrl(urlLocal);
+      if (isIpfsUrl(downloadUrl)) {
+        return;
+      }
+
+      mainWindow.webContents.downloadURL(downloadUrl);
     });
 
     ipcMainHandle(AppAPI.START_MULTIPLE_DOWNLOAD, async (tasks: { url: string; filename: string }[]) => {

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -4,9 +4,9 @@ import { promises as fs, createWriteStream, type WriteStream } from 'node:fs';
 import debug from 'debug';
 
 import type Headers from '../../@types/Headers';
-import ipfsToGatewayUrl from '../../util/ipfs';
 
 import fileExists from './fileExists';
+import maybeIpfsToGatewayUrl from './ipfsGateway';
 import isValidURL from './isValidURL';
 
 const log = debug('chia-gui:downloadFile');
@@ -101,10 +101,11 @@ export default async function downloadFile(
   }
 
   const tempFilePath = `${localPath}.tmp`;
-  // ipfs:// URIs are fetched through an HTTPS gateway — Electron's net stack
-  // cannot request the ipfs scheme. Only this outgoing request uses the
-  // translated URL; callers keep the original URI as the cache key.
-  const request = net.request(ipfsToGatewayUrl(url));
+  // ipfs:// URIs are fetched through an HTTPS gateway when the user has
+  // enabled it — Electron's net stack cannot request the ipfs scheme. Only
+  // this outgoing request uses the translated URL; callers keep the original
+  // URI as the cache key.
+  const request = net.request(maybeIpfsToGatewayUrl(url));
   const outputStream = new WriteStreamPromise(tempFilePath, overrideFile);
 
   // set when we abort the request ourselves, so abort events can be reported

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -66,6 +66,15 @@ class WriteStreamPromise {
 
 export const MAX_FILE_SIZE_EXCEEDED_ERROR = 'Maximum file size exceeded';
 
+const INACTIVITY_TIMEOUT_ERROR_PREFIX = 'Request timed out after';
+const DOWNLOAD_DEADLINE_ERROR_PREFIX = 'Request exceeded the';
+
+/** Matches the messages of both timeout errors below, including messages that
+ * earlier sessions persisted into cache `-info` files. */
+export function isDownloadTimeoutError(message: string): boolean {
+  return message.startsWith(INACTIVITY_TIMEOUT_ERROR_PREFIX) || message.startsWith(DOWNLOAD_DEADLINE_ERROR_PREFIX);
+}
+
 type DownloadFileOptions = {
   timeout?: number;
   maxDuration?: number; // absolute cap on the whole transfer
@@ -136,7 +145,7 @@ export default async function downloadFile(
     }
 
     timeoutId = setTimeout(
-      () => abortWithError(new Error(`Request timed out after ${timeout}ms of inactivity`)),
+      () => abortWithError(new Error(`${INACTIVITY_TIMEOUT_ERROR_PREFIX} ${timeout}ms of inactivity`)),
       timeout,
     );
   }
@@ -144,7 +153,7 @@ export default async function downloadFile(
   // absolute deadline for the whole transfer — the inactivity timeout alone
   // would let a host trickling bytes hold a download slot forever
   const maxDurationTimeoutId = setTimeout(
-    () => abortWithError(new Error(`Request exceeded the ${maxDuration}ms download deadline`)),
+    () => abortWithError(new Error(`${DOWNLOAD_DEADLINE_ERROR_PREFIX} ${maxDuration}ms download deadline`)),
     maxDuration,
   );
 

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -6,7 +6,7 @@ import debug from 'debug';
 import type Headers from '../../@types/Headers';
 
 import fileExists from './fileExists';
-import maybeIpfsToGatewayUrl from './ipfsGateway';
+import { toFetchableUrl } from './ipfsGateway';
 import isValidURL from './isValidURL';
 
 const log = debug('chia-gui:downloadFile');
@@ -102,10 +102,11 @@ export default async function downloadFile(
 
   const tempFilePath = `${localPath}.tmp`;
   // ipfs:// URIs are fetched through an HTTPS gateway when the user has
-  // enabled it — Electron's net stack cannot request the ipfs scheme. Only
+  // enabled it — Electron's net stack cannot request the ipfs scheme, and
+  // with the option off toFetchableUrl refuses the fetch outright. Only
   // this outgoing request uses the translated URL; callers keep the original
   // URI as the cache key.
-  const request = net.request(maybeIpfsToGatewayUrl(url));
+  const request = net.request(toFetchableUrl(url));
   const outputStream = new WriteStreamPromise(tempFilePath, overrideFile);
 
   // set when we abort the request ourselves, so abort events can be reported

--- a/packages/gui/src/electron/utils/downloadFile.ts
+++ b/packages/gui/src/electron/utils/downloadFile.ts
@@ -4,6 +4,7 @@ import { promises as fs, createWriteStream, type WriteStream } from 'node:fs';
 import debug from 'debug';
 
 import type Headers from '../../@types/Headers';
+import ipfsToGatewayUrl from '../../util/ipfs';
 
 import fileExists from './fileExists';
 import isValidURL from './isValidURL';
@@ -100,7 +101,10 @@ export default async function downloadFile(
   }
 
   const tempFilePath = `${localPath}.tmp`;
-  const request = net.request(url);
+  // ipfs:// URIs are fetched through an HTTPS gateway — Electron's net stack
+  // cannot request the ipfs scheme. Only this outgoing request uses the
+  // translated URL; callers keep the original URI as the cache key.
+  const request = net.request(ipfsToGatewayUrl(url));
   const outputStream = new WriteStreamPromise(tempFilePath, overrideFile);
 
   // set when we abort the request ourselves, so abort events can be reported

--- a/packages/gui/src/electron/utils/fetchBuffer.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.ts
@@ -102,7 +102,7 @@ export default async function fetchBuffer(
         }
       }
 
-      const chunks: Uint8Array[] = [];
+      const chunks: Buffer[] = [];
       let dataSize = 0;
 
       response.on('data', (chunk: Buffer) => {
@@ -110,14 +110,13 @@ export default async function fetchBuffer(
           return;
         }
 
-        const buffer = Uint8Array.from(chunk);
-        dataSize += buffer.byteLength;
+        dataSize += chunk.byteLength;
         if (maxSize > 0 && dataSize > maxSize) {
           abortWith(new MaxSizeExceededError(response.headers as Headers));
           return;
         }
 
-        chunks.push(buffer);
+        chunks.push(chunk);
       });
 
       response.on('end', () => {

--- a/packages/gui/src/electron/utils/fetchBuffer.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.ts
@@ -1,8 +1,8 @@
 import { net, type IncomingMessage } from 'electron';
 
 import type Headers from '../../@types/Headers';
-import ipfsToGatewayUrl from '../../util/ipfs';
 
+import maybeIpfsToGatewayUrl from './ipfsGateway';
 import isValidURL from './isValidURL';
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // 10 minutes
@@ -42,9 +42,9 @@ export default async function fetchBuffer(
 
   const request = net.request({
     method: 'GET',
-    // ipfs:// URIs are fetched through an HTTPS gateway — Electron's net
-    // stack cannot request the ipfs scheme.
-    url: ipfsToGatewayUrl(url),
+    // ipfs:// URIs are fetched through an HTTPS gateway when the user has
+    // enabled it — Electron's net stack cannot request the ipfs scheme.
+    url: maybeIpfsToGatewayUrl(url),
     headers,
   });
 

--- a/packages/gui/src/electron/utils/fetchBuffer.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.ts
@@ -1,6 +1,7 @@
 import { net, type IncomingMessage } from 'electron';
 
 import type Headers from '../../@types/Headers';
+import ipfsToGatewayUrl from '../../util/ipfs';
 
 import isValidURL from './isValidURL';
 
@@ -41,7 +42,9 @@ export default async function fetchBuffer(
 
   const request = net.request({
     method: 'GET',
-    url,
+    // ipfs:// URIs are fetched through an HTTPS gateway — Electron's net
+    // stack cannot request the ipfs scheme.
+    url: ipfsToGatewayUrl(url),
     headers,
   });
 

--- a/packages/gui/src/electron/utils/fetchBuffer.ts
+++ b/packages/gui/src/electron/utils/fetchBuffer.ts
@@ -2,7 +2,7 @@ import { net, type IncomingMessage } from 'electron';
 
 import type Headers from '../../@types/Headers';
 
-import maybeIpfsToGatewayUrl from './ipfsGateway';
+import { toFetchableUrl } from './ipfsGateway';
 import isValidURL from './isValidURL';
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // 10 minutes
@@ -43,8 +43,9 @@ export default async function fetchBuffer(
   const request = net.request({
     method: 'GET',
     // ipfs:// URIs are fetched through an HTTPS gateway when the user has
-    // enabled it — Electron's net stack cannot request the ipfs scheme.
-    url: maybeIpfsToGatewayUrl(url),
+    // enabled it — Electron's net stack cannot request the ipfs scheme, and
+    // with the option off toFetchableUrl refuses the fetch outright.
+    url: toFetchableUrl(url),
     headers,
   });
 

--- a/packages/gui/src/electron/utils/fetchJSON.ts
+++ b/packages/gui/src/electron/utils/fetchJSON.ts
@@ -1,7 +1,6 @@
 import { net, IncomingMessage } from 'electron';
 
-import ipfsToGatewayUrl from '../../util/ipfs';
-
+import maybeIpfsToGatewayUrl from './ipfsGateway';
 import isValidURL from './isValidURL';
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // 10 minutes
@@ -19,9 +18,9 @@ export default async function fetchJSON<TData>(
 
   const request = net.request({
     method,
-    // ipfs:// URIs are fetched through an HTTPS gateway — Electron's net
-    // stack cannot request the ipfs scheme.
-    url: ipfsToGatewayUrl(url),
+    // ipfs:// URIs are fetched through an HTTPS gateway when the user has
+    // enabled it — Electron's net stack cannot request the ipfs scheme.
+    url: maybeIpfsToGatewayUrl(url),
     headers,
   });
 

--- a/packages/gui/src/electron/utils/fetchJSON.ts
+++ b/packages/gui/src/electron/utils/fetchJSON.ts
@@ -1,5 +1,7 @@
 import { net, IncomingMessage } from 'electron';
 
+import ipfsToGatewayUrl from '../../util/ipfs';
+
 import isValidURL from './isValidURL';
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // 10 minutes
@@ -17,7 +19,9 @@ export default async function fetchJSON<TData>(
 
   const request = net.request({
     method,
-    url,
+    // ipfs:// URIs are fetched through an HTTPS gateway — Electron's net
+    // stack cannot request the ipfs scheme.
+    url: ipfsToGatewayUrl(url),
     headers,
   });
 

--- a/packages/gui/src/electron/utils/fetchJSON.ts
+++ b/packages/gui/src/electron/utils/fetchJSON.ts
@@ -1,6 +1,6 @@
 import { net, IncomingMessage } from 'electron';
 
-import maybeIpfsToGatewayUrl from './ipfsGateway';
+import { toFetchableUrl } from './ipfsGateway';
 import isValidURL from './isValidURL';
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // 10 minutes
@@ -19,8 +19,9 @@ export default async function fetchJSON<TData>(
   const request = net.request({
     method,
     // ipfs:// URIs are fetched through an HTTPS gateway when the user has
-    // enabled it — Electron's net stack cannot request the ipfs scheme.
-    url: maybeIpfsToGatewayUrl(url),
+    // enabled it — Electron's net stack cannot request the ipfs scheme, and
+    // with the option off toFetchableUrl refuses the fetch outright.
+    url: toFetchableUrl(url),
     headers,
   });
 

--- a/packages/gui/src/electron/utils/ipfsGateway.test.ts
+++ b/packages/gui/src/electron/utils/ipfsGateway.test.ts
@@ -7,6 +7,8 @@ jest.mock('../prefs', () => ({
 const {
   default: maybeIpfsToGatewayUrl,
   ipfsGatewayEnabled,
+  toFetchableUrl,
+  IpfsGatewayDisabledError,
   NFT_IPFS_GATEWAY_PREF,
 } = jest.requireActual<typeof import('./ipfsGateway')>('./ipfsGateway');
 
@@ -61,6 +63,33 @@ describe('maybeIpfsToGatewayUrl', () => {
 
     expect(maybeIpfsToGatewayUrl('ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png')).toBe(
       'https://ipfs.io/ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png',
+    );
+  });
+});
+
+describe('toFetchableUrl', () => {
+  beforeEach(() => {
+    mockReadPrefs.mockReset();
+  });
+
+  it('passes non-ipfs URLs through without consulting the preferences store', () => {
+    expect(toFetchableUrl('https://example.com/image.png')).toBe('https://example.com/image.png');
+    expect(mockReadPrefs).not.toHaveBeenCalled();
+  });
+
+  it('translates ipfs URIs when the gateway option is on', () => {
+    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: true });
+
+    expect(toFetchableUrl('ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png')).toBe(
+      'https://ipfs.io/ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png',
+    );
+  });
+
+  it('refuses ipfs URIs while the gateway option is off', () => {
+    mockReadPrefs.mockReturnValue({});
+
+    expect(() => toFetchableUrl('ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB')).toThrow(
+      IpfsGatewayDisabledError,
     );
   });
 });

--- a/packages/gui/src/electron/utils/ipfsGateway.test.ts
+++ b/packages/gui/src/electron/utils/ipfsGateway.test.ts
@@ -1,0 +1,66 @@
+const mockReadPrefs = jest.fn<Record<string, any>, []>();
+
+jest.mock('../prefs', () => ({
+  readPrefs: mockReadPrefs,
+}));
+
+const {
+  default: maybeIpfsToGatewayUrl,
+  ipfsGatewayEnabled,
+  NFT_IPFS_GATEWAY_PREF,
+} = jest.requireActual<typeof import('./ipfsGateway')>('./ipfsGateway');
+
+describe('ipfsGatewayEnabled', () => {
+  beforeEach(() => {
+    mockReadPrefs.mockReset();
+  });
+
+  it('is disabled when the preference has never been set', () => {
+    mockReadPrefs.mockReturnValue({});
+
+    expect(ipfsGatewayEnabled()).toBe(false);
+  });
+
+  it('is enabled only by an explicit boolean true', () => {
+    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: true });
+    expect(ipfsGatewayEnabled()).toBe(true);
+
+    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: 'true' });
+    expect(ipfsGatewayEnabled()).toBe(false);
+  });
+
+  it('fails closed when the preferences store cannot be read', () => {
+    mockReadPrefs.mockImplementation(() => {
+      throw new Error('userDataDir needs to be initialized');
+    });
+
+    expect(ipfsGatewayEnabled()).toBe(false);
+  });
+});
+
+describe('maybeIpfsToGatewayUrl', () => {
+  beforeEach(() => {
+    mockReadPrefs.mockReset();
+  });
+
+  it('never consults the preferences store for non-ipfs URLs', () => {
+    expect(maybeIpfsToGatewayUrl('https://example.com/image.png')).toBe('https://example.com/image.png');
+    expect(mockReadPrefs).not.toHaveBeenCalled();
+  });
+
+  it('leaves ipfs URIs untranslated while the gateway option is off', () => {
+    mockReadPrefs.mockReturnValue({});
+
+    expect(maybeIpfsToGatewayUrl('ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB')).toBe(
+      'ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB',
+    );
+  });
+
+  it('translates ipfs URIs when the gateway option is on', () => {
+    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: true });
+
+    expect(maybeIpfsToGatewayUrl('ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png')).toBe(
+      'https://ipfs.io/ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png',
+    );
+  });
+});

--- a/packages/gui/src/electron/utils/ipfsGateway.ts
+++ b/packages/gui/src/electron/utils/ipfsGateway.ts
@@ -1,0 +1,32 @@
+import ipfsToGatewayUrl, { isIpfsUrl } from '../../util/ipfs';
+import { readPrefs } from '../prefs';
+
+// Preference key shared with the renderer's useIpfsGateway hook. The renderer
+// persists it through PreferencesAPI.SAVE into prefs.yaml, which is the copy
+// consulted here in the main process.
+export const NFT_IPFS_GATEWAY_PREF = 'nftIpfsGateway';
+
+// Whether ipfs:// NFT resources may be fetched through the public HTTPS
+// gateway. Off by default: the gateway URL is not the URI recorded on chain,
+// so the translation is a user-selectable opt-in. Fails closed when the
+// preferences store is unreadable (e.g. before userData is initialized).
+export function ipfsGatewayEnabled(): boolean {
+  try {
+    return readPrefs()[NFT_IPFS_GATEWAY_PREF] === true;
+  } catch {
+    return false;
+  }
+}
+
+// Translates an ipfs:// URI to its HTTPS gateway equivalent only when the
+// user has enabled gateway fetching; every other URL — and every ipfs URI
+// while the option is off — is returned unchanged, so this can wrap any URL
+// right where it reaches the network layer. The ipfs check runs first so the
+// hot non-ipfs paths never touch the preferences store.
+export default function maybeIpfsToGatewayUrl(url: string): string {
+  if (!isIpfsUrl(url) || !ipfsGatewayEnabled()) {
+    return url;
+  }
+
+  return ipfsToGatewayUrl(url);
+}

--- a/packages/gui/src/electron/utils/ipfsGateway.ts
+++ b/packages/gui/src/electron/utils/ipfsGateway.ts
@@ -30,3 +30,27 @@ export default function maybeIpfsToGatewayUrl(url: string): string {
 
   return ipfsToGatewayUrl(url);
 }
+
+// Thrown instead of attempting a fetch that cannot happen: with the gateway
+// option off there is no URL Electron's net stack could request for an
+// ipfs:// URI. CacheManager treats this error as non-persistent — flipping
+// the option on must retry cleanly, so it never poisons a cache entry.
+export class IpfsGatewayDisabledError extends Error {
+  constructor() {
+    super('IPFS gateway fetching is disabled');
+    this.name = 'IpfsGatewayDisabledError';
+  }
+}
+
+// The URL the network layer may actually request. The gateway option gates
+// only fetching: structural URL validation and serving already-cached content
+// stay independent of it, so every network call site funnels through here
+// instead of checking the option itself.
+export function toFetchableUrl(url: string): string {
+  const requestUrl = maybeIpfsToGatewayUrl(url);
+  if (isIpfsUrl(requestUrl)) {
+    throw new IpfsGatewayDisabledError();
+  }
+
+  return requestUrl;
+}

--- a/packages/gui/src/electron/utils/isValidURL.test.ts
+++ b/packages/gui/src/electron/utils/isValidURL.test.ts
@@ -5,7 +5,6 @@ jest.mock('../prefs', () => ({
 }));
 
 const isValidURL = jest.requireActual<typeof import('./isValidURL')>('./isValidURL').default;
-const { NFT_IPFS_GATEWAY_PREF } = jest.requireActual<typeof import('./ipfsGateway')>('./ipfsGateway');
 
 describe('isValidURL', () => {
   beforeEach(() => {
@@ -23,23 +22,18 @@ describe('isValidURL', () => {
     expect(isValidURL('ftp://example.com/image.png')).toBe(false);
   });
 
-  it('accepts ipfs:// URIs with a CID host when the gateway option is on', () => {
-    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: true });
-
+  it('accepts ipfs:// URIs with a CID host regardless of the gateway option', () => {
     // validator's isURL rejects CID hosts (no TLD), so these pass only via
-    // the gateway translation
+    // the gateway-form translation. The check is structural on purpose: the
+    // gateway option gates fetching (toFetchableUrl), not validity — cache
+    // lookups for already-downloaded ipfs content must keep working while
+    // the option is off.
     expect(isValidURL('ipfs://bafybeiceg2gltyhlkukwetn26k7t2zdvthg4u4c6uj23rpni2adzgvo5si/020.png')).toBe(true);
     expect(isValidURL('ipfs://ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB')).toBe(true);
-  });
-
-  it('rejects ipfs:// URIs while the gateway option is off', () => {
-    expect(isValidURL('ipfs://bafybeiceg2gltyhlkukwetn26k7t2zdvthg4u4c6uj23rpni2adzgvo5si/020.png')).toBe(false);
-    expect(isValidURL('ipfs://ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB')).toBe(false);
+    expect(mockReadPrefs).not.toHaveBeenCalled();
   });
 
   it('rejects a bare ipfs scheme and non-strings', () => {
-    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: true });
-
     expect(isValidURL('ipfs://')).toBe(false);
     expect(isValidURL(undefined as unknown as string)).toBe(false);
   });

--- a/packages/gui/src/electron/utils/isValidURL.test.ts
+++ b/packages/gui/src/electron/utils/isValidURL.test.ts
@@ -1,0 +1,25 @@
+import isValidURL from './isValidURL';
+
+describe('isValidURL', () => {
+  it('accepts https URLs', () => {
+    expect(isValidURL('https://example.com/image.png')).toBe(true);
+  });
+
+  it('requires the protocol and rejects non-https schemes', () => {
+    expect(isValidURL('example.com/image.png')).toBe(false);
+    expect(isValidURL('http://example.com/image.png')).toBe(false);
+    expect(isValidURL('ftp://example.com/image.png')).toBe(false);
+  });
+
+  it('accepts ipfs:// URIs with a CID host', () => {
+    // validator's isURL rejects CID hosts (no TLD), so these pass only via
+    // the gateway translation
+    expect(isValidURL('ipfs://bafybeiceg2gltyhlkukwetn26k7t2zdvthg4u4c6uj23rpni2adzgvo5si/020.png')).toBe(true);
+    expect(isValidURL('ipfs://ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB')).toBe(true);
+  });
+
+  it('rejects a bare ipfs scheme and non-strings', () => {
+    expect(isValidURL('ipfs://')).toBe(false);
+    expect(isValidURL(undefined as unknown as string)).toBe(false);
+  });
+});

--- a/packages/gui/src/electron/utils/isValidURL.test.ts
+++ b/packages/gui/src/electron/utils/isValidURL.test.ts
@@ -1,6 +1,18 @@
-import isValidURL from './isValidURL';
+const mockReadPrefs = jest.fn<Record<string, any>, []>();
+
+jest.mock('../prefs', () => ({
+  readPrefs: mockReadPrefs,
+}));
+
+const isValidURL = jest.requireActual<typeof import('./isValidURL')>('./isValidURL').default;
+const { NFT_IPFS_GATEWAY_PREF } = jest.requireActual<typeof import('./ipfsGateway')>('./ipfsGateway');
 
 describe('isValidURL', () => {
+  beforeEach(() => {
+    mockReadPrefs.mockReset();
+    mockReadPrefs.mockReturnValue({});
+  });
+
   it('accepts https URLs', () => {
     expect(isValidURL('https://example.com/image.png')).toBe(true);
   });
@@ -11,14 +23,23 @@ describe('isValidURL', () => {
     expect(isValidURL('ftp://example.com/image.png')).toBe(false);
   });
 
-  it('accepts ipfs:// URIs with a CID host', () => {
+  it('accepts ipfs:// URIs with a CID host when the gateway option is on', () => {
+    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: true });
+
     // validator's isURL rejects CID hosts (no TLD), so these pass only via
     // the gateway translation
     expect(isValidURL('ipfs://bafybeiceg2gltyhlkukwetn26k7t2zdvthg4u4c6uj23rpni2adzgvo5si/020.png')).toBe(true);
     expect(isValidURL('ipfs://ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB')).toBe(true);
   });
 
+  it('rejects ipfs:// URIs while the gateway option is off', () => {
+    expect(isValidURL('ipfs://bafybeiceg2gltyhlkukwetn26k7t2zdvthg4u4c6uj23rpni2adzgvo5si/020.png')).toBe(false);
+    expect(isValidURL('ipfs://ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB')).toBe(false);
+  });
+
   it('rejects a bare ipfs scheme and non-strings', () => {
+    mockReadPrefs.mockReturnValue({ [NFT_IPFS_GATEWAY_PREF]: true });
+
     expect(isValidURL('ipfs://')).toBe(false);
     expect(isValidURL(undefined as unknown as string)).toBe(false);
   });

--- a/packages/gui/src/electron/utils/isValidURL.ts
+++ b/packages/gui/src/electron/utils/isValidURL.ts
@@ -1,9 +1,15 @@
 import isURL from 'validator/lib/isURL';
 
+import ipfsToGatewayUrl from '../../util/ipfs';
+
 export default function isValidURL(url: string) {
   if (typeof url !== 'string') {
     return false;
   }
 
-  return isURL(url, { protocols: ['https', 'ipfs'], require_protocol: true });
+  // isURL applies an FQDN check to the host, which every ipfs://<CID> URI
+  // fails (a CID has no top-level domain), so listing 'ipfs' as an allowed
+  // protocol is not enough. Validate the HTTPS gateway form instead — it is
+  // also the URL the network layer will actually request.
+  return isURL(ipfsToGatewayUrl(url), { protocols: ['https'], require_protocol: true });
 }

--- a/packages/gui/src/electron/utils/isValidURL.ts
+++ b/packages/gui/src/electron/utils/isValidURL.ts
@@ -1,6 +1,6 @@
 import isURL from 'validator/lib/isURL';
 
-import ipfsToGatewayUrl from '../../util/ipfs';
+import maybeIpfsToGatewayUrl from './ipfsGateway';
 
 export default function isValidURL(url: string) {
   if (typeof url !== 'string') {
@@ -9,7 +9,9 @@ export default function isValidURL(url: string) {
 
   // isURL applies an FQDN check to the host, which every ipfs://<CID> URI
   // fails (a CID has no top-level domain), so listing 'ipfs' as an allowed
-  // protocol is not enough. Validate the HTTPS gateway form instead — it is
-  // also the URL the network layer will actually request.
-  return isURL(ipfsToGatewayUrl(url), { protocols: ['https'], require_protocol: true });
+  // protocol is not enough. When the user has enabled gateway fetching,
+  // validate the HTTPS gateway form instead — it is also the URL the network
+  // layer will actually request; while the option is off, ipfs URIs stay
+  // invalid and are never fetched.
+  return isURL(maybeIpfsToGatewayUrl(url), { protocols: ['https'], require_protocol: true });
 }

--- a/packages/gui/src/electron/utils/isValidURL.ts
+++ b/packages/gui/src/electron/utils/isValidURL.ts
@@ -1,7 +1,15 @@
 import isURL from 'validator/lib/isURL';
 
-import maybeIpfsToGatewayUrl from './ipfsGateway';
+import ipfsToGatewayUrl, { isIpfsUrl } from '../../util/ipfs';
 
+// Structural validation only — deliberately independent of the IPFS gateway
+// preference. CacheManager consults this check before every cache path
+// lookup, so tying it to the preference would strand content that was
+// downloaded and hash-verified while the option was on: the cached bytes
+// could no longer be served, checksummed, or evicted after switching it off,
+// even though serving a local file involves no gateway request. Whether an
+// ipfs URI may actually be FETCHED is decided at the network call sites via
+// toFetchableUrl (electron/utils/ipfsGateway.ts).
 export default function isValidURL(url: string) {
   if (typeof url !== 'string') {
     return false;
@@ -9,9 +17,6 @@ export default function isValidURL(url: string) {
 
   // isURL applies an FQDN check to the host, which every ipfs://<CID> URI
   // fails (a CID has no top-level domain), so listing 'ipfs' as an allowed
-  // protocol is not enough. When the user has enabled gateway fetching,
-  // validate the HTTPS gateway form instead — it is also the URL the network
-  // layer will actually request; while the option is off, ipfs URIs stay
-  // invalid and are never fetched.
-  return isURL(maybeIpfsToGatewayUrl(url), { protocols: ['https'], require_protocol: true });
+  // protocol is not enough — validate the HTTPS gateway form instead.
+  return isURL(isIpfsUrl(url) ? ipfsToGatewayUrl(url) : url, { protocols: ['https'], require_protocol: true });
 }

--- a/packages/gui/src/hooks/useIpfsGateway.ts
+++ b/packages/gui/src/hooks/useIpfsGateway.ts
@@ -1,0 +1,13 @@
+import { usePrefs } from '@chia-network/api-react';
+
+// When enabled, NFT resources published with ipfs:// URIs are fetched through
+// the public HTTPS gateway; the requested URL then differs from the URI
+// recorded on chain, which is why this is a user-selectable opt-in (off by
+// default — ipfs:// resources are simply not fetched). Downloaded content is
+// still verified against the NFT's on-chain hash either way. The main process
+// reads the persisted copy of this preference at every network call site
+// (electron/utils/ipfsGateway.ts); keep the key in sync with
+// NFT_IPFS_GATEWAY_PREF there.
+export default function useIpfsGateway() {
+  return usePrefs<boolean>('nftIpfsGateway', false);
+}

--- a/packages/gui/src/hooks/useNFTVerifyHash.ts
+++ b/packages/gui/src/hooks/useNFTVerifyHash.ts
@@ -7,6 +7,7 @@ import compareChecksums from '../util/compareChecksums';
 
 import selectNFTPreviewState, { type NFTPreviewState } from './selectNFTPreviewState';
 import useCache from './useCache';
+import useIpfsGateway from './useIpfsGateway';
 import useNFT from './useNFT';
 import useNFTMetadata from './useNFTMetadata';
 
@@ -21,6 +22,11 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
   const { preview = false, ignoreSizeLimit = false } = options;
 
   const { getChecksum } = useCache();
+  // Not read directly: the value changes which URIs the main process will
+  // fetch at all, so both verification effects list it as a dependency and
+  // re-run when the user flips the option — without this, NFTs already on
+  // screen would keep their failed state until a remount.
+  const [ipfsGateway] = useIpfsGateway();
 
   const { nft, isLoading: isLoadingNFT, error: errorNFT } = useNFT(nftId);
   const { isLoading: isLoadingMetadata, metadata, error: errorMetadata } = useNFTMetadata(nftId);
@@ -201,7 +207,7 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
         dataGeneration.current += 1;
       }
     };
-  }, [nft, isLoadingNFT, validateData]);
+  }, [nft, isLoadingNFT, validateData, ipfsGateway]);
 
   useEffect(() => {
     const generation = previewGeneration.current + 1;
@@ -227,7 +233,7 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
         previewGeneration.current += 1;
       }
     };
-  }, [preview, nft, metadata, isLoadingNFT, isLoadingMetadata, validatePreview]);
+  }, [preview, nft, metadata, isLoadingNFT, isLoadingMetadata, validatePreview, ipfsGateway]);
 
   const previewState = useMemo(
     () =>

--- a/packages/gui/src/hooks/useNFTVideoLoop.tsx
+++ b/packages/gui/src/hooks/useNFTVideoLoop.tsx
@@ -34,11 +34,6 @@ export function useNFTVideoLoopForNFT(nftId: string): [boolean, (loopVideo: bool
   return [loop, setLoop];
 }
 
-// The effective looping state for one NFT video: the global preference forces
-// looping on when set, but never disables a video's own loop preference.
-export default function useNFTVideoLoop(nftId: string): boolean {
-  const [globalLoop] = useNFTVideoLoopGlobal();
-  const [videoLoop] = useNFTVideoLoopForNFT(nftId);
-
-  return globalLoop || videoLoop;
-}
+// The effective looping state for one NFT video is `global || perVideo`:
+// the global preference forces looping on when set, but never disables a
+// video's own loop preference. Consumers combine the two hooks above.

--- a/packages/gui/src/util/ipfs.test.ts
+++ b/packages/gui/src/util/ipfs.test.ts
@@ -1,0 +1,53 @@
+import ipfsToGatewayUrl, { IPFS_GATEWAY_BASE, getIpfsPath, isIpfsUrl } from './ipfs';
+
+// CID taken from a real mainnet NFT whose on-chain data URI is ipfs://
+const CID_V1 = 'bafybeiceg2gltyhlkukwetn26k7t2zdvthg4u4c6uj23rpni2adzgvo5si';
+const CID_V0 = 'QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB';
+
+describe('isIpfsUrl', () => {
+  it('matches the ipfs scheme case-insensitively', () => {
+    expect(isIpfsUrl(`ipfs://${CID_V1}/020.png`)).toBe(true);
+    expect(isIpfsUrl(`IPFS://${CID_V1}`)).toBe(true);
+  });
+
+  it('does not match other schemes', () => {
+    expect(isIpfsUrl(`https://ipfs.io/ipfs/${CID_V1}`)).toBe(false);
+    expect(isIpfsUrl('')).toBe(false);
+  });
+});
+
+describe('getIpfsPath', () => {
+  it('returns the CID and path', () => {
+    expect(getIpfsPath(`ipfs://${CID_V1}/020.png`)).toBe(`${CID_V1}/020.png`);
+    expect(getIpfsPath(`ipfs://${CID_V1}`)).toBe(CID_V1);
+  });
+
+  it('strips the redundant ipfs/ prefix some minting tools produce', () => {
+    expect(getIpfsPath(`ipfs://ipfs/${CID_V1}/020.png`)).toBe(`${CID_V1}/020.png`);
+  });
+
+  it('preserves the case of CIDv0 base58 hashes', () => {
+    expect(getIpfsPath(`ipfs://${CID_V0}/image.png`)).toBe(`${CID_V0}/image.png`);
+  });
+
+  it('returns undefined for non-ipfs URLs and a bare scheme', () => {
+    expect(getIpfsPath(`https://example.com/${CID_V1}`)).toBeUndefined();
+    expect(getIpfsPath('ipfs://')).toBeUndefined();
+  });
+});
+
+describe('ipfsToGatewayUrl', () => {
+  it('translates ipfs:// URIs to the HTTPS gateway', () => {
+    expect(ipfsToGatewayUrl(`ipfs://${CID_V1}/020.png`)).toBe(`${IPFS_GATEWAY_BASE}${CID_V1}/020.png`);
+    expect(ipfsToGatewayUrl(`ipfs://ipfs/${CID_V1}`)).toBe(`${IPFS_GATEWAY_BASE}${CID_V1}`);
+  });
+
+  it('returns non-ipfs URLs unchanged', () => {
+    const url = 'https://example.com/image.png?size=large';
+    expect(ipfsToGatewayUrl(url)).toBe(url);
+  });
+
+  it('returns an unusable bare scheme unchanged so validation rejects it', () => {
+    expect(ipfsToGatewayUrl('ipfs://')).toBe('ipfs://');
+  });
+});

--- a/packages/gui/src/util/ipfs.ts
+++ b/packages/gui/src/util/ipfs.ts
@@ -1,0 +1,33 @@
+// The public HTTPS gateway used to serve ipfs:// resources. Electron's net
+// stack has no IPFS support, so ipfs:// URIs are fetched through a gateway.
+// The gateway does not need to be trusted for integrity: everything the cache
+// serves is checked against the NFT's on-chain hash before it is shown.
+export const IPFS_GATEWAY_BASE = 'https://ipfs.io/ipfs/';
+
+const IPFS_SCHEME = /^ipfs:\/\//i;
+
+export function isIpfsUrl(url: string): boolean {
+  return typeof url === 'string' && IPFS_SCHEME.test(url);
+}
+
+// Returns the `<CID>[/path]` part of an ipfs:// URI, tolerating the redundant
+// `ipfs://ipfs/<CID>` form produced by some minting tools. CIDv0 hashes are
+// case-sensitive base58, so the value is never case-normalized.
+export function getIpfsPath(url: string): string | undefined {
+  if (!isIpfsUrl(url)) {
+    return undefined;
+  }
+
+  const ipfsPath = url.replace(IPFS_SCHEME, '').replace(/^ipfs\//i, '');
+
+  return ipfsPath.length > 0 ? ipfsPath : undefined;
+}
+
+// Translates an ipfs:// URI to its HTTPS gateway equivalent. Anything else
+// (including an unusable bare `ipfs://`) is returned unchanged, so this can
+// wrap any URL right where it reaches the network layer.
+export default function ipfsToGatewayUrl(url: string): string {
+  const ipfsPath = getIpfsPath(url);
+
+  return ipfsPath === undefined ? url : `${IPFS_GATEWAY_BASE}${ipfsPath}`;
+}


### PR DESCRIPTION
Part **5** of the NFT media pipeline series (#3011 → #3010 → #3029). **This PR is meant to be applied after #3029**: it is stacked on that branch, so until #3029 merges its diff includes #3029's 7 commits — **review only the 3 commits listed below.** Each is independent of the others; together they harden the download path that the earlier PRs put in place.

## What this PR changes and why

### 1. Retry timed-out NFT downloads once per session (`46ca7ecb9`)

Settling download timeouts as permanent cache errors (#3010) fixed the retry-a-stalled-host-on-every-access loop, but overshot: the timeout message is not in the transient-error list, so one slow first byte from a cold gateway — or a briefly offline machine — wrote an error to the `-info` sidecar that survived restarts. The NFT showed "Preview is not available" forever, until the user cleared the entire NFT cache.

`CacheManager` now keeps an in-memory `timedOutUrls` set: a persisted timeout is retried once per app session. Within the session the URL settles after its first timeout (a stalled host still cannot hold a download slot on every gallery visit), but a restart gets a fresh attempt. `downloadFile` exports `isDownloadTimeoutError`, which matches both timeout messages it produces (inactivity and overall deadline) by the same prefixes earlier sessions persisted — so existing poisoned caches recover on their own.

### 2. Bound WalletConnect confirmation-preview resolution with one overall deadline (`f68778eb5`)

`resolveNftPreviewUrl` walks three ordered URI lists per NFT (image data URIs, metadata URIs, extensionless data URIs) with a 10 s timeout per fetch and no overall limit. URI lists are on-chain data that `nft_add_uri` can extend, and the WalletConnect confirmation dialog only opens after parsing settles — so a `take_offer` referencing NFTs with many dead or slow hosts kept the security dialog off screen for 10 s × URIs × lists, minutes in the worst case, while the request could expire.

All fallbacks for one NFT now share a 20 s budget: `nftGetMetadata` / `nftGetImageDataUrl` take a `timeoutBudget`, each fetch gets the remaining time (capped at its own per-fetch timeout), and the walk stops once the budget is spent. Previews degrade to the placeholder in that case — the dialog itself is never held up by more than the budget. NFTs resolve concurrently, so this bounds the whole parse regardless of how many NFTs an offer references.

### 3. Drop redundant buffer copies and a dead hook export (`72a9b8d58`)

The verified-preview path copied every downloaded byte twice for no gain: `fetchBuffer` re-allocated each response chunk element-by-element via `Uint8Array.from` before collecting it (Electron's `net` module delivers fresh Buffers, so retaining them is safe and `Buffer.concat` already performs the single final copy), and the metadata checksum round-tripped the whole buffer through a `latin1` string before hashing — an up-to-10 MB string allocation to produce the digest that hashing the Buffer directly yields.

Also removes the unused `useNFTVideoLoop` default export: both consumers import the named hooks and derive the effective global-or-per-video state themselves, so the wrapper only added surface that could drift from the real logic.

No user-facing strings or settings are added; no cache migration is needed (cache keys and sidecar formats are unchanged).

## Testing

- New `CacheManager` test: a timeout persisted by one session (`Request timed out after …ms of inactivity` in the `-info` sidecar) is retried, and succeeds, in a fresh `CacheManager` instance against the same cache directory.
- New `parseCommandDisplay` test: once a slow metadata host consumes the whole budget, the remaining metadata fallbacks are never tried and the walk resolves to the placeholder; the existing resolution tests now also assert that a numeric budget is passed through to every `nftGetMetadata` / `nftGetImageDataUrl` call.
- Full gui jest suite green (355 tests); eslint/prettier clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKEGodEgVdEuvUM8dza52q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NFT fetch/cache behavior and WalletConnect confirmation previews, including an opt-in third-party gateway. Content remains hash-verified and the gateway is off by default, but cache retry and dialog timing changes are easy to get wrong.
> 
> **Overview**
> Adds an **opt-in** NFT setting to fetch `ipfs://` media through the public `ipfs.io` HTTPS gateway (off by default). Content is still hash-checked against the on-chain URI; Electron cannot request the `ipfs:` scheme directly.
> 
> Network call sites (`downloadFile`, `fetchBuffer`, `fetchJSON`, Chromium downloads) go through `toFetchableUrl`. With the option off, IPFS fetches throw `IpfsGatewayDisabledError` and are **not** persisted as cache errors, so turning the option on retries cleanly. Cached bytes stay keyed by the original URI. Toggling the setting retries failed in-memory metadata and re-runs hash verification.
> 
> Also hardens the download/preview path: persisted download timeouts are retried **once per app session**; WalletConnect confirmation previews share a **20s** fallback budget so slow URI lists cannot delay the security dialog; `fetchBuffer`/checksum drop extra copies; unused `useNFTVideoLoop` default export is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a9b8d580bf6ef5102ab727a8de6db753fb0fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->