### PR TITLE
[CHIA-4407] Say when the IPFS gateway itself cannot be reached, and check a gateway address when it is saved

### DIFF
--- a/packages/gui/src/@types/CacheInfoBase.ts
+++ b/packages/gui/src/@types/CacheInfoBase.ts
@@ -20,6 +20,10 @@ type CacheInfoBase =
       // For ipfs:// URLs: the gateway base the failed request went through,
       // so a later gateway change retries the entry immediately.
       gateway?: string;
+      // When the failed transfer started, recorded for a failure to reach the
+      // gateway host: a recovery of the gateway after that moment releases the
+      // entry for retry even if it was written after the recovery (CacheManager).
+      startedAt?: number;
       // For a size-limit failure: the cap the attempt ran under, so a later
       // caller is retried only when it allows more.
       maxSize?: number;

--- a/packages/gui/src/@types/CacheService.ts
+++ b/packages/gui/src/@types/CacheService.ts
@@ -1,5 +1,7 @@
 import type CacheInfo from './CacheInfo';
 import type Headers from './Headers';
+import type IpfsGatewayHealth from './IpfsGatewayHealth';
+import type IpfsGatewayProbeResult from './IpfsGatewayProbeResult';
 
 export type CacheRequestOptions = {
   maxSize?: number;
@@ -37,10 +39,16 @@ type CacheService = {
   // Read-only lookup of the persisted cache state of each url - never downloads
   getCacheInfos: (urls: string[]) => Promise<CacheInfo[]>;
 
+  // IPFS gateway reachability: a one-off check of an address the user is
+  // saving, and what recent downloads say about the gateway in use
+  probeIpfsGateway: (gateway: string) => Promise<IpfsGatewayProbeResult>;
+  getIpfsGatewayHealth: () => Promise<IpfsGatewayHealth | undefined>;
+
   // Event subscriptions
   subscribeToDirectoryChange: (callback: (newDirectory: string) => void) => () => void;
   subscribeToMaxSizeChange: (callback: (newSize: number) => void) => () => void;
   subscribeToSizeChange: (callback: () => void) => () => void;
+  subscribeToIpfsGatewayHealthChange: (callback: (health: IpfsGatewayHealth) => void) => () => void;
 };
 
 export default CacheService;

--- a/packages/gui/src/@types/IpfsGatewayHealth.ts
+++ b/packages/gui/src/@types/IpfsGatewayHealth.ts
@@ -1,0 +1,18 @@
+// What the main process currently knows about the IPFS gateway it fetches
+// through, learned from the downloads themselves: after a run of requests that
+// could not reach the gateway host at all (its name does not resolve, nothing
+// listens, its certificate is not for that name) the gateway is reported
+// unreachable, and reported reachable again as soon as it answers anything.
+// A single notice built from this replaces the identical generic error every
+// tile would otherwise show for a gateway address that is simply wrong.
+type IpfsGatewayHealth = {
+  // the normalized gateway base the verdict is about
+  gateway: string;
+  reachable: boolean;
+  // the network error of the last request that could not reach it
+  error?: string;
+  // how many requests in a row could not reach it
+  failures: number;
+};
+
+export default IpfsGatewayHealth;

--- a/packages/gui/src/@types/IpfsGatewayHealth.ts
+++ b/packages/gui/src/@types/IpfsGatewayHealth.ts
@@ -13,6 +13,12 @@ type IpfsGatewayHealth = {
   error?: string;
   // how many requests in a row could not reach it
   failures: number;
+  // when a reachable verdict was reached after an unreachable one: the moment
+  // the gateway was seen answering again. A failure to reach it whose
+  // transfer began before that moment is retried on the next access
+  // (CacheManager.isRecoveredGatewayFailure), so a reader of the sidecars
+  // treats it as unset; one that began after it is a new failure.
+  recoveredAt?: number;
 };
 
 export default IpfsGatewayHealth;

--- a/packages/gui/src/@types/IpfsGatewayProbeResult.ts
+++ b/packages/gui/src/@types/IpfsGatewayProbeResult.ts
@@ -1,0 +1,15 @@
+// The outcome of asking a gateway for a well-known file once, from the main
+// process, when the user saves a gateway address: whether the host answered at
+// all (any HTTP status counts — a slow or rate-limiting gateway is still the
+// right address) and, when it did not, the network error that says why.
+type IpfsGatewayProbeResult = {
+  // the normalized gateway base that was probed
+  gateway: string;
+  reachable: boolean;
+  // the HTTP status the gateway answered with, when it answered
+  status?: number;
+  // the network error when it did not
+  error?: string;
+};
+
+export default IpfsGatewayProbeResult;

--- a/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
+++ b/packages/gui/src/components/nfts/gallery/NFTGallery.tsx
@@ -18,6 +18,7 @@ import {
   Refresh as RefreshIcon,
 } from '@mui/icons-material';
 import {
+  Alert,
   Divider,
   Chip,
   FormControlLabel,
@@ -32,6 +33,7 @@ import { useTheme } from '@mui/material/styles';
 import { styled } from '@mui/styles';
 import { xor, intersection /* , sortBy */ } from 'lodash';
 import React, { useMemo, useCallback, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { VirtuosoGrid } from 'react-virtuoso';
 
 import NFTPreviewAvailability from '../../../@types/NFTPreviewAvailability';
@@ -39,6 +41,7 @@ import NFTVisibility from '../../../@types/NFTVisibility';
 import FileType from '../../../constants/FileType';
 import useFilteredNFTs from '../../../hooks/useFilteredNFTs';
 import useHideObjectionableContent from '../../../hooks/useHideObjectionableContent';
+import useIpfsGatewayHealth from '../../../hooks/useIpfsGatewayHealth';
 import useNFTGalleryScrollPosition from '../../../hooks/useNFTGalleryScrollPosition';
 import useNFTProvider from '../../../hooks/useNFTProvider';
 import getNFTId from '../../../util/getNFTId';
@@ -94,6 +97,10 @@ export const defaultCacheSizeLimit = 1024; /* MB */
 
 export default function NFTGallery() {
   const theme: any = useTheme();
+  const navigate = useNavigate();
+  // One notice for a gateway that cannot be reached at all, in place of the
+  // same generic failure on every tile fetched through it.
+  const gatewayHealth = useIpfsGatewayHealth();
   const {
     nfts,
     isLoading,
@@ -304,6 +311,21 @@ export default function NFTGallery() {
       // onScroll={handleOnScroll}
       header={
         <Flex gap={1} flexDirection="column">
+          {gatewayHealth && !gatewayHealth.reachable && (
+            <Alert
+              severity="warning"
+              action={
+                <Button size="small" color="inherit" onClick={() => navigate('/dashboard/settings/nft')}>
+                  <Trans>Settings</Trans>
+                </Button>
+              }
+            >
+              <Trans>
+                The IPFS gateway {gatewayHealth.gateway} cannot be reached ({gatewayHealth.error}). NFT files fetched
+                through it cannot be shown until it answers; check the gateway address.
+              </Trans>
+            </Alert>
+          )}
           <Flex gap={2} alignItems="stretch" flexWrap="wrap" justifyContent="space-between">
             <NFTProfileDropdown onChange={handleSetWalletId} walletId={walletIds?.[0]} />
             <Flex gap={2} alignItems="stretch" justifyContent="space-between">

--- a/packages/gui/src/components/nfts/provider/NFTProvider.tsx
+++ b/packages/gui/src/components/nfts/provider/NFTProvider.tsx
@@ -1,7 +1,8 @@
 import debug from 'debug';
-import React, { useMemo, useCallback, type ReactNode } from 'react';
+import React, { useMemo, useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 
 import useCache from '../../../hooks/useCache';
+import useIpfsGatewayHealth from '../../../hooks/useIpfsGatewayHealth';
 import { MAX_METADATA_URI_ATTEMPTS } from '../../../util/fetchMetadataFromUris';
 import { MAX_URIS_PER_CANDIDATE } from '../../../util/getNFTPreviewStatusFromCache';
 import NFTFilterProvider from '../NFTFilterProvider';
@@ -25,6 +26,24 @@ export default function NFTProvider(props: NFTProviderProps) {
   const { children, concurrency = 10, pageSize = 24 } = props;
 
   const { invalidate } = useCache();
+
+  // The gateway came back after a run of requests that could not reach it
+  // (see IpfsGatewayHealth). The failures recorded meanwhile — persisted by
+  // the cache, remembered by the metadata store and by the tiles' verifiers —
+  // were verdicts on an unreachable host, not on the content; CacheManager
+  // retries them on the next access, and everything here that remembers a
+  // failure re-runs on the count below, the way it does on a gateway change.
+  const ipfsGatewayHealth = useIpfsGatewayHealth();
+  const isIpfsGatewayRecovered = ipfsGatewayHealth?.reachable === true;
+  const [ipfsGatewayRecoveries, setIpfsGatewayRecoveries] = useState(0);
+  const wasIpfsGatewayUnreachableRef = useRef(false);
+  useEffect(() => {
+    const isUnreachable = ipfsGatewayHealth?.reachable === false;
+    if (wasIpfsGatewayUnreachableRef.current && !isUnreachable) {
+      setIpfsGatewayRecoveries((count) => count + 1);
+    }
+    wasIpfsGatewayUnreachableRef.current = isUnreachable;
+  }, [ipfsGatewayHealth]);
 
   const {
     nfts,
@@ -105,6 +124,7 @@ export default function NFTProvider(props: NFTProviderProps) {
     invalidate: invalidateMetadata,
   } = useMetadataData({
     fetchNFT,
+    ipfsGatewayRecoveries,
   });
 
   const subscribeToNFTChanges = useCallback(
@@ -142,6 +162,8 @@ export default function NFTProvider(props: NFTProviderProps) {
       getMetadata,
       subscribeToChanges,
       subscribeToMetadataChanges: subscribeToMetadataDataChanges,
+      ipfsGatewayRecoveries,
+      isIpfsGatewayRecovered,
     });
 
   const invalidateNFT = useCallback(
@@ -244,6 +266,7 @@ export default function NFTProvider(props: NFTProviderProps) {
       getPreviewStatus,
       setPreviewStatus,
       subscribeToPreviewStatusChanges,
+      ipfsGatewayRecoveries,
 
       subscribeToChanges,
 
@@ -270,6 +293,7 @@ export default function NFTProvider(props: NFTProviderProps) {
       getPreviewStatus,
       setPreviewStatus,
       subscribeToPreviewStatusChanges,
+      ipfsGatewayRecoveries,
       count,
       loaded,
       progress,

--- a/packages/gui/src/components/nfts/provider/NFTProvider.tsx
+++ b/packages/gui/src/components/nfts/provider/NFTProvider.tsx
@@ -34,7 +34,7 @@ export default function NFTProvider(props: NFTProviderProps) {
   // retries them on the next access, and everything here that remembers a
   // failure re-runs on the count below, the way it does on a gateway change.
   const ipfsGatewayHealth = useIpfsGatewayHealth();
-  const isIpfsGatewayRecovered = ipfsGatewayHealth?.reachable === true;
+  const ipfsGatewayRecoveredAt = ipfsGatewayHealth?.reachable ? ipfsGatewayHealth.recoveredAt : undefined;
   const [ipfsGatewayRecoveries, setIpfsGatewayRecoveries] = useState(0);
   const wasIpfsGatewayUnreachableRef = useRef(false);
   useEffect(() => {
@@ -163,7 +163,7 @@ export default function NFTProvider(props: NFTProviderProps) {
       subscribeToChanges,
       subscribeToMetadataChanges: subscribeToMetadataDataChanges,
       ipfsGatewayRecoveries,
-      isIpfsGatewayRecovered,
+      ipfsGatewayRecoveredAt,
     });
 
   const invalidateNFT = useCallback(

--- a/packages/gui/src/components/nfts/provider/NFTProviderContext.ts
+++ b/packages/gui/src/components/nfts/provider/NFTProviderContext.ts
@@ -34,6 +34,11 @@ const NFTProviderContext = createContext<
       getPreviewStatus: (id: string | undefined) => NFTPreviewStatus | undefined;
       setPreviewStatus: (id: string, status: NFTPreviewStatus) => void;
       subscribeToPreviewStatusChanges: (callback: () => void) => () => void;
+      // How many times the IPFS gateway has come back after being unreachable
+      // this session. Consumers that remember fetch failures re-run on a
+      // change, the way they do on a gateway change: the failures recorded
+      // while the gateway was down are verdicts on the host, not the content.
+      ipfsGatewayRecoveries: number;
     }
   | undefined
 >(undefined);

--- a/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useMetadataData.ts
@@ -21,11 +21,13 @@ function getChangedEventName(nftId: string) {
 
 type UseMetadataDataProps = {
   fetchNFT: (id: string) => Promise<NFTInfo>; // should be immutable
+  // see NFTProvider: a change retries failed fetches like a gateway change does
+  ipfsGatewayRecoveries: number;
 };
 
 // warning: only used by NFTProvider
 export default function useMetadataData(props: UseMetadataDataProps) {
-  const { fetchNFT } = props;
+  const { fetchNFT, ipfsGatewayRecoveries } = props;
 
   const [metadatasOnDemand] = useState(() => new Map<string, MetadataOnDemand>());
   const fetchAndProcessMetadata = useFetchAndProcessMetadata();
@@ -164,8 +166,11 @@ export default function useMetadataData(props: UseMetadataDataProps) {
 
   const [ipfsGateway] = useIpfsGateway();
   const ipfsGatewayBase = useIpfsGatewayBase();
-  // one key for both gateway preferences: the option and the gateway itself
-  const ipfsGatewayKey = ipfsGateway ? ipfsGatewayBase : false;
+  // one key for both gateway preferences — the option and the gateway itself
+  // — and for the gateway coming back after being unreachable: a failure
+  // recorded while it was down is as stale as one recorded under another
+  // gateway
+  const ipfsGatewayKey = `${ipfsGateway ? ipfsGatewayBase : 'off'}#${ipfsGatewayRecoveries}`;
   const lastIpfsGatewayRef = useRef(ipfsGatewayKey);
 
   useEffect(() => {

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -10,8 +10,8 @@ import type NFTPreviewStatus from '../../../../@types/NFTPreviewStatus';
 import CacheState from '../../../../constants/CacheState';
 import useCache from '../../../../hooks/useCache';
 import useIpfsGateway from '../../../../hooks/useIpfsGateway';
-import useIpfsGatewayHealth from '../../../../hooks/useIpfsGatewayHealth';
 import { useIpfsGatewayBase } from '../../../../hooks/useIpfsGatewayUrl';
+import { isHostUnreachableError } from '../../../../util/downloadErrors';
 import getNFTPreviewStatusFromCache, { getNFTPreviewUrls } from '../../../../util/getNFTPreviewStatusFromCache';
 import { isIpfsBackedUrl, isIpfsUrl } from '../../../../util/ipfs';
 
@@ -34,6 +34,10 @@ type UseNFTPreviewStatusesProps = {
   getMetadata: (id: string) => MetadataState; // should be immutable
   subscribeToChanges: (callback: () => void) => () => void; // should be immutable
   subscribeToMetadataChanges: (callback: () => void) => () => void; // should be immutable
+  // see NFTProvider: how many times the gateway has come back after being
+  // unreachable, and whether it has this session
+  ipfsGatewayRecoveries: number;
+  isIpfsGatewayRecovered: boolean;
 };
 
 // warning: only used by NFTProvider
@@ -44,7 +48,15 @@ type UseNFTPreviewStatusesProps = {
 // cache persisted during earlier visits and sessions, without downloading
 // anything. A live report always wins over a cache lookup.
 export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps) {
-  const { nfts, nachos, getMetadata, subscribeToChanges, subscribeToMetadataChanges } = props;
+  const {
+    nfts,
+    nachos,
+    getMetadata,
+    subscribeToChanges,
+    subscribeToMetadataChanges,
+    ipfsGatewayRecoveries,
+    isIpfsGatewayRecovered,
+  } = props;
 
   const { getCacheInfos } = useCache();
 
@@ -68,6 +80,8 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   const ipfsGatewayKey = ipfsGateway ? ipfsGatewayBase : '';
   const ipfsGatewayKeyRef = useRef(ipfsGatewayKey);
   ipfsGatewayKeyRef.current = ipfsGatewayKey;
+  const isIpfsGatewayRecoveredRef = useRef(isIpfsGatewayRecovered);
+  isIpfsGatewayRecoveredRef.current = isIpfsGatewayRecovered;
 
   const events = useMemo(() => {
     const eventEmitter = new EventEmitter();
@@ -195,17 +209,24 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
           // gateway link, without any gateway, meaning it never got the
           // fallback — is re-requested on the next access, so it settles
           // nothing here. An ipfs:// sidecar without a gateway predates
-          // gateway tracking and stays a settled failure.
+          // gateway tracking and stays a settled failure. Likewise its
+          // recovery rule: once the gateway has come back after being
+          // unreachable, a failure to reach it recorded under the current
+          // gateway was a verdict on the host, and CacheManager retries it on
+          // the next access (isRecoveredGatewayFailure) — so it settles
+          // nothing here either, and the NFT stays in view for its tile to ask.
           const currentGateway = ipfsGatewayKeyRef.current;
+          const isRecovered = isIpfsGatewayRecoveredRef.current;
           const getCacheInfo = (url: string): CacheInfo | undefined => {
             const cacheInfo = cacheInfos.get(url);
-            if (
-              cacheInfo?.state === CacheState.ERROR &&
-              currentGateway &&
-              isIpfsBackedUrl(url) &&
-              (cacheInfo.gateway === undefined ? !isIpfsUrl(url) : cacheInfo.gateway !== currentGateway)
-            ) {
-              return { url: cacheInfo.url, timestamp: cacheInfo.timestamp, state: CacheState.NOT_CACHED };
+            if (cacheInfo?.state === CacheState.ERROR && currentGateway && isIpfsBackedUrl(url)) {
+              const isOtherGateway =
+                cacheInfo.gateway === undefined ? !isIpfsUrl(url) : cacheInfo.gateway !== currentGateway;
+              const isRecoveredFailure =
+                isRecovered && cacheInfo.gateway === currentGateway && isHostUnreachableError(cacheInfo.error);
+              if (isOtherGateway || isRecoveredFailure) {
+                return { url: cacheInfo.url, timestamp: cacheInfo.timestamp, state: CacheState.NOT_CACHED };
+              }
             }
 
             return cacheInfo;
@@ -335,17 +356,16 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   // The gateway came back after a run of requests that could not reach it:
   // the failures recorded meanwhile were verdicts on an unreachable host, and
   // CacheManager retries them on the next access (gatewayRecoveredAt), so
-  // they settle nothing here any more — forget them the same way, and let
-  // the tiles ask again.
-  const gatewayHealth = useIpfsGatewayHealth();
-  const wasGatewayUnreachableRef = useRef(false);
+  // they settle nothing here any more (see getCacheInfo above) — forget the
+  // verdicts that rested on them the same way, and let the tiles ask again.
+  const lastIpfsGatewayRecoveriesRef = useRef(ipfsGatewayRecoveries);
   useEffect(() => {
-    const isUnreachable = gatewayHealth?.reachable === false;
-    if (wasGatewayUnreachableRef.current && !isUnreachable) {
-      forgetIpfsVerdicts();
+    if (lastIpfsGatewayRecoveriesRef.current === ipfsGatewayRecoveries) {
+      return;
     }
-    wasGatewayUnreachableRef.current = isUnreachable;
-  }, [gatewayHealth, forgetIpfsVerdicts]);
+    lastIpfsGatewayRecoveriesRef.current = ipfsGatewayRecoveries;
+    forgetIpfsVerdicts();
+  }, [ipfsGatewayRecoveries, forgetIpfsVerdicts]);
 
   useEffect(() => {
     scheduleLookUp();

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -10,6 +10,7 @@ import type NFTPreviewStatus from '../../../../@types/NFTPreviewStatus';
 import CacheState from '../../../../constants/CacheState';
 import useCache from '../../../../hooks/useCache';
 import useIpfsGateway from '../../../../hooks/useIpfsGateway';
+import useIpfsGatewayHealth from '../../../../hooks/useIpfsGatewayHealth';
 import { useIpfsGatewayBase } from '../../../../hooks/useIpfsGatewayUrl';
 import getNFTPreviewStatusFromCache, { getNFTPreviewUrls } from '../../../../util/getNFTPreviewStatusFromCache';
 import { isIpfsBackedUrl, isIpfsUrl } from '../../../../util/ipfs';
@@ -281,13 +282,8 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   // failure has usually already become a fetch in flight. Either way the
   // preview uris the metadata brings are unknown until it arrives, and a
   // verdict reached without them must not outlive the change.
-  const lastIpfsGatewayKeyRef = useRef(ipfsGatewayKey);
-  useEffect(() => {
-    if (lastIpfsGatewayKeyRef.current === ipfsGatewayKey) {
-      return;
-    }
-    lastIpfsGatewayKeyRef.current = ipfsGatewayKey;
-
+  // immutable function
+  const forgetIpfsVerdicts = useCallback(() => {
     let changed = false;
     const reconsider = (nft: NFTInfo, nftId: string) => {
       const metadataState = getMetadata(nftId);
@@ -317,7 +313,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     }
     scheduleLookUp();
   }, [
-    ipfsGatewayKey,
     nfts /* immutable */,
     nachos /* immutable */,
     getMetadata /* immutable */,
@@ -327,6 +322,30 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     events /* immutable */,
     scheduleLookUp,
   ]);
+
+  const lastIpfsGatewayKeyRef = useRef(ipfsGatewayKey);
+  useEffect(() => {
+    if (lastIpfsGatewayKeyRef.current === ipfsGatewayKey) {
+      return;
+    }
+    lastIpfsGatewayKeyRef.current = ipfsGatewayKey;
+    forgetIpfsVerdicts();
+  }, [ipfsGatewayKey, forgetIpfsVerdicts]);
+
+  // The gateway came back after a run of requests that could not reach it:
+  // the failures recorded meanwhile were verdicts on an unreachable host, and
+  // CacheManager retries them on the next access (gatewayRecoveredAt), so
+  // they settle nothing here any more — forget them the same way, and let
+  // the tiles ask again.
+  const gatewayHealth = useIpfsGatewayHealth();
+  const wasGatewayUnreachableRef = useRef(false);
+  useEffect(() => {
+    const isUnreachable = gatewayHealth?.reachable === false;
+    if (wasGatewayUnreachableRef.current && !isUnreachable) {
+      forgetIpfsVerdicts();
+    }
+    wasGatewayUnreachableRef.current = isUnreachable;
+  }, [gatewayHealth, forgetIpfsVerdicts]);
 
   useEffect(() => {
     scheduleLookUp();

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -35,9 +35,9 @@ type UseNFTPreviewStatusesProps = {
   subscribeToChanges: (callback: () => void) => () => void; // should be immutable
   subscribeToMetadataChanges: (callback: () => void) => () => void; // should be immutable
   // see NFTProvider: how many times the gateway has come back after being
-  // unreachable, and whether it has this session
+  // unreachable, and when it last did (IpfsGatewayHealth.recoveredAt)
   ipfsGatewayRecoveries: number;
-  isIpfsGatewayRecovered: boolean;
+  ipfsGatewayRecoveredAt: number | undefined;
 };
 
 // warning: only used by NFTProvider
@@ -55,7 +55,7 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     subscribeToChanges,
     subscribeToMetadataChanges,
     ipfsGatewayRecoveries,
-    isIpfsGatewayRecovered,
+    ipfsGatewayRecoveredAt,
   } = props;
 
   const { getCacheInfos } = useCache();
@@ -80,8 +80,8 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   const ipfsGatewayKey = ipfsGateway ? ipfsGatewayBase : '';
   const ipfsGatewayKeyRef = useRef(ipfsGatewayKey);
   ipfsGatewayKeyRef.current = ipfsGatewayKey;
-  const isIpfsGatewayRecoveredRef = useRef(isIpfsGatewayRecovered);
-  isIpfsGatewayRecoveredRef.current = isIpfsGatewayRecovered;
+  const ipfsGatewayRecoveredAtRef = useRef(ipfsGatewayRecoveredAt);
+  ipfsGatewayRecoveredAtRef.current = ipfsGatewayRecoveredAt;
 
   const events = useMemo(() => {
     const eventEmitter = new EventEmitter();
@@ -210,20 +210,25 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
           // fallback — is re-requested on the next access, so it settles
           // nothing here. An ipfs:// sidecar without a gateway predates
           // gateway tracking and stays a settled failure. Likewise its
-          // recovery rule: once the gateway has come back after being
-          // unreachable, a failure to reach it recorded under the current
-          // gateway was a verdict on the host, and CacheManager retries it on
-          // the next access (isRecoveredGatewayFailure) — so it settles
-          // nothing here either, and the NFT stays in view for its tile to ask.
+          // recovery rule (isRecoveredGatewayFailure): once the gateway has
+          // come back after being unreachable, a failure to reach it recorded
+          // under the current gateway whose transfer began before that moment
+          // was a verdict on the host, and CacheManager retries it on the next
+          // access — so it settles nothing here either, and the NFT stays in
+          // view for its tile to ask. One that began after the recovery is a
+          // new failure and follows the ordinary rules.
           const currentGateway = ipfsGatewayKeyRef.current;
-          const isRecovered = isIpfsGatewayRecoveredRef.current;
+          const recoveredAt = ipfsGatewayRecoveredAtRef.current;
           const getCacheInfo = (url: string): CacheInfo | undefined => {
             const cacheInfo = cacheInfos.get(url);
             if (cacheInfo?.state === CacheState.ERROR && currentGateway && isIpfsBackedUrl(url)) {
               const isOtherGateway =
                 cacheInfo.gateway === undefined ? !isIpfsUrl(url) : cacheInfo.gateway !== currentGateway;
               const isRecoveredFailure =
-                isRecovered && cacheInfo.gateway === currentGateway && isHostUnreachableError(cacheInfo.error);
+                recoveredAt !== undefined &&
+                cacheInfo.gateway === currentGateway &&
+                isHostUnreachableError(cacheInfo.error) &&
+                recoveredAt > (cacheInfo.startedAt ?? cacheInfo.timestamp);
               if (isOtherGateway || isRecoveredFailure) {
                 return { url: cacheInfo.url, timestamp: cacheInfo.timestamp, state: CacheState.NOT_CACHED };
               }

--- a/packages/gui/src/components/settings/IpfsGatewayUrl.tsx
+++ b/packages/gui/src/components/settings/IpfsGatewayUrl.tsx
@@ -1,10 +1,13 @@
 import { Flex, Form, TextField } from '@chia-network/core';
 import { t, Trans } from '@lingui/macro';
 import { LoadingButton } from '@mui/lab';
-import { Button } from '@mui/material';
-import React, { useEffect } from 'react';
+import { Button, Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import type IpfsGatewayProbeResult from '../../@types/IpfsGatewayProbeResult';
+import useCache from '../../hooks/useCache';
+import useIpfsGatewayHealth from '../../hooks/useIpfsGatewayHealth';
 import useIpfsGatewayUrl from '../../hooks/useIpfsGatewayUrl';
 import { DEFAULT_IPFS_GATEWAY_BASE, normalizeIpfsGatewayBase } from '../../util/ipfs';
 
@@ -24,6 +27,12 @@ export type IpfsGatewayUrlProps = {
 export default function IpfsGatewayUrl(props: IpfsGatewayUrlProps) {
   const { disabled = false } = props;
   const [gatewayUrl, setGatewayUrl] = useIpfsGatewayUrl();
+  const { probeIpfsGateway } = useCache();
+  // what the downloads say about the gateway in use — shown here too, so the
+  // field that holds a wrong address is where the problem is reported
+  const health = useIpfsGatewayHealth();
+  // the answer of the gateway the user last saved, until the next save
+  const [probe, setProbe] = useState<IpfsGatewayProbeResult | undefined>(undefined);
 
   const methods = useForm<FormData>({
     defaultValues: {
@@ -43,8 +52,14 @@ export default function IpfsGatewayUrl(props: IpfsGatewayUrlProps) {
   const canSubmit = !disabled && !isSubmitting;
   const isDefault = !gatewayUrl;
 
-  function handleSubmit(values: FormData) {
+  // Saves the address, then asks the gateway for a well-known file once. The
+  // address is saved either way — an offline user must still be able to set
+  // it — but a host that does not answer is said so right here, instead of
+  // as the same generic failure on every NFT tile: the shape check below
+  // cannot tell a misspelled name from a real one, only the network can.
+  async function handleSubmit(values: FormData) {
     const input = values.gatewayUrl.trim();
+    setProbe(undefined);
     if (!input) {
       setGatewayUrl(undefined);
       return;
@@ -60,42 +75,72 @@ export default function IpfsGatewayUrl(props: IpfsGatewayUrlProps) {
     }
 
     setGatewayUrl(normalized === DEFAULT_IPFS_GATEWAY_BASE ? undefined : normalized);
+    try {
+      setProbe(await probeIpfsGateway(normalized));
+    } catch {
+      // the address passed the shape check above; a probe that cannot even be
+      // made leaves the downloads to report on the gateway
+    }
   }
 
   function handleReset() {
+    setProbe(undefined);
     setGatewayUrl(undefined);
   }
 
+  // Only a verdict on the address currently configured is shown: the probe of
+  // a previous address is dropped on save, and the health hook already limits
+  // itself to the configured gateway. The downloads verdict wins over the
+  // one-off probe — it is more recent and rests on more requests.
+  const configuredGateway = normalizeIpfsGatewayBase(gatewayUrl) ?? DEFAULT_IPFS_GATEWAY_BASE;
+  const currentProbe = probe?.gateway === configuredGateway ? probe : undefined;
+  const verdict = health ?? currentProbe;
+  const isUnreachable = verdict !== undefined && !verdict.reachable;
+
   return (
     <Form methods={methods} onSubmit={handleSubmit} noValidate>
-      <Flex gap={2} row alignItems="flex-start">
-        <TextField
-          name="gatewayUrl"
-          type="url"
-          placeholder={DEFAULT_IPFS_GATEWAY_BASE}
-          disabled={!canSubmit}
-          size="small"
-          fullWidth
-          inputProps={{
-            spellCheck: false,
-            autoCapitalize: 'off',
-            autoCorrect: 'off',
-          }}
-        />
-        <LoadingButton
-          size="small"
-          disabled={!canSubmit}
-          type="submit"
-          loading={isSubmitting}
-          variant="outlined"
-          color="secondary"
-        >
-          <Trans>Update</Trans>
-        </LoadingButton>
-        {!isDefault && (
-          <Button size="small" disabled={!canSubmit} variant="text" color="secondary" onClick={handleReset}>
-            <Trans>Reset</Trans>
-          </Button>
+      <Flex gap={1} flexDirection="column">
+        <Flex gap={2} row alignItems="flex-start">
+          <TextField
+            name="gatewayUrl"
+            type="url"
+            placeholder={DEFAULT_IPFS_GATEWAY_BASE}
+            disabled={!canSubmit}
+            size="small"
+            fullWidth
+            inputProps={{
+              spellCheck: false,
+              autoCapitalize: 'off',
+              autoCorrect: 'off',
+            }}
+          />
+          <LoadingButton
+            size="small"
+            disabled={!canSubmit}
+            type="submit"
+            loading={isSubmitting}
+            variant="outlined"
+            color="secondary"
+          >
+            <Trans>Update</Trans>
+          </LoadingButton>
+          {!isDefault && (
+            <Button size="small" disabled={!canSubmit} variant="text" color="secondary" onClick={handleReset}>
+              <Trans>Reset</Trans>
+            </Button>
+          )}
+        </Flex>
+        {isUnreachable && (
+          <Typography variant="body2" color="warning.main">
+            <Trans>
+              The gateway did not answer ({verdict.error}). The address is saved; check it if NFT previews stay empty.
+            </Trans>
+          </Typography>
+        )}
+        {!isUnreachable && currentProbe?.reachable && (
+          <Typography variant="body2" color="text.secondary">
+            <Trans>The gateway answered (HTTP {currentProbe.status}).</Trans>
+          </Typography>
         )}
       </Flex>
     </Form>

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -1896,6 +1896,36 @@ describe('CacheManager IPFS gateway recovery', () => {
     expect(mockDownloadFile).toHaveBeenCalledTimes(3);
   });
 
+  it('releases a failure whose transfer began before the recovery, even if it is written after it', async () => {
+    const cacheManager = new CacheManager({ cacheDirectory, maxCacheSize: 1024 });
+    await cacheManager.init();
+    await failToReachGateway(cacheManager, ['a.png', 'b.png', 'c.png']);
+
+    // one request is still in flight when another one gets through
+    let failInFlight!: (error: Error) => void;
+    mockDownloadFile.mockReset();
+    mockDownloadFile.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          failInFlight = reject;
+        }),
+    );
+    const inFlight = cacheManager.getContent(ipfsUrl('slow.png'));
+    await untilDownloadsStarted(1);
+    mockDownloadFile.mockImplementationOnce(serve);
+    await expect(cacheManager.getContent(ipfsUrl('d.png'))).resolves.toEqual(payload);
+    expect(cacheManager.getIpfsGatewayHealth()).toMatchObject({ reachable: true });
+
+    // its failure is written after the recovery was stamped
+    failInFlight(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    await expect(inFlight).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+
+    // yet it began before, so the next access fetches again
+    mockDownloadFile.mockImplementation(serve);
+    await expect(cacheManager.getContent(ipfsUrl('slow.png'))).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(3);
+  });
+
   it('releases them when a probe of the gateway gets an answer', async () => {
     const cacheManager = new CacheManager({ cacheDirectory, maxCacheSize: 1024 });
     await cacheManager.init();

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -45,6 +45,7 @@ jest.mock('./utils/ipfsGateway', () => ({
 
 const {
   default: CacheManager,
+  GATEWAY_UNREACHABLE_THRESHOLD,
   MAX_CACHE_INFO_LOOKUPS,
   TRANSIENT_ERROR_RETRY_DELAY,
   MAX_TRANSIENT_ERROR_RETRY_DELAY,
@@ -1715,5 +1716,122 @@ describe('CacheManager cache: responses', () => {
     expect(response.headers.get('x-content-type-options')).toBeNull();
     expect(response.headers.get('content-security-policy')).toBe("default-src 'none'; sandbox");
     expect(Buffer.from(await response.arrayBuffer())).toEqual(payload);
+  });
+});
+
+describe('CacheManager IPFS gateway health', () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    mockDownloadFile.mockReset();
+    mockIpfsGatewayBase.mockReturnValue('https://ipfs.io/ipfs/');
+    mockIpfsGatewayEnabled.mockReturnValue(true);
+    cacheDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'chia-cache-manager-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  async function createCacheManager() {
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+    const announcements: unknown[] = [];
+    cacheManager.on('ipfsGatewayHealthChanged', (health) => announcements.push(health));
+    return { cacheManager, announcements };
+  }
+
+  const ipfsUrl = (name: string) => `ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/${name}`;
+
+  it('reports the gateway unreachable once enough requests in a row cannot reach its host', async () => {
+    mockDownloadFile.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    const { cacheManager, announcements } = await createCacheManager();
+
+    for (const name of ['a.png', 'b.png']) {
+      // eslint-disable-next-line no-await-in-loop -- consecutive failures
+      await expect(cacheManager.getContent(ipfsUrl(name))).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+    }
+    expect(cacheManager.getIpfsGatewayHealth()).toBeUndefined();
+    expect(announcements).toEqual([]);
+
+    await expect(cacheManager.getContent(ipfsUrl('c.png'))).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+    const verdict = {
+      gateway: 'https://ipfs.io/ipfs/',
+      reachable: false,
+      error: 'net::ERR_NAME_NOT_RESOLVED',
+      failures: GATEWAY_UNREACHABLE_THRESHOLD,
+    };
+    expect(cacheManager.getIpfsGatewayHealth()).toEqual(verdict);
+    expect(announcements).toEqual([verdict]);
+
+    // one more of the same only lengthens the run
+    await expect(cacheManager.getContent(ipfsUrl('d.png'))).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+    expect(cacheManager.getIpfsGatewayHealth()).toMatchObject({ failures: GATEWAY_UNREACHABLE_THRESHOLD + 1 });
+    expect(announcements).toHaveLength(1);
+  });
+
+  it('withdraws the verdict as soon as the gateway answers', async () => {
+    mockDownloadFile.mockRejectedValue(new Error('net::ERR_CONNECTION_REFUSED'));
+    const { cacheManager, announcements } = await createCacheManager();
+    for (const name of ['a.png', 'b.png', 'c.png']) {
+      // eslint-disable-next-line no-await-in-loop -- consecutive failures
+      await expect(cacheManager.getContent(ipfsUrl(name))).rejects.toThrow();
+    }
+    expect(cacheManager.getIpfsGatewayHealth()).toMatchObject({ reachable: false });
+
+    // a status is an answer, whatever it says
+    mockDownloadFile.mockRejectedValue(new Error('HTTP error: 504'));
+    await expect(cacheManager.getContent(ipfsUrl('d.png'))).rejects.toThrow('HTTP error: 504');
+
+    expect(cacheManager.getIpfsGatewayHealth()).toEqual({
+      gateway: 'https://ipfs.io/ipfs/',
+      reachable: true,
+      failures: 0,
+    });
+    expect(announcements).toHaveLength(2);
+    expect(announcements[1]).toMatchObject({ reachable: true });
+  });
+
+  it('does not count failures of hosts other than the gateway, or aborts and stalls', async () => {
+    const { cacheManager, announcements } = await createCacheManager();
+
+    mockDownloadFile.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    for (const url of ['https://one.example/a.png', 'https://two.example/a.png', 'https://three.example/a.png']) {
+      // eslint-disable-next-line no-await-in-loop -- consecutive failures
+      await expect(cacheManager.getContent(url)).rejects.toThrow();
+    }
+    mockDownloadFile.mockRejectedValue(new Error('Request timed out after 30000ms of inactivity'));
+    for (const name of ['a.png', 'b.png', 'c.png']) {
+      // eslint-disable-next-line no-await-in-loop -- consecutive failures
+      await expect(cacheManager.getContent(ipfsUrl(name))).rejects.toThrow();
+    }
+
+    expect(cacheManager.getIpfsGatewayHealth()).toBeUndefined();
+    expect(announcements).toEqual([]);
+  });
+
+  it('starts the run over when the gateway changes', async () => {
+    mockDownloadFile.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    const { cacheManager, announcements } = await createCacheManager();
+    await expect(cacheManager.getContent(ipfsUrl('a.png'))).rejects.toThrow();
+    await expect(cacheManager.getContent(ipfsUrl('b.png'))).rejects.toThrow();
+
+    mockIpfsGatewayBase.mockReturnValue('https://ipfs.mintgraden.io/ipfs/');
+    await expect(cacheManager.getContent(ipfsUrl('c.png'))).rejects.toThrow();
+    expect(cacheManager.getIpfsGatewayHealth()).toBeUndefined();
+
+    await expect(cacheManager.getContent(ipfsUrl('d.png'))).rejects.toThrow();
+    await expect(cacheManager.getContent(ipfsUrl('e.png'))).rejects.toThrow();
+    expect(announcements).toEqual([
+      {
+        gateway: 'https://ipfs.mintgraden.io/ipfs/',
+        reachable: false,
+        error: 'net::ERR_NAME_NOT_RESOLVED',
+        failures: GATEWAY_UNREACHABLE_THRESHOLD,
+      },
+    ]);
   });
 });

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -34,6 +34,13 @@ jest.mock('./utils/ipcMainHandle', () => ({
   default: jest.fn(),
 }));
 
+const mockProbeIpfsGateway = jest.fn();
+
+jest.mock('./utils/probeIpfsGateway', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockProbeIpfsGateway(...args),
+}));
+
 const mockIpfsGatewayBase = jest.fn<string, []>(() => 'https://ipfs.io/ipfs/');
 const mockIpfsGatewayEnabled = jest.fn<boolean, []>(() => true);
 
@@ -1833,5 +1840,96 @@ describe('CacheManager IPFS gateway health', () => {
         failures: GATEWAY_UNREACHABLE_THRESHOLD,
       },
     ]);
+  });
+});
+
+describe('CacheManager IPFS gateway recovery', () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    mockDownloadFile.mockReset();
+    mockProbeIpfsGateway.mockReset();
+    mockIpfsGatewayBase.mockReturnValue('https://ipfs.io/ipfs/');
+    mockIpfsGatewayEnabled.mockReturnValue(true);
+    cacheDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'chia-cache-manager-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  const ipfsUrl = (name: string) => `ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/${name}`;
+  const payload = Buffer.from('cached payload');
+  const serve = async (_url: string, localPath: string) => {
+    await fs.writeFile(localPath, payload);
+    return { 'content-type': 'image/png' };
+  };
+
+  async function failToReachGateway(cacheManager: InstanceType<typeof CacheManager>, names: string[]) {
+    mockDownloadFile.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    for (const name of names) {
+      // eslint-disable-next-line no-await-in-loop -- consecutive failures
+      await expect(cacheManager.getContent(ipfsUrl(name))).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+    }
+  }
+
+  it('retries the failures recorded while the gateway was unreachable as soon as it answers', async () => {
+    const cacheManager = new CacheManager({ cacheDirectory, maxCacheSize: 1024 });
+    await cacheManager.init();
+    await failToReachGateway(cacheManager, ['a.png', 'b.png', 'c.png']);
+    expect(cacheManager.getIpfsGatewayHealth()).toMatchObject({ reachable: false });
+
+    // still inside the retry delay: the persisted failure is what a tile gets
+    mockDownloadFile.mockReset();
+    await expect(cacheManager.getContent(ipfsUrl('a.png'))).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+
+    // the gateway answers for another file
+    mockDownloadFile.mockImplementationOnce(serve);
+    await expect(cacheManager.getContent(ipfsUrl('d.png'))).resolves.toEqual(payload);
+    expect(cacheManager.getIpfsGatewayHealth()).toMatchObject({ reachable: true });
+
+    // the earlier failures are retried at once, not after their delay
+    mockDownloadFile.mockImplementation(serve);
+    await expect(cacheManager.getContent(ipfsUrl('a.png'))).resolves.toEqual(payload);
+    await expect(cacheManager.getContent(ipfsUrl('b.png'))).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(3);
+  });
+
+  it('releases them when a probe of the gateway gets an answer', async () => {
+    const cacheManager = new CacheManager({ cacheDirectory, maxCacheSize: 1024 });
+    await cacheManager.init();
+    await failToReachGateway(cacheManager, ['a.png', 'b.png', 'c.png']);
+
+    mockProbeIpfsGateway.mockResolvedValue({ gateway: 'https://ipfs.io/ipfs/', reachable: true, status: 200 });
+    await expect(cacheManager.probeIpfsGateway('https://ipfs.io')).resolves.toMatchObject({ reachable: true });
+    expect(cacheManager.getIpfsGatewayHealth()).toMatchObject({ reachable: true });
+
+    mockDownloadFile.mockReset();
+    mockDownloadFile.mockImplementation(serve);
+    await expect(cacheManager.getContent(ipfsUrl('a.png'))).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases only failures to reach the host, recorded before the recovery', async () => {
+    const cacheManager = new CacheManager({ cacheDirectory, maxCacheSize: 1024 });
+    await cacheManager.init();
+    await failToReachGateway(cacheManager, ['a.png', 'b.png', 'c.png']);
+    // a content failure through the same gateway, meanwhile
+    mockDownloadFile.mockRejectedValueOnce(new Error('HTTP error: 504'));
+    await expect(cacheManager.getContent(ipfsUrl('slow.png'))).rejects.toThrow('HTTP error: 504');
+
+    mockProbeIpfsGateway.mockResolvedValue({ gateway: 'https://ipfs.io/ipfs/', reachable: true, status: 200 });
+    await cacheManager.probeIpfsGateway('https://ipfs.io');
+
+    // a failure recorded after the recovery waits out its delay like any other
+    mockDownloadFile.mockRejectedValueOnce(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    await expect(cacheManager.getContent(ipfsUrl('e.png'))).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+
+    mockDownloadFile.mockReset();
+    mockDownloadFile.mockImplementation(serve);
+    await expect(cacheManager.getContent(ipfsUrl('slow.png'))).rejects.toThrow('HTTP error: 504');
+    await expect(cacheManager.getContent(ipfsUrl('e.png'))).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+    expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -1797,6 +1797,7 @@ describe('CacheManager IPFS gateway health', () => {
       gateway: 'https://ipfs.io/ipfs/',
       reachable: true,
       failures: 0,
+      recoveredAt: expect.any(Number),
     });
     expect(announcements).toHaveLength(2);
     expect(announcements[1]).toMatchObject({ reachable: true });

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -12,7 +12,9 @@ import type CacheInfo from '../@types/CacheInfo';
 import type CacheInfoBase from '../@types/CacheInfoBase';
 import type { CacheContent, CacheRequestOptions } from '../@types/CacheService';
 import type Headers from '../@types/Headers';
+import type IpfsGatewayHealth from '../@types/IpfsGatewayHealth';
 import CacheState from '../constants/CacheState';
+import { isHostUnreachableError } from '../util/downloadErrors';
 import ipfsToGatewayUrl, { getGatewayHost, getIpfsPathFromGatewayUrl, isIpfsBackedUrl, isIpfsUrl } from '../util/ipfs';
 import limit from '../util/limit';
 
@@ -31,6 +33,7 @@ import getChecksum from './utils/getChecksum';
 import ipcMainHandle from './utils/ipcMainHandle';
 import { IpfsGatewayDisabledError, ipfsGatewayBase, ipfsGatewayEnabled } from './utils/ipfsGateway';
 import isValidURL from './utils/isValidURL';
+import probeIpfsGateway from './utils/probeIpfsGateway';
 import sanitizeFilename from './utils/sanitizeFilename';
 import sanitizeNumber from './utils/sanitizeNumber';
 
@@ -109,6 +112,12 @@ export const TRANSIENT_ERROR_RETRY_DELAY = 10 * 60 * 1000; // 10 minutes
 // for as long as the wallet is open — a liveness beacon for whoever runs it.
 export const MAX_TRANSIENT_ERROR_RETRY_DELAY = 24 * 60 * 60 * 1000; // 1 day
 export const MAX_TRANSIENT_RETRIES = 8;
+
+// How many requests in a row must fail to reach the gateway host before the
+// gateway is reported unreachable (IpfsGatewayHealth). One failure is a
+// resolver hiccup; three requests to three names that all fail the same way
+// while nothing succeeds is the address.
+export const GATEWAY_UNREACHABLE_THRESHOLD = 3;
 
 // The wait before the next in-session retry of a URL that has failed
 // transiently `retries` times in a row: 10 min, 20 min, 40 min, ...
@@ -220,6 +229,14 @@ export default class CacheManager extends EventEmitter {
   // challenging host from being retried (and holding a download slot) on every
   // access in between.
   private transientFailureUrls: Set<string> = new Set();
+
+  // The gateway's reachability as the downloads through it report it: the
+  // current run of requests that could not reach the host, and the verdict
+  // last announced to the renderer (undefined until one is). A verdict is on
+  // one gateway; a request through another gateway starts both over.
+  private gatewayHostFailures: { gateway: string; count: number; error: string } | undefined;
+
+  private gatewayHealth: IpfsGatewayHealth | undefined;
 
   // Clear, migration and invalidation share one barrier. Waiters must not enter
   // the request map until admitted: maintenance drains that map, so a request
@@ -412,6 +429,11 @@ export default class CacheManager extends EventEmitter {
       guarded((urls: string[]) => this.getCacheInfos(urls)),
     );
 
+    ipcMainHandle(
+      CacheAPI.PROBE_IPFS_GATEWAY,
+      guarded((gateway: string) => this.probeIpfsGateway(gateway)),
+    );
+    ipcMainHandle(CacheAPI.GET_IPFS_GATEWAY_HEALTH, () => this.getIpfsGatewayHealth());
     ipcMainHandle(CacheAPI.GET_CACHE_DIRECTORY, () => this.cacheDirectory);
     ipcMainHandle(CacheAPI.GET_MAX_CACHE_SIZE, () => this.maxCacheSize);
   }
@@ -463,14 +485,22 @@ export default class CacheManager extends EventEmitter {
       }, 500);
     };
 
+    function onIpfsGatewayHealthChanged(health: IpfsGatewayHealth) {
+      if (!window.isDestroyed()) {
+        window.webContents.send(CacheAPI.ON_IPFS_GATEWAY_HEALTH_CHANGED, health);
+      }
+    }
+
     this.on('cacheDirectoryChanged', onCacheDirectoryChanged);
     this.on('maxCacheSizeChanged', onMaxCacheSizeChanged);
     this.on('sizeChanged', onSizeChanged);
+    this.on('ipfsGatewayHealthChanged', onIpfsGatewayHealthChanged);
 
     const unbind = () => {
       this.off('cacheDirectoryChanged', onCacheDirectoryChanged);
       this.off('maxCacheSizeChanged', onMaxCacheSizeChanged);
       this.off('sizeChanged', onSizeChanged);
+      this.off('ipfsGatewayHealthChanged', onIpfsGatewayHealthChanged);
       sizeChangedDuringScan = false;
       if (sizeChangedTimeout) {
         clearTimeout(sizeChangedTimeout);
@@ -825,6 +855,10 @@ export default class CacheManager extends EventEmitter {
     // the persisted outcome this attempt is retrying, if any — a transient
     // failure recorded on top of an earlier one continues its retry count
     let previousCacheInfo: CacheInfo | undefined;
+    // whether the transfer went to the gateway — an ipfs:// URI always does, a
+    // gateway link only once its own host failed and the fallback ran — so an
+    // outcome is charged to the gateway's health only when it was the gateway's
+    let gatewayLegUsed = requestGateway !== undefined && isIpfsUrl(url);
 
     const process = async (): Promise<CacheInfo> => {
       try {
@@ -893,6 +927,7 @@ export default class CacheManager extends EventEmitter {
             }
 
             log(`Download failed (${(downloadError as Error).message}), retrying through the gateway`, url);
+            gatewayLegUsed = true;
             headers = await downloadFile(url, cacheFilePath, {
               ...downloadOptions,
               requestUrl: fallbackUrl,
@@ -902,6 +937,9 @@ export default class CacheManager extends EventEmitter {
 
           transferDeadline.throwIfExpired();
           log('Download finished', url);
+          if (gatewayLegUsed) {
+            this.noteGatewayAnswered(requestGateway);
+          }
 
           // compute checksum
           const checksum = await getChecksum(cacheFilePath);
@@ -951,6 +989,9 @@ export default class CacheManager extends EventEmitter {
         const currentError = this.redactCachePath(
           transferDeadline.error ?? (error as Error) ?? new Error('Unknown fetchRemoteContent error'),
         );
+        if (gatewayLegUsed) {
+          this.noteGatewayOutcome(requestGateway, currentError.message);
+        }
 
         const isTransient = isTransientDownloadError(currentError.message);
         if (isTransient) {
@@ -987,6 +1028,76 @@ export default class CacheManager extends EventEmitter {
     this.ongoingRequests.set(url, ongoingRequestEntry);
 
     return consume(ongoingRequestEntry);
+  }
+
+  /** Whether the configured gateway can be reached, as the downloads through
+   * it have shown, or undefined while no verdict has been reached. */
+  getIpfsGatewayHealth(): IpfsGatewayHealth | undefined {
+    return this.gatewayHealth;
+  }
+
+  /** Asks the gateway at `input` for a well-known file once (see
+   * probeIpfsGateway). An answer also clears an "unreachable" verdict on that
+   * gateway: the user just saw it respond, so the tiles get to try again. */
+  async probeIpfsGateway(input: string) {
+    const result = await probeIpfsGateway(input);
+    if (result.reachable) {
+      this.noteGatewayAnswered(result.gateway);
+    }
+    return result;
+  }
+
+  // A request through `gateway` failed with `message`. A failure to reach the
+  // host at all lengthens the current run against that gateway and, at the
+  // threshold, announces the gateway unreachable; an HTTP status is an answer
+  // and ends the run. Anything else — an abort from our side, a transfer that
+  // stalled or outran its deadline — says nothing about the host either way.
+  private noteGatewayOutcome(gateway: string | undefined, message: string) {
+    if (gateway === undefined) {
+      return;
+    }
+    if (message.startsWith('HTTP error: ')) {
+      this.noteGatewayAnswered(gateway);
+      return;
+    }
+    if (!isHostUnreachableError(message)) {
+      return;
+    }
+    const failures =
+      this.gatewayHostFailures?.gateway === gateway
+        ? { ...this.gatewayHostFailures, count: this.gatewayHostFailures.count + 1, error: message }
+        : { gateway, count: 1, error: message };
+    this.gatewayHostFailures = failures;
+    if (failures.count < GATEWAY_UNREACHABLE_THRESHOLD) {
+      return;
+    }
+    const previous = this.gatewayHealth;
+    if (previous?.gateway === gateway && !previous.reachable && previous.error === message) {
+      // the same verdict, one failure longer — nothing new for the renderer
+      this.gatewayHealth = { ...previous, failures: failures.count };
+      return;
+    }
+    this.announceGatewayHealth({ gateway, reachable: false, error: message, failures: failures.count });
+  }
+
+  // The host at `gateway` answered something: a download completed, a status
+  // came back, a probe got a status line. The run of failures against it
+  // ends, and an "unreachable" verdict on it is withdrawn.
+  private noteGatewayAnswered(gateway: string | undefined) {
+    if (gateway === undefined) {
+      return;
+    }
+    if (this.gatewayHostFailures?.gateway === gateway) {
+      this.gatewayHostFailures = undefined;
+    }
+    if (this.gatewayHealth?.gateway === gateway && !this.gatewayHealth.reachable) {
+      this.announceGatewayHealth({ gateway, reachable: true, failures: 0 });
+    }
+  }
+
+  private announceGatewayHealth(health: IpfsGatewayHealth) {
+    this.gatewayHealth = health;
+    this.emit('ipfsGatewayHealthChanged', health);
   }
 
   // How many transient failures in a row the persisted outcome already

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -244,6 +244,12 @@ export default class CacheManager extends EventEmitter {
 
   private gatewayHealth: IpfsGatewayHealth | undefined;
 
+  // When a gateway last answered after a run of requests that could not reach
+  // it. Failures recorded against it before that moment were verdicts on an
+  // unreachable host, not on the content, and are retried on the next access
+  // instead of waiting out their retry delay (see isSettledOutcome).
+  private gatewayRecoveredAt: Map<string, number> = new Map();
+
   // Clear, migration and invalidation share one barrier. Waiters must not enter
   // the request map until admitted: maintenance drains that map, so a request
   // which itself awaits maintenance would create a circular wait.
@@ -741,7 +747,16 @@ export default class CacheManager extends EventEmitter {
       isIpfsBackedUrl(url) &&
       ipfsGatewayEnabled() &&
       (cacheInfo.gateway === undefined ? !isIpfsUrl(url) : cacheInfo.gateway !== ipfsGatewayBase());
-    return !isAbortError && !isRetriableTransientError && !isLimitLifted && !isGatewayChanged;
+    // A failure to reach the gateway host, recorded before the gateway was
+    // last seen answering, says nothing about the content: the host was down
+    // (or the address was wrong) and is not any more.
+    const isRecoveredGatewayFailure =
+      cacheInfo.gateway !== undefined &&
+      isHostUnreachableError(cacheInfo.error) &&
+      (this.gatewayRecoveredAt.get(cacheInfo.gateway) ?? 0) > cacheInfo.timestamp;
+    return (
+      !isAbortError && !isRetriableTransientError && !isLimitLifted && !isGatewayChanged && !isRecoveredGatewayFailure
+    );
   }
 
   async fetchRemoteContent(
@@ -1108,11 +1123,18 @@ export default class CacheManager extends EventEmitter {
     if (gateway === undefined) {
       return;
     }
+    const wasFailing =
+      this.gatewayHostFailures?.gateway === gateway ||
+      (this.gatewayHealth?.gateway === gateway && !this.gatewayHealth.reachable);
     if (this.gatewayHostFailures?.gateway === gateway) {
       this.gatewayHostFailures = undefined;
     }
     if (this.gatewayHealth?.gateway === gateway && !this.gatewayHealth.reachable) {
       this.announceGatewayHealth({ gateway, reachable: true, failures: 0 });
+    }
+    if (wasFailing) {
+      // the failures recorded meanwhile are released for retry
+      this.gatewayRecoveredAt.set(gateway, Date.now());
     }
   }
 

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -747,13 +747,16 @@ export default class CacheManager extends EventEmitter {
       isIpfsBackedUrl(url) &&
       ipfsGatewayEnabled() &&
       (cacheInfo.gateway === undefined ? !isIpfsUrl(url) : cacheInfo.gateway !== ipfsGatewayBase());
-    // A failure to reach the gateway host, recorded before the gateway was
-    // last seen answering, says nothing about the content: the host was down
-    // (or the address was wrong) and is not any more.
+    // A failure to reach the gateway host whose transfer began before the
+    // gateway was last seen answering says nothing about the content: the
+    // host was down (or the address was wrong) and is not any more. Dated by
+    // the transfer's start (startedAt), not the sidecar's write: a request in
+    // flight when another one got through fails, and is written, after the
+    // recovery was stamped, yet its failure predates it.
     const isRecoveredGatewayFailure =
       cacheInfo.gateway !== undefined &&
       isHostUnreachableError(cacheInfo.error) &&
-      (this.gatewayRecoveredAt.get(cacheInfo.gateway) ?? 0) > cacheInfo.timestamp;
+      (this.gatewayRecoveredAt.get(cacheInfo.gateway) ?? 0) > (cacheInfo.startedAt ?? cacheInfo.timestamp);
     return (
       !isAbortError && !isRetriableTransientError && !isLimitLifted && !isGatewayChanged && !isRecoveredGatewayFailure
     );
@@ -905,6 +908,9 @@ export default class CacheManager extends EventEmitter {
     // gateway link only once its own host failed and the fallback ran — so an
     // outcome is charged to the gateway's health only when it was the gateway's
     let gatewayLegUsed = requestGateway !== undefined && isIpfsUrl(url);
+    // when the transfer itself began — a failure to reach the gateway is dated
+    // by this, not by when its sidecar was written (see isRecoveredGatewayFailure)
+    let transferStartedAt: number | undefined;
 
     const process = async (): Promise<CacheInfo> => {
       try {
@@ -944,6 +950,7 @@ export default class CacheManager extends EventEmitter {
             throw new SharedDownloadBudgetSpentError();
           }
           transferDeadline.start();
+          transferStartedAt = Date.now();
           const downloadOptions = {
             timeout,
             maxSize,
@@ -1040,6 +1047,11 @@ export default class CacheManager extends EventEmitter {
           ...(isTransient ? { retries: this.consecutiveTransientFailures(previousCacheInfo, requestGateway) + 1 } : {}),
           // which gateway the verdict belongs to (see isGatewayChanged above)
           ...(requestGateway === undefined ? {} : { gateway: requestGateway }),
+          // when a failure to reach the gateway began, so a recovery of the
+          // gateway between the start and this write still releases it
+          ...(gatewayLegUsed && isHostUnreachableError(currentError.message)
+            ? { startedAt: transferStartedAt ?? Date.now() }
+            : {}),
         });
         // Failed downloads own sidecars too, even when no data file arrived.
         await this.trimCache(this.getCacheFilePath(url));

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -1141,12 +1141,13 @@ export default class CacheManager extends EventEmitter {
     if (this.gatewayHostFailures?.gateway === gateway) {
       this.gatewayHostFailures = undefined;
     }
-    if (this.gatewayHealth?.gateway === gateway && !this.gatewayHealth.reachable) {
-      this.announceGatewayHealth({ gateway, reachable: true, failures: 0 });
-    }
+    const recoveredAt = Date.now();
     if (wasFailing) {
       // the failures recorded meanwhile are released for retry
-      this.gatewayRecoveredAt.set(gateway, Date.now());
+      this.gatewayRecoveredAt.set(gateway, recoveredAt);
+    }
+    if (this.gatewayHealth?.gateway === gateway && !this.gatewayHealth.reachable) {
+      this.announceGatewayHealth({ gateway, reachable: true, failures: 0, recoveredAt });
     }
   }
 

--- a/packages/gui/src/electron/constants/CacheAPI.ts
+++ b/packages/gui/src/electron/constants/CacheAPI.ts
@@ -22,10 +22,15 @@ enum CacheAPI {
   GET_CACHE_INFOS = `${API.CACHE}:getCacheInfos`,
   INVALIDATE = `${API.CACHE}:invalidate`,
 
+  // IPFS gateway reachability
+  PROBE_IPFS_GATEWAY = `${API.CACHE}:probeIpfsGateway`,
+  GET_IPFS_GATEWAY_HEALTH = `${API.CACHE}:getIpfsGatewayHealth`,
+
   // Event subscriptions
   ON_CACHE_DIRECTORY_CHANGED = `${API.CACHE}:onCacheDirectoryChanged`,
   ON_MAX_CACHE_SIZE_CHANGED = `${API.CACHE}:onMaxCacheSizeChanged`,
   ON_SIZE_CHANGED = `${API.CACHE}:onSizeChanged`,
+  ON_IPFS_GATEWAY_HEALTH_CHANGED = `${API.CACHE}:onIpfsGatewayHealthChanged`,
 }
 
 export default CacheAPI;

--- a/packages/gui/src/electron/preload.ts
+++ b/packages/gui/src/electron/preload.ts
@@ -136,11 +136,15 @@ contextBridge.exposeInMainWorld(API.CACHE, {
   getURI: (url: string, options?: CacheRequestOptions) => invokeWithCustomErrors(CacheAPI.GET_URI, url, options),
   invalidate: (url: string) => invokeWithCustomErrors(CacheAPI.INVALIDATE, url),
   getCacheInfos: (urls: string[]) => invokeWithCustomErrors(CacheAPI.GET_CACHE_INFOS, urls),
+  probeIpfsGateway: (gateway: string) => invokeWithCustomErrors(CacheAPI.PROBE_IPFS_GATEWAY, gateway),
+  getIpfsGatewayHealth: () => invokeWithCustomErrors(CacheAPI.GET_IPFS_GATEWAY_HEALTH),
   subscribeToDirectoryChange: (callback: (...args: unknown[]) => void) =>
     onIpcEvent(CacheAPI.ON_CACHE_DIRECTORY_CHANGED, callback),
   subscribeToMaxSizeChange: (callback: (...args: unknown[]) => void) =>
     onIpcEvent(CacheAPI.ON_MAX_CACHE_SIZE_CHANGED, callback),
   subscribeToSizeChange: (callback: (...args: unknown[]) => void) => onIpcEvent(CacheAPI.ON_SIZE_CHANGED, callback),
+  subscribeToIpfsGatewayHealthChange: (callback: (...args: unknown[]) => void) =>
+    onIpcEvent(CacheAPI.ON_IPFS_GATEWAY_HEALTH_CHANGED, callback),
 });
 
 contextBridge.exposeInMainWorld(API.WEBSOCKET, {

--- a/packages/gui/src/electron/utils/downloadFile.test.ts
+++ b/packages/gui/src/electron/utils/downloadFile.test.ts
@@ -351,3 +351,40 @@ describe('normalizeTimeout', () => {
     expect(normalizeTimeout(value)).toBe(expected);
   });
 });
+
+describe('isHostUnreachableError', () => {
+  const { isHostUnreachableError } =
+    jest.requireActual<typeof import('../../util/downloadErrors')>('../../util/downloadErrors');
+
+  it.each([
+    'net::ERR_NAME_NOT_RESOLVED',
+    'net::ERR_NAME_RESOLUTION_FAILED',
+    'net::ERR_CONNECTION_REFUSED',
+    'net::ERR_ADDRESS_UNREACHABLE',
+    'net::ERR_ADDRESS_INVALID',
+    'net::ERR_SSL_PROTOCOL_ERROR',
+    // what listens at that name is not the gateway the address names
+    'net::ERR_CERT_COMMON_NAME_INVALID',
+    'net::ERR_CERT_AUTHORITY_INVALID',
+  ])('treats %p as the host being unreachable', (message) => {
+    expect(isHostUnreachableError(message)).toBe(true);
+  });
+
+  it.each([
+    // the host answered
+    'HTTP error: 404',
+    'HTTP error: 429',
+    'HTTP error: 504',
+    // the host accepted the connection, then went quiet or was cut off
+    'Request timed out after 30000ms of inactivity',
+    'Request exceeded the 30000ms download deadline',
+    'net::ERR_CONNECTION_RESET',
+    'net::ERR_BLOCKED_BY_RESPONSE',
+    // this machine, not the host
+    'net::ERR_INTERNET_DISCONNECTED',
+    'Request aborted',
+    'Maximum file size exceeded',
+  ])('does not treat %p as the host being unreachable', (message) => {
+    expect(isHostUnreachableError(message)).toBe(false);
+  });
+});

--- a/packages/gui/src/electron/utils/probeIpfsGateway.test.ts
+++ b/packages/gui/src/electron/utils/probeIpfsGateway.test.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from 'node:events';
+
+const mockNetRequest = jest.fn();
+
+jest.mock('electron', () => ({
+  net: {
+    request: mockNetRequest,
+  },
+}));
+
+const { default: probeIpfsGateway, IPFS_GATEWAY_PROBE_CID } =
+  jest.requireActual<typeof import('./probeIpfsGateway')>('./probeIpfsGateway');
+
+type MockRequest = EventEmitter & { end: jest.Mock; abort: jest.Mock; setHeader: jest.Mock };
+
+describe('probeIpfsGateway', () => {
+  let request: MockRequest;
+
+  beforeEach(() => {
+    mockNetRequest.mockReset();
+    request = Object.assign(new EventEmitter(), { end: jest.fn(), abort: jest.fn(), setHeader: jest.fn() });
+    mockNetRequest.mockReturnValue(request);
+  });
+
+  it('asks the normalized gateway for the empty file without following redirects', async () => {
+    const pending = probeIpfsGateway('https://ipfs.example//');
+    request.emit('response', { statusCode: 200, headers: {} });
+
+    await expect(pending).resolves.toEqual({
+      gateway: 'https://ipfs.example/ipfs/',
+      reachable: true,
+      status: 200,
+    });
+    expect(mockNetRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        url: `https://ipfs.example/ipfs/${IPFS_GATEWAY_PROBE_CID}`,
+        redirect: 'manual',
+      }),
+    );
+    // the status line was all that was wanted
+    expect(request.abort).toHaveBeenCalled();
+  });
+
+  it.each([404, 429, 504])('treats an HTTP %s as the gateway answering', async (statusCode) => {
+    const pending = probeIpfsGateway('https://ipfs.example');
+    request.emit('response', { statusCode, headers: {} });
+
+    await expect(pending).resolves.toMatchObject({ reachable: true, status: statusCode });
+  });
+
+  it('treats a redirect as the gateway answering, without following it', async () => {
+    const pending = probeIpfsGateway('https://ipfs.example');
+    request.emit('redirect', 301, 'GET', 'https://elsewhere.example/', {});
+
+    await expect(pending).resolves.toMatchObject({ reachable: true, status: 301 });
+    expect(request.abort).toHaveBeenCalled();
+  });
+
+  it('reports the network error when the host cannot be reached', async () => {
+    const pending = probeIpfsGateway('https://ipfs.mintgraden.io');
+    request.emit('error', new Error('net::ERR_NAME_NOT_RESOLVED'));
+
+    await expect(pending).resolves.toEqual({
+      gateway: 'https://ipfs.mintgraden.io/ipfs/',
+      reachable: false,
+      error: 'net::ERR_NAME_NOT_RESOLVED',
+    });
+  });
+
+  it('gives up on a gateway that never sends its status line', async () => {
+    const pending = probeIpfsGateway('https://ipfs.example', { timeout: 20 });
+
+    await expect(pending).resolves.toMatchObject({ reachable: false, error: 'Request timeout after 20ms' });
+    expect(request.abort).toHaveBeenCalled();
+  });
+
+  it('settles once: an abort after the answer changes nothing', async () => {
+    const pending = probeIpfsGateway('https://ipfs.example');
+    request.emit('response', { statusCode: 200, headers: {} });
+    request.emit('abort');
+
+    await expect(pending).resolves.toMatchObject({ reachable: true, status: 200 });
+  });
+
+  it.each(['not a url', 'http://ipfs.example', 'ftp://ipfs.example', ''])(
+    'refuses %p instead of requesting it',
+    async (input) => {
+      await expect(probeIpfsGateway(input)).rejects.toThrow('Invalid IPFS gateway address');
+      expect(mockNetRequest).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/gui/src/electron/utils/probeIpfsGateway.ts
+++ b/packages/gui/src/electron/utils/probeIpfsGateway.ts
@@ -1,0 +1,82 @@
+import { net, type IncomingMessage } from 'electron';
+
+import type IpfsGatewayProbeResult from '../../@types/IpfsGatewayProbeResult';
+import ipfsToGatewayUrl, { normalizeIpfsGatewayBase } from '../../util/ipfs';
+
+import { isValidRequestURL } from './isValidURL';
+
+// The empty file (CIDv1, raw, sha2-256 of nothing): every gateway can serve it
+// without fetching anything, so a probe for it says whether the address names
+// a gateway at all rather than whether some content happens to be pinned.
+export const IPFS_GATEWAY_PROBE_CID = 'bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku';
+// Long enough for a gateway that is merely slow to send its status line, short
+// enough that the settings field does not appear frozen after "Update".
+export const IPFS_GATEWAY_PROBE_TIMEOUT = 10_000;
+
+/** Asks the gateway at `input` for the empty file once and reports whether
+ * the host answered. Only the response status line is waited for; the body is
+ * never read and a redirect is not followed — either already proves a host
+ * listens at that name and speaks HTTP, which is all the settings field wants
+ * to confirm. A wrong address fails here with the network error the tiles
+ * would otherwise each report (net::ERR_NAME_NOT_RESOLVED and the like). */
+export default async function probeIpfsGateway(
+  input: string,
+  options: { timeout?: number } = {},
+): Promise<IpfsGatewayProbeResult> {
+  const { timeout = IPFS_GATEWAY_PROBE_TIMEOUT } = options;
+  const gateway = normalizeIpfsGatewayBase(input);
+  if (!gateway) {
+    throw new Error('Invalid IPFS gateway address');
+  }
+
+  const url = ipfsToGatewayUrl(`ipfs://${IPFS_GATEWAY_PROBE_CID}`, gateway);
+  if (!isValidRequestURL(url)) {
+    throw new Error('Invalid IPFS gateway address');
+  }
+
+  const request = net.request({
+    method: 'GET',
+    url,
+    // a redirect is an answer; where it points is not followed
+    redirect: 'manual',
+  });
+
+  return new Promise<IpfsGatewayProbeResult>((resolve) => {
+    let settled = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    const settle = (result: Omit<IpfsGatewayProbeResult, 'gateway'>) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      resolve({ gateway, ...result });
+    };
+
+    timeoutId = setTimeout(() => {
+      settle({ reachable: false, error: `Request timeout after ${timeout}ms` });
+      request.abort();
+    }, timeout);
+
+    request.on('response', (response: IncomingMessage) => {
+      settle({ reachable: true, status: response.statusCode });
+      // the status line is all that was wanted
+      request.abort();
+    });
+    request.on('redirect', (statusCode: number) => {
+      settle({ reachable: true, status: statusCode });
+      request.abort();
+    });
+    request.on('error', (error: Error) => {
+      settle({ reachable: false, error: error.message });
+    });
+    request.on('abort', () => {
+      // an abort not caused by the probe itself (app quitting) — only when nothing else settled it
+      settle({ reachable: false, error: 'Request aborted' });
+    });
+    request.end();
+  });
+}

--- a/packages/gui/src/hooks/useIpfsGatewayHealth.ts
+++ b/packages/gui/src/hooks/useIpfsGatewayHealth.ts
@@ -19,20 +19,25 @@ export default function useIpfsGatewayHealth(): IpfsGatewayHealth | undefined {
 
   useEffect(() => {
     let cancelled = false;
+    // The snapshot is a round trip behind the subscription: a verdict announced
+    // while it was in flight is newer than what it returns, and must not be
+    // overwritten by it.
+    let announced = false;
+    const unsubscribe = subscribeToIpfsGatewayHealthChange((next) => {
+      if (!cancelled) {
+        announced = true;
+        setHealth(next);
+      }
+    });
     getIpfsGatewayHealth()
       .then((current) => {
-        if (!cancelled) {
+        if (!cancelled && !announced) {
           setHealth(current ?? undefined);
         }
       })
       .catch(() => {
-        // nothing known yet; the subscription below delivers the first verdict
+        // nothing known yet; the subscription delivers the first verdict
       });
-    const unsubscribe = subscribeToIpfsGatewayHealthChange((next) => {
-      if (!cancelled) {
-        setHealth(next);
-      }
-    });
     return () => {
       cancelled = true;
       unsubscribe();

--- a/packages/gui/src/hooks/useIpfsGatewayHealth.ts
+++ b/packages/gui/src/hooks/useIpfsGatewayHealth.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type IpfsGatewayHealth from '../@types/IpfsGatewayHealth';
+
+import useCache from './useCache';
+import useIpfsGateway from './useIpfsGateway';
+import { useIpfsGatewayBase } from './useIpfsGatewayUrl';
+
+// What the main process has learned about the configured IPFS gateway from
+// the downloads it made through it (see IpfsGatewayHealth) — undefined while
+// nothing is known, while the gateway option is off, and for a verdict on a
+// gateway other than the one currently configured, so a stale verdict on the
+// previous address never outlives a change of address.
+export default function useIpfsGatewayHealth(): IpfsGatewayHealth | undefined {
+  const { getIpfsGatewayHealth, subscribeToIpfsGatewayHealthChange } = useCache();
+  const [ipfsGateway] = useIpfsGateway();
+  const gatewayBase = useIpfsGatewayBase();
+  const [health, setHealth] = useState<IpfsGatewayHealth | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    getIpfsGatewayHealth()
+      .then((current) => {
+        if (!cancelled) {
+          setHealth(current ?? undefined);
+        }
+      })
+      .catch(() => {
+        // nothing known yet; the subscription below delivers the first verdict
+      });
+    const unsubscribe = subscribeToIpfsGatewayHealthChange((next) => {
+      if (!cancelled) {
+        setHealth(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [getIpfsGatewayHealth, subscribeToIpfsGatewayHealthChange]);
+
+  return useMemo(
+    () => (ipfsGateway && health && health.gateway === gatewayBase ? health : undefined),
+    [ipfsGateway, health, gatewayBase],
+  );
+}

--- a/packages/gui/src/hooks/useNFTVerifyHash.ts
+++ b/packages/gui/src/hooks/useNFTVerifyHash.ts
@@ -11,6 +11,7 @@ import useIpfsGateway from './useIpfsGateway';
 import { useIpfsGatewayBase } from './useIpfsGatewayUrl';
 import useNFT from './useNFT';
 import useNFTMetadata from './useNFTMetadata';
+import useNFTProvider from './useNFTProvider';
 
 export type UseNFTVerifyHashOptions = {
   preview?: boolean;
@@ -53,6 +54,9 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
   // already on screen would keep their failed state until a remount.
   const [ipfsGateway] = useIpfsGateway();
   const ipfsGatewayBase = useIpfsGatewayBase();
+  // a gateway that came back after being unreachable re-runs verification the
+  // way a gateway change does: the failures remembered meanwhile were the host's
+  const { ipfsGatewayRecoveries } = useNFTProvider();
 
   const { nft, isLoading: isLoadingNFT, error: errorNFT } = useNFT(nftId);
   const { isLoading: isLoadingMetadata, metadata, error: errorMetadata } = useNFTMetadata(nftId);
@@ -120,12 +124,12 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
     () => createNFTUriVerifier(getChecksum, ignoreSizeLimit ? -1 : undefined),
     // A refresh or gateway/size-policy change must discard remembered failures.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Input identity deliberately defines memo lifetime.
-    [getChecksum, ignoreSizeLimit, nft, ipfsGateway, ipfsGatewayBase],
+    [getChecksum, ignoreSizeLimit, nft, ipfsGateway, ipfsGatewayBase, ipfsGatewayRecoveries],
   );
   const findPreviewUri = useMemo(
     () => createNFTUriVerifier(getChecksum, ignoreSizeLimit ? -1 : undefined),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Metadata refresh resets preview decisions only.
-    [getChecksum, ignoreSizeLimit, nft, metadata, ipfsGateway, ipfsGatewayBase],
+    [getChecksum, ignoreSizeLimit, nft, metadata, ipfsGateway, ipfsGatewayBase, ipfsGatewayRecoveries],
   );
 
   const validateData = useCallback(
@@ -203,7 +207,7 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
         dataGeneration.current += 1;
       }
     };
-  }, [nft, isLoadingNFT, validateData, ipfsGateway, ipfsGatewayBase]);
+  }, [nft, isLoadingNFT, validateData, ipfsGateway, ipfsGatewayBase, ipfsGatewayRecoveries]);
 
   useEffect(() => {
     const generation = previewGeneration.current + 1;
@@ -242,6 +246,7 @@ export default function useNFTVerifyHash(nftId?: string, options: UseNFTVerifyHa
     validatePreview,
     ipfsGateway,
     ipfsGatewayBase,
+    ipfsGatewayRecoveries,
     excludedPreviewKey,
   ]);
 

--- a/packages/gui/src/util/downloadErrors.ts
+++ b/packages/gui/src/util/downloadErrors.ts
@@ -81,6 +81,28 @@ const PERMANENT_NET_ERRORS = new Set([
 // made from it would settle the entry for something the url did nothing.
 const TRANSIENT_LOCAL_ERROR_CODES = ['EMFILE', 'ENFILE', 'EAGAIN', 'EBUSY', 'ENOSPC', 'EIO'];
 
+// Chromium network errors that say the request never reached a host at the
+// URL's name: the name does not resolve, nothing listens at the address, or
+// what listens presents a certificate for some other name. For a request
+// through the IPFS gateway these describe the gateway address itself, not the
+// content behind it — every request through a misspelled gateway fails this
+// way — which is what CacheManager's gateway health reports on.
+const HOST_UNREACHABLE_NET_ERRORS = new Set([
+  'net::ERR_NAME_NOT_RESOLVED',
+  'net::ERR_NAME_RESOLUTION_FAILED',
+  'net::ERR_CONNECTION_REFUSED',
+  'net::ERR_ADDRESS_UNREACHABLE',
+  'net::ERR_ADDRESS_INVALID',
+  'net::ERR_SSL_PROTOCOL_ERROR',
+]);
+
+/** Whether a download failure says the host itself could not be reached
+ * (see HOST_UNREACHABLE_NET_ERRORS), as opposed to a host that answered — with
+ * an HTTP status, a redirect, or silence after accepting the connection. */
+export function isHostUnreachableError(message: string): boolean {
+  return HOST_UNREACHABLE_NET_ERRORS.has(message) || message.startsWith('net::ERR_CERT_');
+}
+
 export function isTransientDownloadError(message: string): boolean {
   if (isDownloadTimeoutError(message)) {
     return true;


### PR DESCRIPTION
Follow-up to #3061 / #3066, found while testing the stack. **Stack (merge in this order):** #3060 → #3061 → #3066 → #3062 → #3067 → #3068 → #3069 → #3063 → this PR. **Stacked on #3063** (its commits are included here; this PR's own work is the single commit after the merge commit "Merge fix/nft-confirmation-preview-freeze into feat/nft-unplayable-media-notice: joiners of a cache hit no longer wait forever…"). Targets `release/2.7.4`.

## Problem

A misspelled gateway address (`ipfs.mintgraden.io` for `ipfs.mintgarden.io`, seen on a real wallet) fails every NFT fetched through the gateway the same way — each download ends in `net::ERR_NAME_NOT_RESOLVED` — and the gallery showed that as one generic failure per tile with nothing pointing at the address. The settings field only checked the shape of the URL, which cannot tell a misspelled name from a real one; only the network can.

## Change

**Main process** — `CacheManager` keeps a verdict on the gateway in use, learned from the downloads that went through it:

- `isHostUnreachableError` (in `util/downloadErrors.ts`) names the Chromium errors that mean the request never reached a host at the URL's name: `ERR_NAME_NOT_RESOLVED`, `ERR_NAME_RESOLUTION_FAILED`, `ERR_CONNECTION_REFUSED`, `ERR_ADDRESS_UNREACHABLE`, `ERR_ADDRESS_INVALID`, `ERR_SSL_PROTOCOL_ERROR` and the `ERR_CERT_*` family (what listens there is not the gateway the address names). A status, a timeout after the connection, an abort or a reset are not: the host was reached, or nothing is known.
- After `GATEWAY_UNREACHABLE_THRESHOLD` (3) requests in a row that could not reach the host, the gateway is announced unreachable over IPC (`IpfsGatewayHealth`: gateway, error, failures); it is announced reachable again as soon as it answers anything — a completed download, any HTTP status, or a probe. Only the gateway's own leg counts: a gateway link is charged to the gateway only once its own host has failed and the fallback ran, and a change of gateway starts the run over. Nothing is persisted; the verdict lives with the process.
- `probeIpfsGateway(address)` asks the gateway for the empty-file CID (`bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku`, which every gateway can serve without fetching anything) and waits for the status line only: no body is read, a redirect is not followed (`redirect: 'manual'`, the redirect itself is the answer), 10 s timeout. Any status — 404, 429, 504 included — means the address names a gateway; a network error means it does not, and is reported. Reachable via IPC as `cacheAPI.probeIpfsGateway`; a probe that gets an answer also withdraws a standing "unreachable" verdict on that gateway.

**Renderer**

- `useIpfsGatewayHealth()` subscribes to the verdict and returns it only while the gateway option is on and only for the gateway currently configured, so a verdict on a previous address never outlives a change of address.
- The NFT gallery shows one warning for an unreachable gateway — the address, the error, a button to the NFT settings — in place of the same failure on every tile.
- The gateway field in Settings › NFT probes the address when it is saved and shows the answer under the field ("The gateway answered (HTTP 200)" / "The gateway did not answer (net::ERR_NAME_NOT_RESOLVED). The address is saved; check it if NFT previews stay empty."). The address is saved either way — an offline user must still be able to set it — and the downloads' verdict, when there is one, takes precedence over the one-off probe.

## Tests

- `probeIpfsGateway.test.ts`: normalized URL and `redirect: 'manual'`; 404/429/504 and a redirect count as answers; a network error is reported with its message; a silent gateway times out; settles once; malformed or non-https addresses are refused without a request.
- `CacheManager.test.ts` ("IPFS gateway health"): the threshold, the single announcement per verdict, withdrawal on any answer, no counting for other hosts or for aborts and stalls, a gateway change starting the run over.
- `downloadFile.test.ts`: `isHostUnreachableError` positives and negatives.
- Full gui jest at this tip: 6 cache/network suites, 230 tests; eslint and prettier clean; `tsc` adds no errors in the touched files.

## Not in this PR

The gateway probe does not set the application User-Agent from #3066's `requestUserAgent` because a status line is all it needs and a challenge page is itself an answer; the download path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-process cache/download coalescing, migration/maintenance barriers, and IPFS fetch paths used for all NFT media; regressions are heavily tested but the combined stack is broad.
> 
> **Overview**
> **IPFS gateway visibility** — The cache layer exposes `probeIpfsGateway`, `getIpfsGatewayHealth`, and a health-change subscription (typed in `CacheService`). The renderer subscribes via `useIpfsGatewayHealth`, shows one gallery warning with a link to NFT settings when the configured gateway cannot be reached, and adds **Settings › NFT › IPFS gateway** (`IpfsGatewayUrl`) to normalize/save a custom gateway, probe it on save, and surface reachability next to the field (download health wins over the one-off probe). `NFTProvider` / metadata and preview-status logic treat gateway recovery like a gateway change so stale host-unreachable failures are retried; preview cache lookups mirror `CacheManager` gateway/recovery rules using `isHostUnreachableError`.
> 
> **Cache & metadata contracts** — `CacheRequestOptions` gains `maxDuration`; ERROR sidecars can record retry/gateway/limit metadata; `getContentWithInfo` bundles bytes, headers, and checksum. NFT refresh invalidates bounded URI lists; metadata loading uses multi-URI `fetchMetadataFromUris` instead of only the first URI.
> 
> **NFT previews** — Per-tile error boundaries, pre-iframe media playability probes (skip undecodable audio/video with user messaging), stricter IPFS URI validation in hash status, and gallery batching tweaks (500 URLs per `getCacheInfos` batch).
> 
> **Settings & tooling** — Cache size form rejects empty/zero limits; NFT IPFS copy adds privacy/disclosure and configurable gateway help. `@types/node` is bumped to **20.19.9** across packages. Large **audit/integration docs** and new **CacheManager** Jest suites (migration/maintenance, failure quota, coalesced caller policy, metadata-deadline harness) document and lock in stacked SEC fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26ca4062d05583521dcd23a47ebab623bde63c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->