### PR TITLE
checkpoint: into main from release/2.7.4  @ ee1c3facc2def1939c9c5019cacb64a73d501c6f

### DIFF
--- a/packages/core/src/components/Table/TableControlled.tsx
+++ b/packages/core/src/components/Table/TableControlled.tsx
@@ -20,7 +20,8 @@ import Color from '../../constants/Color';
 import LoadingOverlay from '../LoadingOverlay';
 
 const StyledTableHead = styled(TableHead)`
-  background-color: ${({ theme }) => (theme.palette.mode === 'dark' ? Color.Neutral[700] : Color.Neutral[200])};
+  background-color: ${({ theme }) =>
+    theme.palette.surfaces?.tableHeader ?? (theme.palette.mode === 'dark' ? Color.Neutral[700] : Color.Neutral[200])};
   font-weight: 500;
 `;
 
@@ -28,13 +29,18 @@ export const StyledTableRow = styled(({ odd, oddRowBackgroundColor, ...rest }) =
   ${({ odd, oddRowBackgroundColor, theme }) =>
     odd
       ? `background-color: ${
-          oddRowBackgroundColor || (theme.palette.mode === 'dark' ? Color.Neutral[800] : Color.Neutral[100])
+          oddRowBackgroundColor ||
+          theme.palette.surfaces?.tableRowAlternate ||
+          (theme.palette.mode === 'dark' ? Color.Neutral[800] : Color.Neutral[100])
         };`
       : undefined}
 `;
 
 const StyledExpandedTableRow = styled(({ isExpanded, ...rest }) => <TableRow {...rest} />)`
-  background-color: ${({ theme }) => (theme.palette.mode === 'dark' ? Color.Neutral[700] : Color.Neutral[200])};
+  background-color: ${({ theme }) =>
+    theme.palette.surfaces?.tableExpanded ??
+    theme.palette.surfaces?.tableHeader ??
+    (theme.palette.mode === 'dark' ? Color.Neutral[700] : Color.Neutral[200])};
   ${({ isExpanded }) => (!isExpanded ? 'display: none;' : undefined)}
 `;
 
@@ -42,7 +48,8 @@ const StyledTableCell = styled(({ width, minWidth, maxWidth, ...rest }) => <Tabl
   max-width: ${({ minWidth, maxWidth, width }) => (maxWidth || width || minWidth) ?? 'none'};
   min-width: ${({ minWidth }) => minWidth || '0'};
   width: ${({ width, minWidth }) => (width || minWidth ? width : 'auto')}};
-  border-bottom: 1px solid ${({ theme }) => (theme.palette.mode === 'dark' ? Color.Neutral[800] : Color.Neutral[200])};
+  border-bottom: 1px solid
+    ${({ theme }) => theme.palette.surfaces?.tableBorder ?? (theme.palette.mode === 'dark' ? Color.Neutral[800] : Color.Neutral[200])};
 `;
 
 const StyledTableCellContent = styled(Box)<{ forceWrap: boolean }>`

--- a/packages/core/src/theme/themeAugmentation.ts
+++ b/packages/core/src/theme/themeAugmentation.ts
@@ -36,6 +36,14 @@ type ChiaSemanticPalette = {
   highlight?: string;
 };
 
+type ChiaSurfacePalette = {
+  control?: string;
+  tableHeader?: string;
+  tableRowAlternate?: string;
+  tableExpanded?: string;
+  tableBorder?: string;
+};
+
 declare module '@mui/material/styles' {
   interface Theme {
     chiaTheme: {
@@ -53,6 +61,7 @@ declare module '@mui/material/styles' {
     danger?: ChiaPaletteColor;
     highlight?: ChiaPaletteColor;
     semantic?: ChiaSemanticPalette;
+    surfaces?: ChiaSurfacePalette;
     sidebarSelectedFill?: string | { light?: string; dark?: string; main?: string };
     sidebarText?: { light?: string; dark?: string; main?: string };
   }
@@ -62,6 +71,7 @@ declare module '@mui/material/styles' {
     danger?: ChiaPaletteColor;
     highlight?: ChiaPaletteColor;
     semantic?: ChiaSemanticPalette;
+    surfaces?: ChiaSurfacePalette;
     sidebarSelectedFill?: string | { light?: string; dark?: string; main?: string };
     sidebarText?: { light?: string; dark?: string; main?: string };
   }

--- a/packages/core/src/theme/variants/field/dark.ts
+++ b/packages/core/src/theme/variants/field/dark.ts
@@ -58,6 +58,13 @@ export default createTheme(
         main: 'rgba(247, 223, 155, 0.16)',
         dark: 'rgba(247, 223, 155, 0.2)',
       },
+      surfaces: {
+        control: 'rgba(56, 43, 24, 0.9)',
+        tableHeader: 'rgba(78, 63, 31, 0.92)',
+        tableRowAlternate: 'rgba(49, 38, 22, 0.86)',
+        tableExpanded: 'rgba(78, 63, 31, 0.92)',
+        tableBorder: 'rgba(247, 223, 155, 0.2)',
+      },
       sidebarBackground: '#211d13',
       sidebarSelectedFill: 'rgba(247, 223, 155, 0.16)',
       sidebarIconSelected: {

--- a/packages/core/src/theme/variants/field/light.ts
+++ b/packages/core/src/theme/variants/field/light.ts
@@ -55,6 +55,13 @@ export default createTheme({
       main: 'rgba(71, 58, 36, 0.16)',
       dark: Color.Neutral[700],
     },
+    surfaces: {
+      control: 'rgba(234, 218, 183, 0.86)',
+      tableHeader: 'rgba(221, 202, 159, 0.78)',
+      tableRowAlternate: 'rgba(234, 218, 183, 0.58)',
+      tableExpanded: 'rgba(221, 202, 159, 0.78)',
+      tableBorder: 'rgba(126, 99, 48, 0.2)',
+    },
     sidebarBackground: '#302c1f',
     sidebarSelectedFill: 'rgba(247, 223, 155, 0.18)',
     sidebarIconSelected: {

--- a/packages/wallets/src/components/WalletReceiveAddressField.tsx
+++ b/packages/wallets/src/components/WalletReceiveAddressField.tsx
@@ -27,7 +27,8 @@ const WalletReceiveAddressWrapper = styled.div`
     border: 1px solid
       ${(props) => (props.isDarkMode ? props.theme.palette.border.dark : props.theme.palette.border.main)};
     border-radius: 4px;
-    background: ${(props) => (props.isDarkMode ? Color.Neutral[800] : Color.Neutral[100])};
+    background: ${(props) =>
+      props.theme.palette.surfaces?.control || (props.isDarkMode ? Color.Neutral[800] : Color.Neutral[100])};
   }
   > .MuiButton-root:hover {
     background: ${({ theme }) => useColorModeValue(theme, 'sidebarBackground')};
@@ -42,7 +43,7 @@ const WalletReceiveAddressWrapper = styled.div`
     padding: 3px 5px;
   }
   fieldSet {
-    border: 1px solid ${alpha(Color.Neutral[900], 0.15)};
+    border: 1px solid ${({ theme }) => theme.palette.border.main || alpha(Color.Neutral[900], 0.15)};
   }
 `;
 


### PR DESCRIPTION
Source hash: ee1c3facc2def1939c9c5019cacb64a73d501c6f
Remaining commits: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theming and presentation only; optional chaining preserves existing behavior for themes that do not define `surfaces`.
> 
> **Overview**
> Introduces **`palette.surfaces`** on the MUI theme (typed in `themeAugmentation.ts`) with tokens for **control**, **table header**, **alternate rows**, **expanded rows**, and **table borders**.
> 
> **`TableControlled`** now reads those tokens (with the same light/dark neutral fallbacks when unset) instead of hard-coded `Color.Neutral` for header, zebra, expanded, and cell borders. The **field** light/dark variants populate the new surface colors so tables and controls match that theme.
> 
> **`WalletReceiveAddressField`** uses `surfaces.control` for the copy button background and `palette.border.main` for the fieldset border instead of fixed neutral/alpha values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f33ed5a168c47350e93e1b40d8332ceb45c3f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->