### PR TITLE
[CHIA-4398] fix nft preview

### DIFF
--- a/packages/core/src/components/LayoutDashboard/LayoutDashboard.tsx
+++ b/packages/core/src/components/LayoutDashboard/LayoutDashboard.tsx
@@ -7,7 +7,6 @@ import React, { type ReactNode, useState, Suspense, useCallback } from 'react';
 import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 
-import Color from '../../constants/Color';
 import useGetLatestVersionFromWebsite from '../../hooks/useGetLatestVersionFromWebsite';
 import useOpenDialog from '../../hooks/useOpenDialog';
 import EmojiAndColorPicker from '../../screens/SelectKey/EmojiAndColorPicker';
@@ -22,7 +21,7 @@ import NewerAppVersionAvailable from './NewerAppVersionAvailable';
 // import LayoutFooter from '../LayoutMain/LayoutFooter';
 
 const StyledAppBar = styled(({ drawer, ...rest }) => <AppBar {...rest} />)`
-  border-bottom: 1px solid ${({ theme }) => (theme.palette.mode === 'dark' ? Color.Neutral[700] : Color.Neutral[300])};
+  border-bottom: 1px solid ${({ theme }) => getColorModeValue(theme, 'border')};
   width: ${({ theme, drawer }) => (drawer ? `calc(100% - ${theme.drawer.width})` : '100%')};
   margin-left: ${({ theme, drawer }) => (drawer ? theme.drawer.width : 0)};
   z-index: ${({ theme }) => theme.zIndex.drawer + 1};};
@@ -249,7 +248,7 @@ export default function LayoutDashboard(props: LayoutDashboardProps) {
                               >
                                 <EditIcon
                                   style={{
-                                    color: isDark ? Color.Neutral[600] : Color.Neutral[400],
+                                    color: theme.palette.text.secondary,
                                   }}
                                 />
                               </IconButton>

--- a/packages/gui/src/components/nfts/NFTCard.tsx
+++ b/packages/gui/src/components/nfts/NFTCard.tsx
@@ -1,4 +1,4 @@
-import { Color, IconButton, Flex } from '@chia-network/core';
+import { IconButton, Flex } from '@chia-network/core';
 import { MoreVert } from '@mui/icons-material';
 import { Card, CardActionArea, CardContent, Checkbox, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -63,7 +63,7 @@ function NFTCard(props: NFTCardProps) {
       <Card
         sx={{
           borderRadius: '8px',
-          borderColor: theme.palette.mode === 'light' ? Color.Neutral[300] : Color.Neutral[700],
+          borderColor: theme.palette.mode === 'light' ? theme.palette.border.main : theme.palette.border.dark,
           opacity: isHidden ? 0.5 : 1,
         }}
         variant="outlined"

--- a/packages/gui/src/components/nfts/NFTDetails.tsx
+++ b/packages/gui/src/components/nfts/NFTDetails.tsx
@@ -1,6 +1,5 @@
 import { toBech32m } from '@chia-network/api';
 import {
-  Color,
   Flex,
   CardKeyValue,
   CopyToClipboard,
@@ -23,7 +22,7 @@ import removeHexPrefix from '../../util/removeHexPrefix';
 
 const StyledTitle = styled(Box)`
   font-size: 0.625rem;
-  color: ${alpha(Color.Neutral[50], 0.7)};
+  color: ${({ theme }) => alpha(theme.palette.common.white, 0.7)};
 `;
 
 const StyledValue = styled(Box)`

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -454,17 +454,17 @@ export default function NFTPreview(props: NFTPreviewProps) {
                 size="small"
                 disabled={globalVideoLoop}
                 onClick={handleToggleVideoLoop}
-                sx={{
-                  backgroundColor: alpha(Color.Neutral[900], 0.4),
-                  color: loopVideo ? Color.Green[400] : Color.Neutral[200],
+                sx={(theme) => ({
+                  backgroundColor: alpha(theme.palette.common.black, 0.4),
+                  color: loopVideo ? theme.palette.primary.main : theme.palette.common.white,
                   '&:hover': {
-                    backgroundColor: alpha(Color.Neutral[900], 0.6),
+                    backgroundColor: alpha(theme.palette.common.black, 0.6),
                   },
                   '&.Mui-disabled': {
-                    backgroundColor: alpha(Color.Neutral[900], 0.4),
-                    color: Color.Green[400],
+                    backgroundColor: alpha(theme.palette.common.black, 0.4),
+                    color: theme.palette.primary.main,
                   },
-                }}
+                })}
               >
                 <LoopIcon fontSize="small" />
               </IconButton>

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -3,6 +3,7 @@ import {
   Loading,
   Flex,
   SandboxedIframe,
+  getSemanticColors,
   usePersistState,
   useDarkMode,
   useThemeAssets,
@@ -454,17 +455,21 @@ export default function NFTPreview(props: NFTPreviewProps) {
                 size="small"
                 disabled={globalVideoLoop}
                 onClick={handleToggleVideoLoop}
-                sx={(theme) => ({
-                  backgroundColor: alpha(theme.palette.common.black, 0.4),
-                  color: loopVideo ? theme.palette.primary.main : theme.palette.common.white,
-                  '&:hover': {
-                    backgroundColor: alpha(theme.palette.common.black, 0.6),
-                  },
-                  '&.Mui-disabled': {
+                sx={(theme) => {
+                  // highlight stays readable on this overlay; Chia light primary.main does not
+                  const loopAccent = getSemanticColors(theme.palette).highlight;
+                  return {
                     backgroundColor: alpha(theme.palette.common.black, 0.4),
-                    color: theme.palette.primary.main,
-                  },
-                })}
+                    color: loopVideo ? loopAccent : theme.palette.common.white,
+                    '&:hover': {
+                      backgroundColor: alpha(theme.palette.common.black, 0.6),
+                    },
+                    '&.Mui-disabled': {
+                      backgroundColor: alpha(theme.palette.common.black, 0.4),
+                      color: loopAccent,
+                    },
+                  };
+                }}
               >
                 <LoopIcon fontSize="small" />
               </IconButton>

--- a/packages/gui/src/components/nfts/NFTProperties.tsx
+++ b/packages/gui/src/components/nfts/NFTProperties.tsx
@@ -1,5 +1,5 @@
 import type { NFTAttribute } from '@chia-network/api';
-import { Color, CopyToClipboard, Flex, Tooltip } from '@chia-network/core';
+import { CopyToClipboard, Flex, Tooltip } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import { alpha, Box, Grid, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -12,7 +12,7 @@ import isRankingAttribute from '../../util/isRankingAttribute';
 
 const StyledTitle = styled(Box)`
   font-size: 0.625rem;
-  color: ${alpha(Color.Neutral[50], 0.7)};
+  color: ${({ theme }) => alpha(theme.palette.common.white, 0.7)};
 `;
 
 const StyledValue = styled(Box)`

--- a/packages/gui/src/components/nfts/NFTSummary.tsx
+++ b/packages/gui/src/components/nfts/NFTSummary.tsx
@@ -1,5 +1,5 @@
 import type { NFTAttribute } from '@chia-network/api';
-import { Color, CopyToClipboard, Flex, Loading, TooltipIcon, truncateValue } from '@chia-network/core';
+import { CopyToClipboard, Flex, Loading, TooltipIcon, truncateValue } from '@chia-network/core';
 import { t, Trans } from '@lingui/macro';
 import { alpha, Box, Card, CardContent, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -18,7 +18,7 @@ import NFTTitle from './NFTTitle';
 
 const StyledTitle = styled(Box)`
   font-size: 0.625rem;
-  color: ${alpha(Color.Neutral[50], 0.7)};
+  color: ${({ theme }) => alpha(theme.palette.common.white, 0.7)};
 `;
 
 const StyledValue = styled(Box)`

--- a/packages/gui/src/components/nfts/NFTTransferConfirmationDialog.tsx
+++ b/packages/gui/src/components/nfts/NFTTransferConfirmationDialog.tsx
@@ -1,12 +1,4 @@
-import {
-  Color,
-  useCurrencyCode,
-  chiaToMojo,
-  ConfirmDialog,
-  Flex,
-  TooltipIcon,
-  FormatLargeNumber,
-} from '@chia-network/core';
+import { useCurrencyCode, chiaToMojo, ConfirmDialog, Flex, TooltipIcon, FormatLargeNumber } from '@chia-network/core';
 import { Trans, Plural } from '@lingui/macro';
 import { alpha, Box, Divider, Typography } from '@mui/material';
 import React, { type ReactNode } from 'react';
@@ -14,7 +6,7 @@ import styled from 'styled-components';
 
 const StyledTitle = styled(Box)`
   font-size: 0.625rem;
-  color: ${alpha(Color.Neutral[50], 0.7)};
+  color: ${({ theme }) => alpha(theme.palette.common.white, 0.7)};
 `;
 
 const StyledValue = styled(Box)`

--- a/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
+++ b/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
@@ -3,7 +3,6 @@ import type { NFTInfo } from '@chia-network/api';
 import { useLocalStorage } from '@chia-network/api-react';
 import {
   Button,
-  Color,
   FormatLargeNumber,
   Flex,
   LayoutDashboardSub,
@@ -315,7 +314,7 @@ export default function NFTGallery() {
                   backgroundColor: 'background.paper',
                   paddingX: 1,
                   borderRadius: 1,
-                  borderColor: theme.palette.mode === 'dark' ? Color.Neutral[700] : Color.Neutral[300],
+                  borderColor: theme.palette.mode === 'dark' ? theme.palette.border.dark : theme.palette.border.main,
                   borderWidth: 1,
                   borderStyle: 'solid',
                 }}

--- a/packages/gui/src/components/nfts/gallery/NFTGallerySearch.tsx
+++ b/packages/gui/src/components/nfts/gallery/NFTGallerySearch.tsx
@@ -1,4 +1,4 @@
-import { Color, Flex } from '@chia-network/core';
+import { Flex } from '@chia-network/core';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { InputBase, InputBaseProps } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -11,14 +11,14 @@ export type SearchProps = InputBaseProps & {
 
 export default function Search(props: SearchProps) {
   const { onUpdate, placeholder, ...rest } = props;
-  const theme: any = useTheme();
+  const theme = useTheme();
 
   return (
     <Flex
       gap={1}
       alignItems="center"
       sx={{
-        borderColor: theme.palette.mode === 'dark' ? Color.Neutral[700] : Color.Neutral[300],
+        borderColor: theme.palette.mode === 'dark' ? theme.palette.border.dark : theme.palette.border.main,
         backgroundColor: 'background.paper',
         paddingX: 1,
         borderRadius: 1,
@@ -26,7 +26,7 @@ export default function Search(props: SearchProps) {
         borderStyle: 'solid',
       }}
     >
-      <SearchIcon sx={{ color: theme.palette.mode === 'dark' ? Color.Neutral[400] : Color.Neutral[500] }} />
+      <SearchIcon sx={{ color: 'text.secondary' }} />
       <InputBase
         onInput={(event) => onUpdate((event.target as HTMLInputElement).value)}
         placeholder={placeholder}

--- a/packages/gui/src/components/nfts/gallery/SelectedActionsDialog.tsx
+++ b/packages/gui/src/components/nfts/gallery/SelectedActionsDialog.tsx
@@ -1,5 +1,4 @@
 import type { NFTInfo } from '@chia-network/api';
-import { Color } from '@chia-network/core';
 import { t } from '@lingui/macro';
 import { alpha } from '@mui/material';
 import React from 'react';
@@ -9,12 +8,12 @@ import useHiddenNFTs from '../../../hooks/useHiddenNFTs';
 import NFTContextualActions, { NFTContextualActionTypes } from '../NFTContextualActions';
 
 const SelectedItemsContainer = styled.div`
-  color: ${Color.Neutral[50]};
-  background: ${alpha(Color.Neutral[900], 0.87)};
+  color: ${({ theme }) => theme.palette.common.white};
+  background: ${({ theme }) => alpha(theme.palette.common.black, 0.87)};
   box-shadow:
-    0px 11px 14px -7px ${alpha(Color.Neutral[900], 0.2)},
-    0px 23px 36px 3px ${alpha(Color.Neutral[900], 0.14)},
-    0px 9px 44px 8px ${alpha(Color.Neutral[900], 0.12)};
+    0px 11px 14px -7px ${({ theme }) => alpha(theme.palette.common.black, 0.2)},
+    0px 23px 36px 3px ${({ theme }) => alpha(theme.palette.common.black, 0.14)},
+    0px 9px 44px 8px ${({ theme }) => alpha(theme.palette.common.black, 0.12)};
   border-radius: 16px;
   padding: 12px 32px;
   display: inline-block;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Visual/theming-only changes across NFT and layout components with no auth, data, or transaction logic touched.
> 
> **Overview**
> Replaces hardcoded `Color` neutral/green constants across the dashboard layout and NFT gallery/details UI with **MUI theme tokens** (`theme.palette.border`, `text.secondary`, `common.black`/`white`, and `getColorModeValue` for borders).
> 
> The main behavioral fix is in **NFT preview**: the video loop overlay button now uses **`getSemanticColors(...).highlight`** instead of `Color.Green[400]`, so the active loop state stays readable on the dark overlay (especially in light theme where `primary.main` was a poor fit).
> 
> Gallery search/toolbar borders and the multi-select floating actions bar are updated the same way; **`Color` imports are dropped** where no longer needed, and gallery search drops the loose `theme: any` typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac9be15a8220f825f48757c79eefb35571a8e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->