### PR TITLE
fix nft preview

### DIFF
--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -454,17 +454,17 @@ export default function NFTPreview(props: NFTPreviewProps) {
                 size="small"
                 disabled={globalVideoLoop}
                 onClick={handleToggleVideoLoop}
-                sx={{
-                  backgroundColor: alpha(Color.Neutral[900], 0.4),
-                  color: loopVideo ? Color.Green[400] : Color.Neutral[200],
+                sx={(theme) => ({
+                  backgroundColor: alpha(theme.palette.common.black, 0.4),
+                  color: loopVideo ? theme.palette.primary.main : theme.palette.common.white,
                   '&:hover': {
-                    backgroundColor: alpha(Color.Neutral[900], 0.6),
+                    backgroundColor: alpha(theme.palette.common.black, 0.6),
                   },
                   '&.Mui-disabled': {
-                    backgroundColor: alpha(Color.Neutral[900], 0.4),
-                    color: Color.Green[400],
+                    backgroundColor: alpha(theme.palette.common.black, 0.4),
+                    color: theme.palette.primary.main,
                   },
-                }}
+                })}
               >
                 <LoopIcon fontSize="small" />
               </IconButton>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Visual-only styling on a single overlay control; no behavior or data changes.
> 
> **Overview**
> Updates the **video loop** overlay `IconButton` on NFT previews so its colors follow the MUI theme instead of hardcoded `Color` tokens.
> 
> The `sx` prop now uses a theme callback: semi-transparent **black** for the background (default and hover), **primary** when looping is active (including disabled state when global loop is on), and **white** for the idle icon. This should keep the control readable and on-brand in light/dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c8a0efa75c3a2626091b3b86b9ecf042f316d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->