### PR TITLE
Checkpoint Merge

### DIFF
--- a/packages/gui/src/electron/commands/Commands.ts
+++ b/packages/gui/src/electron/commands/Commands.ts
@@ -13,7 +13,7 @@ export type ParamSchema = {
   isOptional?: boolean;
   hide?: boolean; // hidden from the confirm dialog - still showed under json details
   type: 'string' | 'number' | 'bool' | 'bigint' | 'json';
-  humanize?: 'mojo-to-xch' | 'mojo-to-cat';
+  humanize?: 'mojo-to-xch' | 'mojo-to-cat' | 'puzzle-decorator';
 };
 
 type CommandBase = {
@@ -163,6 +163,7 @@ export const Commands: Record<string, CommandSchema> = {
         name: 'puzzle_decorator',
         label: () => i18n._(/* i18n */ { id: 'Puzzle Decorator' }),
         type: 'json',
+        humanize: 'puzzle-decorator',
         isOptional: true,
       },
     ],
@@ -172,6 +173,34 @@ export const Commands: Record<string, CommandSchema> = {
         title: () => i18n._(/* i18n */ { id: 'Send Transaction' }),
         requiresSync: true,
         defaults: { wallet_id: 1 },
+        params: [
+          {
+            name: 'amount',
+            label: () => i18n._(/* i18n */ { id: 'Amount' }),
+            type: 'bigint',
+            humanize: 'mojo-to-xch',
+          },
+          {
+            name: 'fee',
+            label: () => i18n._(/* i18n */ { id: 'Fee' }),
+            type: 'bigint',
+            humanize: 'mojo-to-xch',
+          },
+          { name: 'address', label: () => i18n._(/* i18n */ { id: 'Address' }), type: 'string' },
+          {
+            name: 'wallet_id',
+            label: () => i18n._(/* i18n */ { id: 'Wallet Id' }),
+            type: 'number',
+            hide: true,
+          },
+          {
+            name: 'memos',
+            label: () => i18n._(/* i18n */ { id: 'Memos' }),
+            type: 'json',
+            isOptional: true,
+            hide: true,
+          },
+        ],
       },
     ],
   },
@@ -393,6 +422,16 @@ export const Commands: Record<string, CommandSchema> = {
       {
         command: 'chia_signMessageByAddress',
         title: () => i18n._(/* i18n */ { id: 'Sign Message by Address' }),
+        params: [
+          { name: 'address', label: () => i18n._(/* i18n */ { id: 'Address' }), type: 'string' },
+          { name: 'message', label: () => i18n._(/* i18n */ { id: 'Message' }), type: 'string' },
+          {
+            name: 'is_hex',
+            label: () => i18n._(/* i18n */ { id: 'Message Is Hex Encoded String' }),
+            type: 'bool',
+            isOptional: true,
+          },
+        ],
       },
     ],
   },
@@ -878,13 +917,6 @@ export const Commands: Record<string, CommandSchema> = {
         label: () => i18n._(/* i18n */ { id: 'Reuse Puzzle Hash' }),
         type: 'bool',
         isOptional: true,
-      },
-    ],
-    dapp: [
-      {
-        command: 'chia_mintBulk',
-        title: () => i18n._(/* i18n */ { id: 'Mint Bulk' }),
-        message: () => i18n._(/* i18n */ { id: 'Create a spend bundle to mint multiple NFTs' }),
       },
     ],
   },

--- a/packages/gui/src/electron/commands/humanizeParamValue.ts
+++ b/packages/gui/src/electron/commands/humanizeParamValue.ts
@@ -1,4 +1,5 @@
 import JSONBig from 'json-bigint';
+import moment from 'moment';
 
 import { i18n } from '../../config/locales';
 // import { lookupCat } from '../utils/dappEnrichment';
@@ -7,6 +8,14 @@ import mojoToChiaLocaleString from '../utils/mojoToChiaLocaleString';
 import { parseMojos } from '../utils/parseMojos';
 
 import { type ParamSchema } from './Commands';
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSONBig.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
 
 function formatMojoXch(amount: unknown, networkPrefix?: string): string {
   const formatted = mojoToChiaLocaleString(amount as string | number);
@@ -30,6 +39,39 @@ async function formatMojoCat(amount: unknown, data: Record<string, unknown>): Pr
   // return cat?.displayName ? `${formatted} ${cat.displayName}` : formatted;
 }
 
+function formatDuration(rawSeconds: unknown): string {
+  const seconds = Number(rawSeconds);
+  if (!Number.isFinite(seconds)) {
+    return String(rawSeconds);
+  }
+  if (seconds <= 0) {
+    return i18n._(/* i18n */ { id: 'None' });
+  }
+  return moment.duration(seconds, 'seconds').humanize();
+}
+
+function formatPuzzleDecorator(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return safeJsonStringify(value);
+  }
+
+  return value
+    .map((entry) => {
+      if (entry && typeof entry === 'object' && (entry as Record<string, unknown>).decorator === 'CLAWBACK') {
+        const timelock = (entry as Record<string, unknown>).clawback_timelock;
+        return i18n._(
+          /* i18n */ {
+            id: 'Clawback timelock: {duration}. Recipient can claim after this delay; sender can reclaim until recipient claims.',
+            values: { duration: formatDuration(timelock) },
+          },
+        );
+      }
+
+      return safeJsonStringify(entry);
+    })
+    .join('\n');
+}
+
 export async function humanizeParamValue(
   param: ParamSchema,
   value: unknown,
@@ -48,6 +90,8 @@ export async function humanizeParamValue(
         return formatMojoXch(value, networkPrefix);
       case 'mojo-to-cat':
         return formatMojoCat(value, data);
+      case 'puzzle-decorator':
+        return formatPuzzleDecorator(value);
       default:
         throw new Error('Unhandled humanize type');
     }
@@ -62,11 +106,7 @@ export async function humanizeParamValue(
     case 'bool':
       return value === true ? i18n._(/* i18n */ { id: 'Yes' }) : i18n._(/* i18n */ { id: 'No' });
     case 'json':
-      try {
-        return JSONBig.stringify(value, null, 2);
-      } catch {
-        return String(value);
-      }
+      return safeJsonStringify(value);
     default: {
       throw new Error('Unhandled param type');
     }

--- a/packages/gui/src/electron/commands/humanizeParams.test.ts
+++ b/packages/gui/src/electron/commands/humanizeParams.test.ts
@@ -1,5 +1,4 @@
-import { type ParamSchema } from './Commands';
-import { humanizeDappCommand } from './humanizeDappCommand';
+import { Commands, type ParamSchema } from './Commands';
 import { humanizeParams } from './humanizeParams';
 
 function buildParam(name: string, options: Partial<ParamSchema> = {}): ParamSchema {
@@ -88,8 +87,8 @@ describe('humanizeParams', () => {
       puzzle_decorator: [{ decorator: 'CLAWBACK', clawback_timelock: 99_999_999_999 }],
     };
 
-    const result = await humanizeDappCommand('chia_sendTransaction', data, 'txch');
-    const row = result.rows.find(({ field }) => field === 'puzzle_decorator');
+    const rows = await humanizeParams(Commands['chia_wallet.send_transaction'].params, data, 'txch');
+    const row = rows.find(({ field }) => field === 'puzzle_decorator');
 
     expect(row?.value).toContain('Clawback timelock');
     expect(row?.value).toContain('years');

--- a/packages/gui/src/electron/commands/humanizeParams.test.ts
+++ b/packages/gui/src/electron/commands/humanizeParams.test.ts
@@ -1,4 +1,5 @@
 import { type ParamSchema } from './Commands';
+import { humanizeDappCommand } from './humanizeDappCommand';
 import { humanizeParams } from './humanizeParams';
 
 function buildParam(name: string, options: Partial<ParamSchema> = {}): ParamSchema {
@@ -77,5 +78,42 @@ describe('humanizeParams', () => {
     const data = { amount: 'not-a-bigint' };
 
     await expect(humanizeParams(params, data)).rejects.toThrow('Cannot convert not-a-bigint to a BigInt');
+  });
+
+  it('decodes a clawback puzzle decorator into a human-readable timelock', async () => {
+    const data = {
+      amount: 1n,
+      fee: 0n,
+      address: 'txch1abc',
+      puzzle_decorator: [{ decorator: 'CLAWBACK', clawback_timelock: 99_999_999_999 }],
+    };
+
+    const result = await humanizeDappCommand('chia_sendTransaction', data, 'txch');
+    const row = result.rows.find(({ field }) => field === 'puzzle_decorator');
+
+    expect(row?.value).toContain('Clawback timelock');
+    expect(row?.value).toContain('years');
+    expect(row?.value).toContain('sender can reclaim until recipient claims');
+    expect(row?.value).not.toContain('99999999999');
+  });
+
+  it('falls back to JSON for unknown puzzle decorator entries', async () => {
+    const params = [buildParam('puzzle_decorator', { type: 'json', humanize: 'puzzle-decorator' })];
+    const data = {
+      puzzle_decorator: [{ decorator: 'UNKNOWN', foo: 1 }],
+    };
+
+    const [row] = await humanizeParams(params, data);
+
+    expect(row.value).toContain('UNKNOWN');
+  });
+
+  it('renders an empty puzzle decorator array as JSON instead of a blank value', async () => {
+    const params = [buildParam('puzzle_decorator', { type: 'json', humanize: 'puzzle-decorator' })];
+    const data = { puzzle_decorator: [] };
+
+    const [row] = await humanizeParams(params, data);
+
+    expect(row.value).toBe('[]');
   });
 });

--- a/packages/gui/src/electron/commands/parseDappParams.test.ts
+++ b/packages/gui/src/electron/commands/parseDappParams.test.ts
@@ -28,6 +28,23 @@ describe('parseDappParams', () => {
       ).toThrow('param not allowed for dapp: evil_extra');
     });
 
+    it.each(['puzzle_decorator', 'puzzleDecorator'])(
+      'rejects dapp-supplied send transaction decorators using the %s spelling',
+      (field) => {
+        expect(() =>
+          parseDappParams(
+            'chia_sendTransaction',
+            serialize({
+              amount: '1',
+              fee: '0',
+              address: 'txch1address',
+              [field]: [{ decorator: 'CLAWBACK', clawback_timelock: '99999999999' }],
+            }),
+          ),
+        ).toThrow('param not allowed for dapp: puzzle_decorator');
+      },
+    );
+
     it('normalizes camelCase params to snake_case before allowlist validation', () => {
       const result = parseDappParams(
         'chia_pushTransactions',

--- a/packages/gui/src/electron/dialogs/Confirm/Confirm.tsx
+++ b/packages/gui/src/electron/dialogs/Confirm/Confirm.tsx
@@ -50,7 +50,7 @@ export type ConfirmProps = {
   message: string;
   confirmLabel: ReactNode;
   destructive: boolean;
-  /** Pre-resolved param rows from `renderConfirm` (label/value pairs). */
+  /** Pre-resolved param rows from the command humanizer (label/value pairs). */
   rows: ConfirmRow[];
   /** Daemon-derived offer summary / CAT info; rendered if present. */
   display?: ConfirmDisplay;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dapp parameter allowlists and transaction confirmation presentation; blocking `puzzle_decorator` from dapps is security-relevant for spend flows.
> 
> **Overview**
> Improves wallet **confirm dialogs** for `send_transaction` by humanizing optional `puzzle_decorator` values (notably **CLAWBACK** timelocks as readable durations via moment) instead of raw JSON, and wires that through a new `puzzle-decorator` param humanize type.
> 
> **Dapp-facing command metadata** is expanded: `chia_sendTransaction` and `chia_signMessageByAddress` now declare explicit allowlisted `params` for confirmation/humanization (XCH amounts, address, memos, etc.), while **`puzzle_decorator` stays wallet-only**—dapp calls with `puzzle_decorator` / `puzzleDecorator` are rejected. The **`chia_mintBulk`** dapp entry is removed from the mint-bulk wallet command mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8ae5ace3ceb6507f81b59abe323f49de271123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->