### PR TITLE
[CHIA-4407] Sort a preview whose download failed under "unavailable" until the cache would retry it

### DIFF
--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -335,6 +335,14 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
               // every input is known and the cache cannot decide — only a
               // download can, and the tile that performs it reports it
               settled.add(nftId);
+              // a provisional verdict reached while the metadata was still
+              // loading (see above) is stale now that the metadata has
+              // arrived: drop it so the NFT rejoins the available previews
+              // and a tile mounts to fetch the candidates it brought
+              retryDue.delete(nftId);
+              if (statuses.delete(nftId)) {
+                changed = true;
+              }
             }
             // otherwise the metadata is still loading: swept again once it settles
           });

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -6,16 +6,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type CacheInfo from '../../../../@types/CacheInfo';
 import type MetadataState from '../../../../@types/MetadataState';
-import NFTPreviewStatus from '../../../../@types/NFTPreviewStatus';
+import type NFTPreviewStatus from '../../../../@types/NFTPreviewStatus';
 import CacheState from '../../../../constants/CacheState';
 import useCache from '../../../../hooks/useCache';
 import useIpfsGateway from '../../../../hooks/useIpfsGateway';
 import { useIpfsGatewayBase } from '../../../../hooks/useIpfsGatewayUrl';
 import { isHostUnreachableError } from '../../../../util/downloadErrors';
-import getNFTPreviewStatusFromCache, {
-  getNFTPreviewRetryDueAt,
-  getNFTPreviewUrls,
-} from '../../../../util/getNFTPreviewStatusFromCache';
+import getNFTPreviewStatusFromCache, { getNFTPreviewUrls } from '../../../../util/getNFTPreviewStatusFromCache';
 import { isIpfsBackedUrl } from '../../../../util/ipfs';
 
 const log = debug('chia-gui:NFTProvider:useNFTPreviewStatuses');
@@ -73,11 +70,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   // which forgets it here.
   const [cacheInfos /* immutable */] = useState(() => new Map<string, CacheInfo>());
 
-  // NFTs classified unavailable on the strength of a transient failure, and
-  // when the cache will retry that failure on access: at that time the NFT is
-  // undecided again and is looked at once more (see scheduleRetryDueLookUp).
-  const [retryDue /* immutable */] = useState(() => new Map<string, number>());
-
   // The gateway ipfs:// files are fetched through, and https gateway links
   // fall back to (empty while the option is off). A change of it forgets the
   // verdicts that rested on ipfs files (forgetIpfsVerdicts) and sweeps again;
@@ -106,8 +98,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   const setPreviewStatus = useCallback(
     (nftId: string, status: NFTPreviewStatus) => {
       settled.add(nftId);
-      // a live report is the verdict; nothing to look at again
-      retryDue.delete(nftId);
 
       if (statuses.get(nftId) === status) {
         return;
@@ -116,7 +106,7 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
       statuses.set(nftId, status);
       events.emit('changed');
     },
-    [events /* immutable */, statuses /* immutable */, settled /* immutable */, retryDue /* immutable */],
+    [events /* immutable */, statuses /* immutable */, settled /* immutable */],
   );
 
   // Bumped by every invalidation. A lookup whose IPC round-trip spans one may
@@ -129,20 +119,13 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     (nftId: string, urls: string[]) => {
       invalidationGeneration.current += 1;
       settled.delete(nftId);
-      retryDue.delete(nftId);
       urls.forEach((url) => cacheInfos.delete(url));
 
       if (statuses.delete(nftId)) {
         events.emit('changed');
       }
     },
-    [
-      events /* immutable */,
-      statuses /* immutable */,
-      settled /* immutable */,
-      cacheInfos /* immutable */,
-      retryDue /* immutable */,
-    ],
+    [events /* immutable */, statuses /* immutable */, settled /* immutable */, cacheInfos /* immutable */],
   );
 
   // immutable function
@@ -159,53 +142,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
 
   const isLookingUpRef = useRef(false);
   const lookUpAgainRef = useRef(false);
-
-  // The sweep below, reachable from the retry timer that the sweep itself
-  // (re)arms; a ref breaks the cycle between the two callbacks.
-  const lookUpFromCacheRef = useRef<() => Promise<void>>(async () => {});
-
-  // Wakes when the earliest transient failure behind an "unavailable" verdict
-  // is due for a retry: those NFTs are undecided again — the cache would fetch
-  // the file for a tile that asked — so their verdicts are forgotten and the
-  // sweep runs once more. Re-armed after every sweep for whatever is due next;
-  // nothing is armed while no verdict rests on a transient failure.
-  const retryDueTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const scheduleRetryDueLookUp = useCallback(() => {
-    if (retryDueTimeoutRef.current) {
-      clearTimeout(retryDueTimeoutRef.current);
-      retryDueTimeoutRef.current = undefined;
-    }
-    let earliest: number | undefined;
-    retryDue.forEach((dueAt) => {
-      if (earliest === undefined || dueAt < earliest) {
-        earliest = dueAt;
-      }
-    });
-    if (earliest === undefined) {
-      return;
-    }
-    retryDueTimeoutRef.current = setTimeout(
-      () => {
-        retryDueTimeoutRef.current = undefined;
-        const now = Date.now();
-        let changed = false;
-        retryDue.forEach((dueAt, nftId) => {
-          if (dueAt <= now) {
-            retryDue.delete(nftId);
-            settled.delete(nftId);
-            if (statuses.delete(nftId)) {
-              changed = true;
-            }
-          }
-        });
-        if (changed) {
-          events.emit('changed');
-        }
-        lookUpFromCacheRef.current();
-      },
-      Math.max(0, earliest - Date.now()),
-    );
-  }, [retryDue /* immutable */, settled /* immutable */, statuses /* immutable */, events /* immutable */]);
 
   // Classifies every NFT not yet settled from the cache's persisted state.
   // Runs serialized: a sweep that finds the flag set simply sweeps once more
@@ -309,8 +245,7 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
               return;
             }
 
-            const now = Date.now();
-            const status = getNFTPreviewStatusFromCache(nft, metadataState, getCacheInfo, now);
+            const status = getNFTPreviewStatusFromCache(nft, metadataState, getCacheInfo);
             if (status) {
               statuses.set(nftId, status);
               // A verdict reached while the metadata is still being fetched
@@ -323,15 +258,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
                 settled.add(nftId);
               }
               changed = true;
-              const dueAt =
-                status === NFTPreviewStatus.UNAVAILABLE
-                  ? getNFTPreviewRetryDueAt(nft, metadataState, getCacheInfo, now)
-                  : undefined;
-              if (dueAt !== undefined) {
-                retryDue.set(nftId, dueAt);
-              } else {
-                retryDue.delete(nftId);
-              }
             } else if (!metadataState.isLoading) {
               // every input is known and the cache cannot decide — only a
               // download can, and the tile that performs it reports it
@@ -340,7 +266,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
               // loading (see above) is stale now that the metadata has
               // arrived: drop it so the NFT rejoins the available previews
               // and a tile mounts to fetch the candidates it brought
-              retryDue.delete(nftId);
               if (statuses.delete(nftId)) {
                 changed = true;
               }
@@ -357,7 +282,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
       log(`Error looking up preview statuses from the cache: ${(e as Error).message}`);
     } finally {
       isLookingUpRef.current = false;
-      scheduleRetryDueLookUp();
     }
   }, [
     nfts /* immutable */,
@@ -367,11 +291,8 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     statuses /* immutable */,
     settled /* immutable */,
     cacheInfos /* immutable */,
-    retryDue /* immutable */,
     events /* immutable */,
-    scheduleRetryDueLookUp /* immutable */,
   ]);
-  lookUpFromCacheRef.current = lookUpFromCache;
 
   const lookUpTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -416,7 +337,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
 
       invalidationGeneration.current += 1;
       settled.delete(nftId);
-      retryDue.delete(nftId);
       ipfsUrls.forEach((url) => cacheInfos.delete(url));
       if (statuses.delete(nftId)) {
         changed = true;
@@ -435,7 +355,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     }
     scheduleLookUp();
   }, [
-    retryDue /* immutable */,
     nfts /* immutable */,
     nachos /* immutable */,
     getMetadata /* immutable */,
@@ -482,10 +401,6 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
       if (lookUpTimeoutRef.current) {
         clearTimeout(lookUpTimeoutRef.current);
         lookUpTimeoutRef.current = undefined;
-      }
-      if (retryDueTimeoutRef.current) {
-        clearTimeout(retryDueTimeoutRef.current);
-        retryDueTimeoutRef.current = undefined;
       }
     };
   }, [scheduleLookUp, subscribeToChanges, subscribeToMetadataChanges]);

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -312,7 +312,15 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
             const status = getNFTPreviewStatusFromCache(nft, metadataState, getCacheInfo, now);
             if (status) {
               statuses.set(nftId, status);
-              settled.add(nftId);
+              // A verdict reached while the metadata is still being fetched
+              // (the fetch looked doomed) is provisional: should the fetch
+              // bring the metadata after all, its preview candidates may
+              // change the verdict, so the NFT is left unsettled and the
+              // store's change notification has it swept again. A tile's
+              // live report settles it regardless.
+              if (!metadataState.isLoading) {
+                settled.add(nftId);
+              }
               changed = true;
               const dueAt =
                 status === NFTPreviewStatus.UNAVAILABLE

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -6,12 +6,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type CacheInfo from '../../../../@types/CacheInfo';
 import type MetadataState from '../../../../@types/MetadataState';
-import type NFTPreviewStatus from '../../../../@types/NFTPreviewStatus';
+import NFTPreviewStatus from '../../../../@types/NFTPreviewStatus';
 import CacheState from '../../../../constants/CacheState';
 import useCache from '../../../../hooks/useCache';
 import useIpfsGateway from '../../../../hooks/useIpfsGateway';
 import { useIpfsGatewayBase } from '../../../../hooks/useIpfsGatewayUrl';
-import getNFTPreviewStatusFromCache, { getNFTPreviewUrls } from '../../../../util/getNFTPreviewStatusFromCache';
+import getNFTPreviewStatusFromCache, {
+  getNFTPreviewRetryDueAt,
+  getNFTPreviewUrls,
+} from '../../../../util/getNFTPreviewStatusFromCache';
 import { isIpfsBackedUrl, isIpfsUrl } from '../../../../util/ipfs';
 
 const log = debug('chia-gui:NFTProvider:useNFTPreviewStatuses');
@@ -57,6 +60,11 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   // which forgets it here.
   const [cacheInfos /* immutable */] = useState(() => new Map<string, CacheInfo>());
 
+  // NFTs classified unavailable on the strength of a transient failure, and
+  // when the cache will retry that failure on access: at that time the NFT is
+  // undecided again and is looked at once more (see scheduleRetryDueLookUp).
+  const [retryDue /* immutable */] = useState(() => new Map<string, number>());
+
   // The gateway ipfs:// files are fetched through, and https gateway links
   // fall back to (empty while the option is off). A persisted ipfs failure is
   // a verdict on the gateway it went through; CacheManager re-requests such
@@ -84,6 +92,8 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   const setPreviewStatus = useCallback(
     (nftId: string, status: NFTPreviewStatus) => {
       settled.add(nftId);
+      // a live report is the verdict; nothing to look at again
+      retryDue.delete(nftId);
 
       if (statuses.get(nftId) === status) {
         return;
@@ -92,7 +102,7 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
       statuses.set(nftId, status);
       events.emit('changed');
     },
-    [events /* immutable */, statuses /* immutable */, settled /* immutable */],
+    [events /* immutable */, statuses /* immutable */, settled /* immutable */, retryDue /* immutable */],
   );
 
   // Bumped by every invalidation. A lookup whose IPC round-trip spans one may
@@ -105,13 +115,20 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     (nftId: string, urls: string[]) => {
       invalidationGeneration.current += 1;
       settled.delete(nftId);
+      retryDue.delete(nftId);
       urls.forEach((url) => cacheInfos.delete(url));
 
       if (statuses.delete(nftId)) {
         events.emit('changed');
       }
     },
-    [events /* immutable */, statuses /* immutable */, settled /* immutable */, cacheInfos /* immutable */],
+    [
+      events /* immutable */,
+      statuses /* immutable */,
+      settled /* immutable */,
+      cacheInfos /* immutable */,
+      retryDue /* immutable */,
+    ],
   );
 
   // immutable function
@@ -128,6 +145,53 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
 
   const isLookingUpRef = useRef(false);
   const lookUpAgainRef = useRef(false);
+
+  // The sweep below, reachable from the retry timer that the sweep itself
+  // (re)arms; a ref breaks the cycle between the two callbacks.
+  const lookUpFromCacheRef = useRef<() => Promise<void>>(async () => {});
+
+  // Wakes when the earliest transient failure behind an "unavailable" verdict
+  // is due for a retry: those NFTs are undecided again — the cache would fetch
+  // the file for a tile that asked — so their verdicts are forgotten and the
+  // sweep runs once more. Re-armed after every sweep for whatever is due next;
+  // nothing is armed while no verdict rests on a transient failure.
+  const retryDueTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const scheduleRetryDueLookUp = useCallback(() => {
+    if (retryDueTimeoutRef.current) {
+      clearTimeout(retryDueTimeoutRef.current);
+      retryDueTimeoutRef.current = undefined;
+    }
+    let earliest: number | undefined;
+    retryDue.forEach((dueAt) => {
+      if (earliest === undefined || dueAt < earliest) {
+        earliest = dueAt;
+      }
+    });
+    if (earliest === undefined) {
+      return;
+    }
+    retryDueTimeoutRef.current = setTimeout(
+      () => {
+        retryDueTimeoutRef.current = undefined;
+        const now = Date.now();
+        let changed = false;
+        retryDue.forEach((dueAt, nftId) => {
+          if (dueAt <= now) {
+            retryDue.delete(nftId);
+            settled.delete(nftId);
+            if (statuses.delete(nftId)) {
+              changed = true;
+            }
+          }
+        });
+        if (changed) {
+          events.emit('changed');
+        }
+        lookUpFromCacheRef.current();
+      },
+      Math.max(0, earliest - Date.now()),
+    );
+  }, [retryDue /* immutable */, settled /* immutable */, statuses /* immutable */, events /* immutable */]);
 
   // Classifies every NFT not yet settled from the cache's persisted state.
   // Runs serialized: a sweep that finds the flag set simply sweeps once more
@@ -217,11 +281,21 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
               return;
             }
 
-            const status = getNFTPreviewStatusFromCache(nft, metadataState, getCacheInfo);
+            const now = Date.now();
+            const status = getNFTPreviewStatusFromCache(nft, metadataState, getCacheInfo, now);
             if (status) {
               statuses.set(nftId, status);
               settled.add(nftId);
               changed = true;
+              const dueAt =
+                status === NFTPreviewStatus.UNAVAILABLE
+                  ? getNFTPreviewRetryDueAt(nft, metadataState, getCacheInfo, now)
+                  : undefined;
+              if (dueAt !== undefined) {
+                retryDue.set(nftId, dueAt);
+              } else {
+                retryDue.delete(nftId);
+              }
             } else if (!metadataState.isLoading) {
               // every input is known and the cache cannot decide — only a
               // download can, and the tile that performs it reports it
@@ -239,6 +313,7 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
       log(`Error looking up preview statuses from the cache: ${(e as Error).message}`);
     } finally {
       isLookingUpRef.current = false;
+      scheduleRetryDueLookUp();
     }
   }, [
     nfts /* immutable */,
@@ -248,8 +323,11 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     statuses /* immutable */,
     settled /* immutable */,
     cacheInfos /* immutable */,
+    retryDue /* immutable */,
     events /* immutable */,
+    scheduleRetryDueLookUp /* immutable */,
   ]);
+  lookUpFromCacheRef.current = lookUpFromCache;
 
   const lookUpTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -299,6 +377,7 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
 
       invalidationGeneration.current += 1;
       settled.delete(nftId);
+      retryDue.delete(nftId);
       ipfsUrls.forEach((url) => cacheInfos.delete(url));
       if (statuses.delete(nftId)) {
         changed = true;
@@ -318,6 +397,7 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
     scheduleLookUp();
   }, [
     ipfsGatewayKey,
+    retryDue /* immutable */,
     nfts /* immutable */,
     nachos /* immutable */,
     getMetadata /* immutable */,
@@ -341,6 +421,10 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
       if (lookUpTimeoutRef.current) {
         clearTimeout(lookUpTimeoutRef.current);
         lookUpTimeoutRef.current = undefined;
+      }
+      if (retryDueTimeoutRef.current) {
+        clearTimeout(retryDueTimeoutRef.current);
+        retryDueTimeoutRef.current = undefined;
       }
     };
   }, [scheduleLookUp, subscribeToChanges, subscribeToMetadataChanges]);

--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -16,7 +16,7 @@ import getNFTPreviewStatusFromCache, {
   getNFTPreviewRetryDueAt,
   getNFTPreviewUrls,
 } from '../../../../util/getNFTPreviewStatusFromCache';
-import { isIpfsBackedUrl, isIpfsUrl } from '../../../../util/ipfs';
+import { isIpfsBackedUrl } from '../../../../util/ipfs';
 
 const log = debug('chia-gui:NFTProvider:useNFTPreviewStatuses');
 
@@ -79,10 +79,9 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   const [retryDue /* immutable */] = useState(() => new Map<string, number>());
 
   // The gateway ipfs:// files are fetched through, and https gateway links
-  // fall back to (empty while the option is off). A persisted ipfs failure is
-  // a verdict on the gateway it went through; CacheManager re-requests such
-  // an entry as soon as the gateway differs, so here it settles nothing under
-  // any other gateway.
+  // fall back to (empty while the option is off). A change of it forgets the
+  // verdicts that rested on ipfs files (forgetIpfsVerdicts) and sweeps again;
+  // the recorded failures themselves still count (see getCacheInfo below).
   const [ipfsGateway] = useIpfsGateway();
   const ipfsGatewayBase = useIpfsGatewayBase();
   const ipfsGatewayKey = ipfsGateway ? ipfsGatewayBase : '';
@@ -268,34 +267,36 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
             break;
           }
 
-          // Mirrors CacheManager's gateway-change rule: while the option is
-          // on, a failure recorded under another gateway — or, for an https
-          // gateway link, without any gateway, meaning it never got the
-          // fallback — is re-requested on the next access, so it settles
-          // nothing here. An ipfs:// sidecar without a gateway predates
-          // gateway tracking and stays a settled failure. Likewise its
-          // recovery rule (isRecoveredGatewayFailure): once the gateway has
-          // come back after being unreachable, a failure to reach it recorded
-          // under the current gateway whose transfer began before that moment
-          // was a verdict on the host, and CacheManager retries it on the next
-          // access — so it settles nothing here either, and the NFT stays in
-          // view for its tile to ask. One that began after the recovery is a
-          // new failure and follows the ordinary rules.
+          // A failure recorded under another gateway is still a failure for
+          // the filter. CacheManager re-requests such an entry through the
+          // current gateway the moment a tile asks (its gateway-change rule),
+          // so nothing is lost by classifying it: the NFT sits under
+          // "unavailable", and the tile that asks — in that view, or in the
+          // unfiltered gallery — reports whatever the new gateway yields. Reading
+          // it as "never fetched" instead put every file whose hosts are gone
+          // back under "Preview available" after every gateway change, each
+          // holding a download slot until it failed the same way again. What
+          // does settle nothing here is CacheManager's recovery rule
+          // (isRecoveredGatewayFailure): once the gateway has come back after
+          // being unreachable, a failure to reach it recorded under the current
+          // gateway whose transfer began before that moment was a verdict on
+          // the host, not on the content, so the NFT stays in view for its tile
+          // to ask. One that began after the recovery is a new failure and
+          // follows the ordinary rules.
           const currentGateway = ipfsGatewayKeyRef.current;
           const recoveredAt = ipfsGatewayRecoveredAtRef.current;
           const getCacheInfo = (url: string): CacheInfo | undefined => {
             const cacheInfo = cacheInfos.get(url);
-            if (cacheInfo?.state === CacheState.ERROR && currentGateway && isIpfsBackedUrl(url)) {
-              const isOtherGateway =
-                cacheInfo.gateway === undefined ? !isIpfsUrl(url) : cacheInfo.gateway !== currentGateway;
-              const isRecoveredFailure =
-                recoveredAt !== undefined &&
-                cacheInfo.gateway === currentGateway &&
-                isHostUnreachableError(cacheInfo.error) &&
-                recoveredAt > (cacheInfo.startedAt ?? cacheInfo.timestamp);
-              if (isOtherGateway || isRecoveredFailure) {
-                return { url: cacheInfo.url, timestamp: cacheInfo.timestamp, state: CacheState.NOT_CACHED };
-              }
+            if (
+              cacheInfo?.state === CacheState.ERROR &&
+              currentGateway &&
+              isIpfsBackedUrl(url) &&
+              recoveredAt !== undefined &&
+              cacheInfo.gateway === currentGateway &&
+              isHostUnreachableError(cacheInfo.error) &&
+              recoveredAt > (cacheInfo.startedAt ?? cacheInfo.timestamp)
+            ) {
+              return { url: cacheInfo.url, timestamp: cacheInfo.timestamp, state: CacheState.NOT_CACHED };
             }
 
             return cacheInfo;

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -17,7 +17,10 @@ import CacheState from '../constants/CacheState';
 import {
   DOWNLOAD_DEADLINE_ERROR_PREFIX,
   INACTIVITY_TIMEOUT_ERROR_PREFIX,
+  MAX_TRANSIENT_RETRIES,
+  TRANSIENT_ERROR_RETRY_DELAY,
   isHostUnreachableError,
+  transientErrorRetryDelay,
 } from '../util/downloadErrors';
 import ipfsToGatewayUrl, {
   getGatewayHost,
@@ -107,24 +110,18 @@ async function safeUnlink(filePath: string) {
 }
 
 const INFO_SUFFIX = '-info';
+// The transient-failure retry schedule is shared with the renderer's gallery
+// filter (getNFTPreviewStatusFromCache) and lives in util/downloadErrors.
+export {
+  TRANSIENT_ERROR_RETRY_DELAY,
+  MAX_TRANSIENT_ERROR_RETRY_DELAY,
+  MAX_TRANSIENT_RETRIES,
+  transientErrorRetryDelay,
+} from '../util/downloadErrors';
+
 const FILE_SUFFIX = '-chiacache';
 const MAX_TOTAL_SIZE = 1024 * 1024 * 1024; // 1GB
 const MAX_FILE_SIZE = 1024 * 1024 * 100; // 100MB
-
-// How long a persisted transient download failure (timeout, gateway error,
-// rate limit, bot challenge) settles before the next access retries it. Long
-// enough that a stalled host is not re-probed on every tile mount, short
-// enough that a gateway hiccup does not blank an NFT until the GUI restarts.
-export const TRANSIENT_ERROR_RETRY_DELAY = 10 * 60 * 1000; // 10 minutes
-
-// The delay doubles with every consecutive transient failure, up to this
-// ceiling, and after MAX_TRANSIENT_RETRIES failures in a row the entry settles
-// for good (until the NFT is refreshed or the cache cleared). Every URL here
-// is minter-authored, so a retry schedule must have a bound: with a fixed
-// delay a host that answers 503 forever would be re-probed every ten minutes
-// for as long as the wallet is open — a liveness beacon for whoever runs it.
-export const MAX_TRANSIENT_ERROR_RETRY_DELAY = 24 * 60 * 60 * 1000; // 1 day
-export const MAX_TRANSIENT_RETRIES = 8;
 
 // How many requests in a row must fail to reach the gateway host before the
 // gateway is reported unreachable (IpfsGatewayHealth). One failure is a
@@ -141,13 +138,6 @@ export const COLD_IPFS_PATH_DURATION = TRANSIENT_ERROR_RETRY_DELAY;
 // for a per-minute limit to open up, short enough that the tiles in view are
 // not blanked by one burst.
 export const RATE_LIMIT_COOLDOWN = 30 * 1000;
-
-// The wait before the next in-session retry of a URL that has failed
-// transiently `retries` times in a row: 10 min, 20 min, 40 min, ...
-export function transientErrorRetryDelay(retries: number): number {
-  const exponent = Math.max(0, Math.min(retries - 1, 31));
-  return Math.min(TRANSIENT_ERROR_RETRY_DELAY * 2 ** exponent, MAX_TRANSIENT_ERROR_RETRY_DELAY);
-}
 
 // Bounds on one getCacheInfos call (see there). The renderer's sweep asks for
 // at most 500 urls at a time; the cap leaves headroom for that and refuses

--- a/packages/gui/src/electron/utils/downloadFile.test.ts
+++ b/packages/gui/src/electron/utils/downloadFile.test.ts
@@ -388,24 +388,3 @@ describe('isHostUnreachableError', () => {
     expect(isHostUnreachableError(message)).toBe(false);
   });
 });
-
-describe('transientRetryDueAt', () => {
-  const { MAX_TRANSIENT_RETRIES, transientErrorRetryDelay, transientRetryDueAt } =
-    jest.requireActual<typeof import('../../util/downloadErrors')>('../../util/downloadErrors');
-
-  it('is the failure time plus the delay its retry count earns', () => {
-    expect(transientRetryDueAt({ timestamp: 1000, retries: 1 })).toBe(1000 + transientErrorRetryDelay(1));
-    expect(transientRetryDueAt({ timestamp: 1000, retries: 3 })).toBe(1000 + transientErrorRetryDelay(3));
-    // a sidecar without a count is a first failure
-    expect(transientRetryDueAt({ timestamp: 1000 })).toBe(1000 + transientErrorRetryDelay(0));
-  });
-
-  it('is due at once for a sidecar written before failures were timestamped', () => {
-    expect(transientRetryDueAt({ retries: 2 })).toBe(0);
-    expect(transientRetryDueAt({ timestamp: 0, retries: 2 })).toBe(0);
-  });
-
-  it('is never due once the retries are exhausted', () => {
-    expect(transientRetryDueAt({ timestamp: 1000, retries: MAX_TRANSIENT_RETRIES })).toBeUndefined();
-  });
-});

--- a/packages/gui/src/electron/utils/downloadFile.test.ts
+++ b/packages/gui/src/electron/utils/downloadFile.test.ts
@@ -388,3 +388,24 @@ describe('isHostUnreachableError', () => {
     expect(isHostUnreachableError(message)).toBe(false);
   });
 });
+
+describe('transientRetryDueAt', () => {
+  const { MAX_TRANSIENT_RETRIES, transientErrorRetryDelay, transientRetryDueAt } =
+    jest.requireActual<typeof import('../../util/downloadErrors')>('../../util/downloadErrors');
+
+  it('is the failure time plus the delay its retry count earns', () => {
+    expect(transientRetryDueAt({ timestamp: 1000, retries: 1 })).toBe(1000 + transientErrorRetryDelay(1));
+    expect(transientRetryDueAt({ timestamp: 1000, retries: 3 })).toBe(1000 + transientErrorRetryDelay(3));
+    // a sidecar without a count is a first failure
+    expect(transientRetryDueAt({ timestamp: 1000 })).toBe(1000 + transientErrorRetryDelay(0));
+  });
+
+  it('is due at once for a sidecar written before failures were timestamped', () => {
+    expect(transientRetryDueAt({ retries: 2 })).toBe(0);
+    expect(transientRetryDueAt({ timestamp: 0, retries: 2 })).toBe(0);
+  });
+
+  it('is never due once the retries are exhausted', () => {
+    expect(transientRetryDueAt({ timestamp: 1000, retries: MAX_TRANSIENT_RETRIES })).toBeUndefined();
+  });
+});

--- a/packages/gui/src/util/downloadErrors.ts
+++ b/packages/gui/src/util/downloadErrors.ts
@@ -103,37 +103,6 @@ export function transientErrorRetryDelay(retries: number): number {
   return Math.min(TRANSIENT_ERROR_RETRY_DELAY * 2 ** exponent, MAX_TRANSIENT_ERROR_RETRY_DELAY);
 }
 
-// How many transient failures in a row make a file's preview unavailable for
-// the gallery filter even once its retry is due. One failure is a hiccup and
-// the file rejoins "Preview available" as soon as the cache would try again;
-// a file that has failed again on that retry has shown a pattern, and
-// advertising it as available for another 30-second attempt each time its
-// delay runs out — for every such file after every restart — fills the view
-// with failures. The cache still retries it whenever a tile asks (in the
-// unavailable view, or in the unfiltered gallery); it is the filter's verdict
-// that waits for that to actually succeed.
-export const REPEATED_TRANSIENT_FAILURES = 2;
-
-/** When the cache will next retry a persisted transient failure on access:
- * the time its retry delay runs out, 0 for a sidecar written before failures
- * were timestamped (retried on the next access), or undefined once the entry
- * has failed MAX_TRANSIENT_RETRIES times in a row and settled for good. Until
- * that time a tile asking for the file is served the persisted failure, so the
- * preview is unavailable for now — which is how the gallery filter reads it
- * (getNFTPreviewStatusFromCache). The cache also retries each such failure
- * once per session regardless of the delay, which a reader of the sidecar
- * cannot see; a tile that asks then reports the outcome live. */
-export function transientRetryDueAt(failure: { timestamp?: number; retries?: number }): number | undefined {
-  const retries = failure.retries ?? 0;
-  if (retries >= MAX_TRANSIENT_RETRIES) {
-    return undefined;
-  }
-  if (!failure.timestamp) {
-    return 0;
-  }
-  return failure.timestamp + transientErrorRetryDelay(retries);
-}
-
 // Chromium network errors that say the request never reached a host at the
 // URL's name: the name does not resolve, nothing listens at the address, or
 // what listens presents a certificate for some other name. For a request

--- a/packages/gui/src/util/downloadErrors.ts
+++ b/packages/gui/src/util/downloadErrors.ts
@@ -81,6 +81,48 @@ const PERMANENT_NET_ERRORS = new Set([
 // made from it would settle the entry for something the url did nothing.
 const TRANSIENT_LOCAL_ERROR_CODES = ['EMFILE', 'ENFILE', 'EAGAIN', 'EBUSY', 'ENOSPC', 'EIO'];
 
+// How long a persisted transient download failure (timeout, gateway error,
+// rate limit, bot challenge) settles before the next access retries it. Long
+// enough that a stalled host is not re-probed on every tile mount, short
+// enough that a gateway hiccup does not blank an NFT until the GUI restarts.
+export const TRANSIENT_ERROR_RETRY_DELAY = 10 * 60 * 1000; // 10 minutes
+
+// The delay doubles with every consecutive transient failure, up to this
+// ceiling, and after MAX_TRANSIENT_RETRIES failures in a row the entry settles
+// for good (until the NFT is refreshed or the cache cleared). Every URL here
+// is minter-authored, so a retry schedule must have a bound: with a fixed
+// delay a host that answers 503 forever would be re-probed every ten minutes
+// for as long as the wallet is open — a liveness beacon for whoever runs it.
+export const MAX_TRANSIENT_ERROR_RETRY_DELAY = 24 * 60 * 60 * 1000; // 1 day
+export const MAX_TRANSIENT_RETRIES = 8;
+
+// The wait before the next in-session retry of a URL that has failed
+// transiently `retries` times in a row: 10 min, 20 min, 40 min, ...
+export function transientErrorRetryDelay(retries: number): number {
+  const exponent = Math.max(0, Math.min(retries - 1, 31));
+  return Math.min(TRANSIENT_ERROR_RETRY_DELAY * 2 ** exponent, MAX_TRANSIENT_ERROR_RETRY_DELAY);
+}
+
+/** When the cache will next retry a persisted transient failure on access:
+ * the time its retry delay runs out, 0 for a sidecar written before failures
+ * were timestamped (retried on the next access), or undefined once the entry
+ * has failed MAX_TRANSIENT_RETRIES times in a row and settled for good. Until
+ * that time a tile asking for the file is served the persisted failure, so the
+ * preview is unavailable for now — which is how the gallery filter reads it
+ * (getNFTPreviewStatusFromCache). The cache also retries each such failure
+ * once per session regardless of the delay, which a reader of the sidecar
+ * cannot see; a tile that asks then reports the outcome live. */
+export function transientRetryDueAt(failure: { timestamp?: number; retries?: number }): number | undefined {
+  const retries = failure.retries ?? 0;
+  if (retries >= MAX_TRANSIENT_RETRIES) {
+    return undefined;
+  }
+  if (!failure.timestamp) {
+    return 0;
+  }
+  return failure.timestamp + transientErrorRetryDelay(retries);
+}
+
 // Chromium network errors that say the request never reached a host at the
 // URL's name: the name does not resolve, nothing listens at the address, or
 // what listens presents a certificate for some other name. For a request

--- a/packages/gui/src/util/downloadErrors.ts
+++ b/packages/gui/src/util/downloadErrors.ts
@@ -103,6 +103,17 @@ export function transientErrorRetryDelay(retries: number): number {
   return Math.min(TRANSIENT_ERROR_RETRY_DELAY * 2 ** exponent, MAX_TRANSIENT_ERROR_RETRY_DELAY);
 }
 
+// How many transient failures in a row make a file's preview unavailable for
+// the gallery filter even once its retry is due. One failure is a hiccup and
+// the file rejoins "Preview available" as soon as the cache would try again;
+// a file that has failed again on that retry has shown a pattern, and
+// advertising it as available for another 30-second attempt each time its
+// delay runs out — for every such file after every restart — fills the view
+// with failures. The cache still retries it whenever a tile asks (in the
+// unavailable view, or in the unfiltered gallery); it is the filter's verdict
+// that waits for that to actually succeed.
+export const REPEATED_TRANSIENT_FAILURES = 2;
+
 /** When the cache will next retry a persisted transient failure on access:
  * the time its retry delay runs out, 0 for a sidecar written before failures
  * were timestamped (retried on the next access), or undefined once the entry

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
@@ -3,9 +3,11 @@ import type MetadataState from '../@types/MetadataState';
 import NFTPreviewStatus from '../@types/NFTPreviewStatus';
 import CacheState from '../constants/CacheState';
 
+import { MAX_TRANSIENT_RETRIES, transientErrorRetryDelay } from './downloadErrors';
 import getNFTPreviewStatusFromCache, {
   MAX_URIS_PER_CANDIDATE,
   getNFTPreviewUrls,
+  getNFTPreviewRetryDueAt,
 } from './getNFTPreviewStatusFromCache';
 
 const HASH = '0xabc123';
@@ -92,7 +94,8 @@ describe('getNFTPreviewStatusFromCache', () => {
     'net::ERR_CONNECTION_RESET',
     'net::ERR_NAME_NOT_RESOLVED',
     'Request timed out after 30000ms of inactivity',
-  ])('stays undecided after %p, an error the cache will retry', (message) => {
+  ])('stays undecided after %p, an error the cache will retry on the next access', (message) => {
+    // recorded long ago: its retry delay has run out
     const status = getNFTPreviewStatusFromCache(
       { dataUris: ['https://a/x.png'], dataHash: HASH },
       noMetadata,
@@ -100,6 +103,68 @@ describe('getNFTPreviewStatusFromCache', () => {
     );
 
     expect(status).toBeUndefined();
+  });
+
+  describe('a transient failure inside its retry delay', () => {
+    const now = 1_700_000_000_000;
+    const failure = (retries: number | undefined, ago: number): CacheInfo => ({
+      url: 'https://a/x.png',
+      state: CacheState.ERROR,
+      error: 'HTTP error: 504',
+      timestamp: now - ago,
+      ...(retries === undefined ? {} : { retries }),
+    });
+    const nft = { dataUris: ['https://a/x.png'], dataHash: HASH };
+
+    it('is unavailable for now: a tile that asked would be served the persisted failure', () => {
+      expect(getNFTPreviewStatusFromCache(nft, noMetadata, lookup([failure(1, 1000)]), now)).toBe(
+        NFTPreviewStatus.UNAVAILABLE,
+      );
+      expect(getNFTPreviewRetryDueAt(nft, noMetadata, lookup([failure(1, 1000)]), now)).toBe(
+        now - 1000 + transientErrorRetryDelay(1),
+      );
+    });
+
+    it('is undecided again once the delay has run out', () => {
+      const infos = lookup([failure(1, transientErrorRetryDelay(1))]);
+      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBeUndefined();
+      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
+    });
+
+    it('waits longer after every consecutive failure', () => {
+      const infos = lookup([failure(3, transientErrorRetryDelay(3) - 1)]);
+      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
+      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBe(now + 1);
+    });
+
+    it('is unavailable for good once the retries are exhausted', () => {
+      const infos = lookup([failure(MAX_TRANSIENT_RETRIES, 365 * 24 * 60 * 60 * 1000)]);
+      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
+      // nothing to look at again
+      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
+    });
+
+    it('treats a sidecar written before failures were timestamped as due', () => {
+      const infos = lookup([{ ...failure(1, 0), timestamp: 0 }]);
+      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBeUndefined();
+    });
+
+    it('is not held back by an abort, which the cache retries at once', () => {
+      const infos = lookup([{ ...failure(1, 1000), error: 'Request aborted' }]);
+      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBeUndefined();
+      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
+    });
+
+    it('reports the earliest retry among the sources', () => {
+      const infos = lookup([
+        { ...failure(2, 1000), url: 'https://a/x.png' },
+        { ...failure(1, 1000), url: 'https://thumbs/x.png' },
+      ]);
+      expect(getNFTPreviewStatusFromCache(nft, metadataWithPreview, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
+      expect(getNFTPreviewRetryDueAt(nft, metadataWithPreview, infos, now)).toBe(
+        now - 1000 + transientErrorRetryDelay(1),
+      );
+    });
   });
 
   it.each(['HTTP error: 404', 'HTTP error: 410', 'HTTP error: 501', 'net::ERR_CERT_AUTHORITY_INVALID', 'Invalid URL'])(

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
@@ -3,11 +3,9 @@ import type MetadataState from '../@types/MetadataState';
 import NFTPreviewStatus from '../@types/NFTPreviewStatus';
 import CacheState from '../constants/CacheState';
 
-import { MAX_TRANSIENT_RETRIES, REPEATED_TRANSIENT_FAILURES, transientErrorRetryDelay } from './downloadErrors';
 import getNFTPreviewStatusFromCache, {
   MAX_URIS_PER_CANDIDATE,
   getNFTPreviewUrls,
-  getNFTPreviewRetryDueAt,
 } from './getNFTPreviewStatusFromCache';
 
 const HASH = '0xabc123';
@@ -85,24 +83,57 @@ describe('getNFTPreviewStatusFromCache', () => {
   // The cache retries these on a later access, so a tile that asked would
   // fetch again; settling the NFT as unavailable would hide it from a
   // filtered gallery, and a hidden tile never asks.
+  it.each(['Request aborted', 'Response aborted'])(
+    'stays undecided after %p, a download cancelled from our side and retried on the next access',
+    (message) => {
+      const status = getNFTPreviewStatusFromCache(
+        { dataUris: ['https://a/x.png'], dataHash: HASH },
+        noMetadata,
+        lookup([errored('https://a/x.png', message)]),
+      );
+
+      expect(status).toBeUndefined();
+    },
+  );
+
   it.each([
-    'Request aborted',
-    'Response aborted',
     'HTTP error: 503',
     'HTTP error: 403',
     'HTTP error: 429',
     'net::ERR_CONNECTION_RESET',
     'net::ERR_NAME_NOT_RESOLVED',
     'Request timed out after 30000ms of inactivity',
-  ])('stays undecided after %p, an error the cache will retry on the next access', (message) => {
-    // recorded long ago: its retry delay has run out
+  ])('is unavailable after %p, a transient failure the cache retries only when a tile asks', (message) => {
+    // recorded long ago, so the cache would retry it for a tile that asked —
+    // the filter still shows what a tile would be shown right now
     const status = getNFTPreviewStatusFromCache(
       { dataUris: ['https://a/x.png'], dataHash: HASH },
       noMetadata,
       lookup([errored('https://a/x.png', message)]),
     );
 
-    expect(status).toBeUndefined();
+    expect(status).toBe(NFTPreviewStatus.UNAVAILABLE);
+  });
+
+  it('is unavailable after a transient failure whatever its age or count', () => {
+    const now = 1_700_000_000_000;
+    for (const [retries, ago] of [
+      [undefined, 1000],
+      [1, 1000],
+      [1, 2 * 60 * 60 * 1000],
+      [5, 24 * 60 * 60 * 1000],
+    ] as const) {
+      const info: CacheInfo = {
+        url: 'https://a/x.png',
+        state: CacheState.ERROR,
+        error: 'HTTP error: 504',
+        timestamp: now - ago,
+        ...(retries === undefined ? {} : { retries }),
+      };
+      expect(
+        getNFTPreviewStatusFromCache({ dataUris: ['https://a/x.png'], dataHash: HASH }, noMetadata, lookup([info])),
+      ).toBe(NFTPreviewStatus.UNAVAILABLE);
+    }
   });
 
   describe('an ipfs twin of a failed gateway link', () => {
@@ -227,28 +258,28 @@ describe('getNFTPreviewStatusFromCache', () => {
 
     it('is unavailable when the data file and every metadata copy have been seen to fail', () => {
       const infos = lookup([repeated('https://a/x.png'), repeated(nft.metadataUris[0]), repeated(nft.metadataUris[1])]);
-      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos)).toBe(NFTPreviewStatus.UNAVAILABLE);
     });
 
     it('stays undecided while a metadata copy has never been fetched, or is cached', () => {
       const fresh = lookup([repeated('https://a/x.png'), repeated(nft.metadataUris[0])]);
-      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, fresh, now)).toBeUndefined();
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, fresh)).toBeUndefined();
 
       const cachedCopy = lookup([
         repeated('https://a/x.png'),
         repeated(nft.metadataUris[0]),
         cached(nft.metadataUris[1], '0x1234'),
       ]);
-      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, cachedCopy, now)).toBeUndefined();
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, cachedCopy)).toBeUndefined();
     });
 
-    it('stays undecided while a metadata copy failed only once and its retry is due', () => {
+    it('is unavailable even when a metadata copy failed only once: a tile asking would be shown that failure', () => {
       const infos = lookup([
         repeated('https://a/x.png'),
         repeated(nft.metadataUris[0]),
-        { ...repeated(nft.metadataUris[1]), retries: 1 },
+        { ...repeated(nft.metadataUris[1]), retries: 1, timestamp: now - 24 * 60 * 60 * 1000 },
       ]);
-      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos, now)).toBeUndefined();
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos)).toBe(NFTPreviewStatus.UNAVAILABLE);
     });
 
     it('stays undecided when only some of the recorded copies could be consulted', () => {
@@ -257,88 +288,12 @@ describe('getNFTPreviewStatusFromCache', () => {
         metadataUris: Array.from({ length: MAX_URIS_PER_CANDIDATE + 1 }, (_, i) => `https://a/${i}.json`),
       };
       const infos = lookup([repeated('https://a/x.png'), ...many.metadataUris.map((uri) => repeated(uri))]);
-      expect(getNFTPreviewStatusFromCache(many, loadingMetadata, infos, now)).toBeUndefined();
+      expect(getNFTPreviewStatusFromCache(many, loadingMetadata, infos)).toBeUndefined();
     });
 
     it('does not decide the preview from the data file alone while the metadata is merely slow', () => {
       const infos = lookup([repeated('https://a/x.png')]);
-      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos, now)).toBeUndefined();
-    });
-  });
-
-  describe('a transient failure inside its retry delay', () => {
-    const now = 1_700_000_000_000;
-    const failure = (retries: number | undefined, ago: number): CacheInfo => ({
-      url: 'https://a/x.png',
-      state: CacheState.ERROR,
-      error: 'HTTP error: 504',
-      timestamp: now - ago,
-      ...(retries === undefined ? {} : { retries }),
-    });
-    const nft = { dataUris: ['https://a/x.png'], dataHash: HASH };
-
-    it('is unavailable for now: a tile that asked would be served the persisted failure', () => {
-      expect(getNFTPreviewStatusFromCache(nft, noMetadata, lookup([failure(1, 1000)]), now)).toBe(
-        NFTPreviewStatus.UNAVAILABLE,
-      );
-      expect(getNFTPreviewRetryDueAt(nft, noMetadata, lookup([failure(1, 1000)]), now)).toBe(
-        now - 1000 + transientErrorRetryDelay(1),
-      );
-    });
-
-    it('is undecided again once the delay has run out', () => {
-      const infos = lookup([failure(1, transientErrorRetryDelay(1))]);
-      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBeUndefined();
-      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
-    });
-
-    it('stays unavailable once the failure has repeated, even when its retry is due', () => {
-      for (const retries of [REPEATED_TRANSIENT_FAILURES, 3, 5]) {
-        // long past its delay: the cache would retry it for a tile that asked
-        const infos = lookup([failure(retries, transientErrorRetryDelay(retries) + 60_000)]);
-        expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
-        // and it earns no wake-up: the verdict holds until a tile gets the file
-        expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
-      }
-    });
-
-    it('gives a first failure its second chance, but not a repeated one, in the same NFT', () => {
-      const infos = lookup([
-        { ...failure(1, transientErrorRetryDelay(1) + 1), url: 'https://a/x.png' },
-        { ...failure(3, transientErrorRetryDelay(3) + 1), url: 'https://thumbs/x.png' },
-      ]);
-      // the thumbnail has repeated and counts as failed; the data file is due, so the NFT is undecided
-      expect(getNFTPreviewStatusFromCache(nft, metadataWithPreview, infos, now)).toBeUndefined();
-    });
-
-    it('is unavailable for good once the retries are exhausted', () => {
-      const infos = lookup([failure(MAX_TRANSIENT_RETRIES, 365 * 24 * 60 * 60 * 1000)]);
-      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
-      // nothing to look at again
-      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
-    });
-
-    it('treats a sidecar written before failures were timestamped as due', () => {
-      const infos = lookup([{ ...failure(1, 0), timestamp: 0 }]);
-      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBeUndefined();
-    });
-
-    it('is not held back by an abort, which the cache retries at once', () => {
-      const infos = lookup([{ ...failure(1, 1000), error: 'Request aborted' }]);
-      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBeUndefined();
-      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
-    });
-
-    it('reports the earliest retry among the sources', () => {
-      const infos = lookup([
-        { ...failure(1, 5000), url: 'https://a/x.png' },
-        { ...failure(1, 1000), url: 'https://thumbs/x.png' },
-      ]);
-      expect(getNFTPreviewStatusFromCache(nft, metadataWithPreview, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
-      // the older failure's retry comes first
-      expect(getNFTPreviewRetryDueAt(nft, metadataWithPreview, infos, now)).toBe(
-        now - 5000 + transientErrorRetryDelay(1),
-      );
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos)).toBeUndefined();
     });
   });
 

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
@@ -3,7 +3,7 @@ import type MetadataState from '../@types/MetadataState';
 import NFTPreviewStatus from '../@types/NFTPreviewStatus';
 import CacheState from '../constants/CacheState';
 
-import { MAX_TRANSIENT_RETRIES, transientErrorRetryDelay } from './downloadErrors';
+import { MAX_TRANSIENT_RETRIES, REPEATED_TRANSIENT_FAILURES, transientErrorRetryDelay } from './downloadErrors';
 import getNFTPreviewStatusFromCache, {
   MAX_URIS_PER_CANDIDATE,
   getNFTPreviewUrls,
@@ -131,10 +131,23 @@ describe('getNFTPreviewStatusFromCache', () => {
       expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
     });
 
-    it('waits longer after every consecutive failure', () => {
-      const infos = lookup([failure(3, transientErrorRetryDelay(3) - 1)]);
-      expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
-      expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBe(now + 1);
+    it('stays unavailable once the failure has repeated, even when its retry is due', () => {
+      for (const retries of [REPEATED_TRANSIENT_FAILURES, 3, 5]) {
+        // long past its delay: the cache would retry it for a tile that asked
+        const infos = lookup([failure(retries, transientErrorRetryDelay(retries) + 60_000)]);
+        expect(getNFTPreviewStatusFromCache(nft, noMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
+        // and it earns no wake-up: the verdict holds until a tile gets the file
+        expect(getNFTPreviewRetryDueAt(nft, noMetadata, infos, now)).toBeUndefined();
+      }
+    });
+
+    it('gives a first failure its second chance, but not a repeated one, in the same NFT', () => {
+      const infos = lookup([
+        { ...failure(1, transientErrorRetryDelay(1) + 1), url: 'https://a/x.png' },
+        { ...failure(3, transientErrorRetryDelay(3) + 1), url: 'https://thumbs/x.png' },
+      ]);
+      // the thumbnail has repeated and counts as failed; the data file is due, so the NFT is undecided
+      expect(getNFTPreviewStatusFromCache(nft, metadataWithPreview, infos, now)).toBeUndefined();
     });
 
     it('is unavailable for good once the retries are exhausted', () => {
@@ -157,12 +170,13 @@ describe('getNFTPreviewStatusFromCache', () => {
 
     it('reports the earliest retry among the sources', () => {
       const infos = lookup([
-        { ...failure(2, 1000), url: 'https://a/x.png' },
+        { ...failure(1, 5000), url: 'https://a/x.png' },
         { ...failure(1, 1000), url: 'https://thumbs/x.png' },
       ]);
       expect(getNFTPreviewStatusFromCache(nft, metadataWithPreview, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
+      // the older failure's retry comes first
       expect(getNFTPreviewRetryDueAt(nft, metadataWithPreview, infos, now)).toBe(
-        now - 1000 + transientErrorRetryDelay(1),
+        now - 5000 + transientErrorRetryDelay(1),
       );
     });
   });

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
@@ -140,6 +140,48 @@ describe('getNFTPreviewStatusFromCache', () => {
       expect(status).toBeUndefined();
     });
 
+    it.each([['a failed ipfs uri does not fail a never-fetched link: its own host would still be tried', twin, link]])(
+      '%s',
+      (_label, failedUri, neverFetched) => {
+        const status = getNFTPreviewStatusFromCache(
+          { dataUris: [failedUri, neverFetched], dataHash: HASH },
+          noMetadata,
+          lookup([{ ...failedLink, url: failedUri }]),
+          now,
+        );
+        expect(status).toBeUndefined();
+      },
+    );
+
+    it.each([
+      // the content exists; a twin would be downloaded (and mismatch on its own)
+      ['a hash mismatch', cached(link, '0xffff')],
+      // no verdict on the content
+      ['a network error', { ...failedLink, error: 'net::ERR_CONNECTION_RESET' }],
+      ["the caller's deadline running out", { ...failedLink, error: 'Request exceeded the 30000ms download deadline' }],
+    ])('does not fail the twin after %s of the link', (_label, linkInfo) => {
+      const status = getNFTPreviewStatusFromCache(
+        { dataUris: [link, twin], dataHash: HASH },
+        noMetadata,
+        lookup([linkInfo as CacheInfo]),
+        now,
+      );
+      expect(status).toBeUndefined();
+    });
+
+    it.each(['HTTP error: 404', 'HTTP error: 504', 'Request timed out after 30000ms of inactivity'])(
+      'fails the twin after %p of the link, which cools the content for the gateway',
+      (error) => {
+        const status = getNFTPreviewStatusFromCache(
+          { dataUris: [link, twin], dataHash: HASH },
+          noMetadata,
+          lookup([{ ...failedLink, error }]),
+          now,
+        );
+        expect(status).toBe(NFTPreviewStatus.UNAVAILABLE);
+      },
+    );
+
     it('lets a twin with an outcome of its own speak for itself', () => {
       const status = getNFTPreviewStatusFromCache(
         { dataUris: [link, twin], dataHash: HASH },

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
@@ -105,6 +105,67 @@ describe('getNFTPreviewStatusFromCache', () => {
     expect(status).toBeUndefined();
   });
 
+  describe('metadata still being fetched', () => {
+    const now = 1_700_000_000_000;
+    const repeated = (url: string, error = 'HTTP error: 504'): CacheInfo => ({
+      url,
+      state: CacheState.ERROR,
+      error,
+      timestamp: now - 60 * 60 * 1000,
+      retries: 3,
+    });
+    const nft = {
+      dataUris: ['https://a/x.png'],
+      dataHash: HASH,
+      metadataUris: ['https://a/x.json', 'ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/x.json'],
+    };
+
+    it('consults the metadata uris while the fetch is in flight, and not once it has settled', () => {
+      expect(getNFTPreviewUrls(nft, loadingMetadata)).toEqual([...nft.metadataUris, 'https://a/x.png']);
+      expect(getNFTPreviewUrls(nft, noMetadata)).toEqual(['https://a/x.png']);
+    });
+
+    it('is unavailable when the data file and every metadata copy have been seen to fail', () => {
+      const infos = lookup([repeated('https://a/x.png'), repeated(nft.metadataUris[0]), repeated(nft.metadataUris[1])]);
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos, now)).toBe(NFTPreviewStatus.UNAVAILABLE);
+    });
+
+    it('stays undecided while a metadata copy has never been fetched, or is cached', () => {
+      const fresh = lookup([repeated('https://a/x.png'), repeated(nft.metadataUris[0])]);
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, fresh, now)).toBeUndefined();
+
+      const cachedCopy = lookup([
+        repeated('https://a/x.png'),
+        repeated(nft.metadataUris[0]),
+        cached(nft.metadataUris[1], '0x1234'),
+      ]);
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, cachedCopy, now)).toBeUndefined();
+    });
+
+    it('stays undecided while a metadata copy failed only once and its retry is due', () => {
+      const infos = lookup([
+        repeated('https://a/x.png'),
+        repeated(nft.metadataUris[0]),
+        { ...repeated(nft.metadataUris[1]), retries: 1 },
+      ]);
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos, now)).toBeUndefined();
+    });
+
+    it('stays undecided when only some of the recorded copies could be consulted', () => {
+      const many = {
+        ...nft,
+        metadataUris: Array.from({ length: MAX_URIS_PER_CANDIDATE + 1 }, (_, i) => `https://a/${i}.json`),
+      };
+      const infos = lookup([repeated('https://a/x.png'), ...many.metadataUris.map((uri) => repeated(uri))]);
+      expect(getNFTPreviewStatusFromCache(many, loadingMetadata, infos, now)).toBeUndefined();
+    });
+
+    it('does not decide the preview from the data file alone while the metadata is merely slow', () => {
+      const infos = lookup([repeated('https://a/x.png')]);
+      expect(getNFTPreviewStatusFromCache(nft, loadingMetadata, infos, now)).toBeUndefined();
+    });
+  });
+
   describe('a transient failure inside its retry delay', () => {
     const now = 1_700_000_000_000;
     const failure = (retries: number | undefined, ago: number): CacheInfo => ({

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
@@ -190,6 +190,8 @@ describe('getNFTPreviewStatusFromCache', () => {
       // no verdict on the content
       ['a network error', { ...failedLink, error: 'net::ERR_CONNECTION_RESET' }],
       ["the caller's deadline running out", { ...failedLink, error: 'Request exceeded the 30000ms download deadline' }],
+      // the host is put on cooldown; the content is not cold and the twin is still fetched
+      ['a rate limit', { ...failedLink, error: 'HTTP error: 429' }],
     ])('does not fail the twin after %s of the link', (_label, linkInfo) => {
       const status = getNFTPreviewStatusFromCache(
         { dataUris: [link, twin], dataHash: HASH },

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.test.ts
@@ -105,6 +105,64 @@ describe('getNFTPreviewStatusFromCache', () => {
     expect(status).toBeUndefined();
   });
 
+  describe('an ipfs twin of a failed gateway link', () => {
+    const now = 1_700_000_000_000;
+    const CID = 'QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB';
+    const link = `https://nftstorage.link/ipfs/${CID}/x.png`;
+    const twin = `ipfs://${CID}/x.png`;
+    const failedLink: CacheInfo = {
+      url: link,
+      state: CacheState.ERROR,
+      error: 'HTTP error: 504',
+      timestamp: now - 60 * 60 * 1000,
+      retries: 3,
+    };
+
+    it('is unavailable when the link failed and its never-fetched twin names the same content', () => {
+      // the cache refuses the twin as cold content without writing a sidecar
+      const status = getNFTPreviewStatusFromCache(
+        { dataUris: [link, twin], dataHash: HASH },
+        noMetadata,
+        lookup([failedLink]),
+        now,
+      );
+      expect(status).toBe(NFTPreviewStatus.UNAVAILABLE);
+    });
+
+    it('stays undecided for a never-fetched uri naming other content', () => {
+      const other = 'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/x.png';
+      const status = getNFTPreviewStatusFromCache(
+        { dataUris: [link, other], dataHash: HASH },
+        noMetadata,
+        lookup([failedLink]),
+        now,
+      );
+      expect(status).toBeUndefined();
+    });
+
+    it('lets a twin with an outcome of its own speak for itself', () => {
+      const status = getNFTPreviewStatusFromCache(
+        { dataUris: [link, twin], dataHash: HASH },
+        noMetadata,
+        lookup([failedLink, cached(twin, HASH)]),
+        now,
+      );
+      expect(status).toBe(NFTPreviewStatus.AVAILABLE);
+    });
+
+    it('dooms a metadata fetch whose ipfs copy is the twin of its failed gateway copy', () => {
+      const metaLink = `https://nftstorage.link/ipfs/${CID}/x.json`;
+      const metaTwin = `ipfs://${CID}/x.json`;
+      const status = getNFTPreviewStatusFromCache(
+        { dataUris: [link, twin], dataHash: HASH, metadataUris: [metaLink, metaTwin] },
+        loadingMetadata,
+        lookup([failedLink, { ...failedLink, url: metaLink }]),
+        now,
+      );
+      expect(status).toBe(NFTPreviewStatus.UNAVAILABLE);
+    });
+  });
+
   describe('metadata still being fetched', () => {
     const now = 1_700_000_000_000;
     const repeated = (url: string, error = 'HTTP error: 504'): CacheInfo => ({

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
@@ -15,6 +15,8 @@ import {
 export type NFTPreviewSource = {
   dataUris?: string[];
   dataHash?: string;
+  // where the metadata — and with it the preview candidates — comes from
+  metadataUris?: string[];
 };
 
 type PreviewCandidate = {
@@ -60,9 +62,20 @@ function consultedUris(candidate: PreviewCandidate): string[] {
   return candidate.hash && Array.isArray(candidate.uris) ? candidate.uris.slice(0, MAX_URIS_PER_CANDIDATE) : [];
 }
 
+// The metadata uris the classification consults while the metadata is still
+// being fetched (see isMetadataFetchDoomed), bounded like a source's.
+function consultedMetadataUris(nft: NFTPreviewSource, metadataState: MetadataState): string[] {
+  return metadataState.isLoading && Array.isArray(nft.metadataUris)
+    ? nft.metadataUris.slice(0, MAX_URIS_PER_CANDIDATE)
+    : [];
+}
+
 /** The urls whose cache state `getNFTPreviewStatusFromCache` consults. */
 export function getNFTPreviewUrls(nft: NFTPreviewSource, metadataState: MetadataState): string[] {
-  return getCandidates(nft, settledMetadata(metadataState)).flatMap(consultedUris);
+  return [
+    ...consultedMetadataUris(nft, metadataState),
+    ...getCandidates(nft, settledMetadata(metadataState)).flatMap(consultedUris),
+  ];
 }
 
 type UriOutcome = 'verified' | 'failed' | 'undecided';
@@ -71,6 +84,18 @@ function classifyUri(hash: string, cacheInfo: CacheInfo | undefined, now: number
   if (cacheInfo?.state === CacheState.CACHED) {
     // a cached file with the wrong checksum is a settled failure for this uri
     return cacheInfo.checksum && compareChecksums(cacheInfo.checksum, hash) ? 'verified' : 'failed';
+  }
+
+  return classifyFailure(cacheInfo, now);
+}
+
+// Whether a persisted outcome without a hash to check against — a metadata
+// uri while its fetch is in flight — is a failure a tile asking for it would
+// be served, by the same rules as classifyUri's. A cached file counts as
+// verified: it is what the fetch will come back with.
+function classifyFailure(cacheInfo: CacheInfo | undefined, now: number): UriOutcome {
+  if (cacheInfo?.state === CacheState.CACHED) {
+    return 'verified';
   }
 
   if (cacheInfo?.state === CacheState.ERROR) {
@@ -113,13 +138,38 @@ function classifyUri(hash: string, cacheInfo: CacheInfo | undefined, now: number
  * preview sources are unknown, and a thumbnail may still make the preview
  * available even when the data file itself is unreachable.
  */
+// A metadata fetch still in flight whose every source the cache has already
+// seen fail — and would serve that failure to a tile asking now. The metadata
+// store fetches every NFT's metadata on the first pass through the gallery,
+// and for a file whose hosts are gone that fetch spends its whole budget
+// (each uri's transfer deadline, in a queue full of the same) before it fails
+// the same way it did last time; until then the NFT would count as undecided
+// — undecided counts as available — and its tile would sit in "Preview
+// available" showing the failure of its data file. Nothing settles here: the
+// fetch runs on, and if it does bring the metadata the store's change
+// notification has the NFT swept again with the preview candidates it brings.
+function isMetadataFetchDoomed(
+  nft: NFTPreviewSource,
+  metadataState: MetadataState,
+  getCacheInfo: (url: string) => CacheInfo | undefined,
+  now: number,
+): boolean {
+  const uris = consultedMetadataUris(nft, metadataState);
+  return (
+    uris.length > 0 &&
+    // every recorded copy, not just the consulted ones, must have been seen to fail
+    uris.length === (nft.metadataUris?.length ?? 0) &&
+    uris.every((uri) => classifyFailure(getCacheInfo(uri), now) === 'failed')
+  );
+}
+
 export default function getNFTPreviewStatusFromCache(
   nft: NFTPreviewSource,
   metadataState: MetadataState,
   getCacheInfo: (url: string) => CacheInfo | undefined,
   now: number = Date.now(),
 ): NFTPreviewStatus | undefined {
-  let isUndecided = metadataState.isLoading;
+  let isUndecided = metadataState.isLoading && !isMetadataFetchDoomed(nft, metadataState, getCacheInfo, now);
 
   for (const candidate of getCandidates(nft, settledMetadata(metadataState))) {
     // a source without a hash or uris has nothing to verify and contributes
@@ -166,9 +216,14 @@ export function getNFTPreviewRetryDueAt(
   now: number = Date.now(),
 ): number | undefined {
   let dueAt: number | undefined;
-  for (const candidate of getCandidates(nft, settledMetadata(metadataState))) {
+  const uriGroups = [
+    // a metadata fetch the cache has seen fail: its first-time failures get a wake-up too
+    consultedMetadataUris(nft, metadataState),
     // consultedUris is empty for a source without a hash
-    for (const uri of consultedUris(candidate)) {
+    ...getCandidates(nft, settledMetadata(metadataState)).map(consultedUris),
+  ];
+  for (const uris of uriGroups) {
+    for (const uri of uris) {
       const cacheInfo = getCacheInfo(uri);
       if (
         cacheInfo?.state === CacheState.ERROR &&

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
@@ -5,7 +5,7 @@ import NFTPreviewStatus from '../@types/NFTPreviewStatus';
 import CacheState from '../constants/CacheState';
 
 import compareChecksums from './compareChecksums';
-import { isAbortedDownloadError, isTransientDownloadError } from './downloadErrors';
+import { isAbortedDownloadError, isTransientDownloadError, transientRetryDueAt } from './downloadErrors';
 
 export type NFTPreviewSource = {
   dataUris?: string[];
@@ -62,21 +62,30 @@ export function getNFTPreviewUrls(nft: NFTPreviewSource, metadataState: Metadata
 
 type UriOutcome = 'verified' | 'failed' | 'undecided';
 
-function classifyUri(hash: string, cacheInfo: CacheInfo | undefined): UriOutcome {
+function classifyUri(hash: string, cacheInfo: CacheInfo | undefined, now: number): UriOutcome {
   if (cacheInfo?.state === CacheState.CACHED) {
     // a cached file with the wrong checksum is a settled failure for this uri
     return cacheInfo.checksum && compareChecksums(cacheInfo.checksum, hash) ? 'verified' : 'failed';
   }
 
   if (cacheInfo?.state === CacheState.ERROR) {
-    // A failure the cache will try again — an abort on the next access, a
+    // A failure the cache will try again on the next access — an abort, or a
     // transient one (timeout, 5xx, rate limit, bot challenge, network error)
-    // once its retry delay has passed — settles nothing: a tile that asked for
-    // the file would fetch it. Calling the NFT unavailable here would hide it
-    // from a filtered gallery, and a hidden tile never asks.
-    return isAbortedDownloadError(cacheInfo.error) || isTransientDownloadError(cacheInfo.error)
-      ? 'undecided'
-      : 'failed';
+    // whose retry delay has passed — settles nothing: a tile that asked for
+    // the file would fetch it, so calling the NFT unavailable would hide from
+    // a filtered gallery a file that may well arrive. A transient failure
+    // still inside its retry delay is what a tile would be served, so for now
+    // the preview is unavailable — and the sweep looks again when the delay
+    // runs out (getNFTPreviewRetryDueAt). One that has exhausted its retries
+    // is settled for good.
+    if (isAbortedDownloadError(cacheInfo.error)) {
+      return 'undecided';
+    }
+    if (isTransientDownloadError(cacheInfo.error)) {
+      const dueAt = transientRetryDueAt(cacheInfo);
+      return dueAt !== undefined && dueAt <= now ? 'undecided' : 'failed';
+    }
+    return 'failed';
   }
 
   return 'undecided';
@@ -99,6 +108,7 @@ export default function getNFTPreviewStatusFromCache(
   nft: NFTPreviewSource,
   metadataState: MetadataState,
   getCacheInfo: (url: string) => CacheInfo | undefined,
+  now: number = Date.now(),
 ): NFTPreviewStatus | undefined {
   let isUndecided = metadataState.isLoading;
 
@@ -108,7 +118,7 @@ export default function getNFTPreviewStatusFromCache(
     const uris = consultedUris(candidate);
     if (candidate.hash && uris.length) {
       for (const uri of uris) {
-        const outcome = classifyUri(candidate.hash, getCacheInfo(uri));
+        const outcome = classifyUri(candidate.hash, getCacheInfo(uri), now);
 
         if (outcome === 'verified') {
           return NFTPreviewStatus.AVAILABLE;
@@ -128,4 +138,34 @@ export default function getNFTPreviewStatusFromCache(
   }
 
   return isUndecided ? undefined : NFTPreviewStatus.UNAVAILABLE;
+}
+
+/**
+ * When an NFT classified unavailable may become undecided again: the earliest
+ * time one of its consulted uris' transient failures is retried on access
+ * (see transientRetryDueAt), if any lies ahead of `now`. The sweep that
+ * classified the NFT looks at it again then, so a file that failed during a
+ * gateway hiccup rejoins the gallery's available previews — and gets its tile
+ * to ask for it — without the user having to visit the unavailable ones.
+ */
+export function getNFTPreviewRetryDueAt(
+  nft: NFTPreviewSource,
+  metadataState: MetadataState,
+  getCacheInfo: (url: string) => CacheInfo | undefined,
+  now: number = Date.now(),
+): number | undefined {
+  let dueAt: number | undefined;
+  for (const candidate of getCandidates(nft, settledMetadata(metadataState))) {
+    // consultedUris is empty for a source without a hash
+    for (const uri of consultedUris(candidate)) {
+      const cacheInfo = getCacheInfo(uri);
+      if (cacheInfo?.state === CacheState.ERROR && isTransientDownloadError(cacheInfo.error)) {
+        const uriDueAt = transientRetryDueAt(cacheInfo);
+        if (uriDueAt !== undefined && uriDueAt > now && (dueAt === undefined || uriDueAt < dueAt)) {
+          dueAt = uriDueAt;
+        }
+      }
+    }
+  }
+  return dueAt;
 }

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
@@ -5,7 +5,12 @@ import NFTPreviewStatus from '../@types/NFTPreviewStatus';
 import CacheState from '../constants/CacheState';
 
 import compareChecksums from './compareChecksums';
-import { isAbortedDownloadError, isTransientDownloadError, transientRetryDueAt } from './downloadErrors';
+import {
+  REPEATED_TRANSIENT_FAILURES,
+  isAbortedDownloadError,
+  isTransientDownloadError,
+  transientRetryDueAt,
+} from './downloadErrors';
 
 export type NFTPreviewSource = {
   dataUris?: string[];
@@ -76,12 +81,16 @@ function classifyUri(hash: string, cacheInfo: CacheInfo | undefined, now: number
     // a filtered gallery a file that may well arrive. A transient failure
     // still inside its retry delay is what a tile would be served, so for now
     // the preview is unavailable — and the sweep looks again when the delay
-    // runs out (getNFTPreviewRetryDueAt). One that has exhausted its retries
-    // is settled for good.
+    // runs out (getNFTPreviewRetryDueAt). One that has repeated
+    // (REPEATED_TRANSIENT_FAILURES) stays unavailable until a tile gets the
+    // file, and one that has exhausted its retries is settled for good.
     if (isAbortedDownloadError(cacheInfo.error)) {
       return 'undecided';
     }
     if (isTransientDownloadError(cacheInfo.error)) {
+      if ((cacheInfo.retries ?? 0) >= REPEATED_TRANSIENT_FAILURES) {
+        return 'failed';
+      }
       const dueAt = transientRetryDueAt(cacheInfo);
       return dueAt !== undefined && dueAt <= now ? 'undecided' : 'failed';
     }
@@ -142,11 +151,13 @@ export default function getNFTPreviewStatusFromCache(
 
 /**
  * When an NFT classified unavailable may become undecided again: the earliest
- * time one of its consulted uris' transient failures is retried on access
- * (see transientRetryDueAt), if any lies ahead of `now`. The sweep that
- * classified the NFT looks at it again then, so a file that failed during a
- * gateway hiccup rejoins the gallery's available previews — and gets its tile
- * to ask for it — without the user having to visit the unavailable ones.
+ * time one of its consulted uris' first-time transient failures is retried on
+ * access (see transientRetryDueAt), if any lies ahead of `now`. The sweep that
+ * classified the NFT looks at it again then, so a file that failed once
+ * during a gateway hiccup rejoins the gallery's available previews — and gets
+ * its tile to ask for it — without the user having to visit the unavailable
+ * ones. A failure that has repeated (REPEATED_TRANSIENT_FAILURES) earns no
+ * such wake-up: its verdict holds until a tile gets the file.
  */
 export function getNFTPreviewRetryDueAt(
   nft: NFTPreviewSource,
@@ -159,7 +170,11 @@ export function getNFTPreviewRetryDueAt(
     // consultedUris is empty for a source without a hash
     for (const uri of consultedUris(candidate)) {
       const cacheInfo = getCacheInfo(uri);
-      if (cacheInfo?.state === CacheState.ERROR && isTransientDownloadError(cacheInfo.error)) {
+      if (
+        cacheInfo?.state === CacheState.ERROR &&
+        isTransientDownloadError(cacheInfo.error) &&
+        (cacheInfo.retries ?? 0) < REPEATED_TRANSIENT_FAILURES
+      ) {
         const uriDueAt = transientRetryDueAt(cacheInfo);
         if (uriDueAt !== undefined && uriDueAt > now && (dueAt === undefined || uriDueAt < dueAt)) {
           dueAt = uriDueAt;

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
@@ -6,12 +6,13 @@ import CacheState from '../constants/CacheState';
 
 import compareChecksums from './compareChecksums';
 import {
+  INACTIVITY_TIMEOUT_ERROR_PREFIX,
   REPEATED_TRANSIENT_FAILURES,
   isAbortedDownloadError,
   isTransientDownloadError,
   transientRetryDueAt,
 } from './downloadErrors';
-import { getIpfsPathFromAnyUrl } from './ipfs';
+import { getIpfsPathFromAnyUrl, isIpfsBackedUrl, isIpfsUrl } from './ipfs';
 
 export type NFTPreviewSource = {
   dataUris?: string[];
@@ -126,17 +127,32 @@ function classifyFailure(cacheInfo: CacheInfo | undefined, now: number): UriOutc
   return 'undecided';
 }
 
-// The ipfs paths (`<CID>[/path]`) of the uris among `uris` whose outcome is a
-// failure. An NFT commonly records the same file twice — a gateway link and
-// its ipfs:// twin — and CacheManager refuses the twin of content the gateway
-// just failed to produce without a download and without a sidecar of its own
-// (ColdIpfsPathError), so the twin never gets an outcome here. A uri never
-// fetched that names the same content as one that failed is read as failed
-// too: a tile asking for it would be refused the same way.
-function failedIpfsPaths(uris: string[], outcomeOf: (uri: string) => UriOutcome): Set<string> {
+// An NFT commonly records the same file twice — an https gateway link and its
+// ipfs:// twin. When the link fails on its own host and then through the
+// gateway with an HTTP status or an inactivity timeout, CacheManager remembers
+// the content as cold and refuses the ipfs:// twin — whose only route is that
+// gateway — without a download and without a sidecar of its own
+// (ColdIpfsPathError), so the twin never gets an outcome here. The ipfs paths
+// (`<CID>[/path]`) of exactly those failures: a persisted HTTP-status or
+// inactivity failure of a gateway link that classifies as failed. Not a hash
+// mismatch (the content exists), not a network or deadline error (no verdict
+// on the content), and not a failed ipfs:// uri (a link's own host would
+// still be tried).
+const HTTP_STATUS_FAILURE = /^HTTP error: \d{3}$/;
+
+function failedIpfsPaths(
+  uris: string[],
+  getCacheInfo: (url: string) => CacheInfo | undefined,
+  outcomeOf: (uri: string) => UriOutcome,
+): Set<string> {
   const paths = new Set<string>();
   uris.forEach((uri) => {
-    if (outcomeOf(uri) === 'failed') {
+    const cacheInfo = getCacheInfo(uri);
+    const isGatewayLink = isIpfsBackedUrl(uri) && !isIpfsUrl(uri);
+    const isContentFailure =
+      cacheInfo?.state === CacheState.ERROR &&
+      (HTTP_STATUS_FAILURE.test(cacheInfo.error) || cacheInfo.error.startsWith(INACTIVITY_TIMEOUT_ERROR_PREFIX));
+    if (isGatewayLink && isContentFailure && outcomeOf(uri) === 'failed') {
       const ipfsPath = getIpfsPathFromAnyUrl(uri);
       if (ipfsPath) {
         paths.add(ipfsPath);
@@ -146,8 +162,11 @@ function failedIpfsPaths(uris: string[], outcomeOf: (uri: string) => UriOutcome)
   return paths;
 }
 
+// A never-fetched ipfs:// uri naming content a gateway link of the same NFT
+// failed to get (see failedIpfsPaths): a tile asking for it would be refused
+// the same way, so it is read as failed too.
 function isTwinOfFailure(uri: string, cacheInfo: CacheInfo | undefined, failedPaths: Set<string>): boolean {
-  if (cacheInfo !== undefined && cacheInfo.state !== CacheState.NOT_CACHED) {
+  if (!isIpfsUrl(uri) || (cacheInfo !== undefined && cacheInfo.state !== CacheState.NOT_CACHED)) {
     return false;
   }
   const ipfsPath = getIpfsPathFromAnyUrl(uri);
@@ -172,7 +191,7 @@ function isMetadataFetchDoomed(
 ): boolean {
   const uris = consultedMetadataUris(nft, metadataState);
   const outcomeOf = (uri: string) => classifyFailure(getCacheInfo(uri), now);
-  const failedPaths = failedIpfsPaths(uris, outcomeOf);
+  const failedPaths = failedIpfsPaths(uris, getCacheInfo, outcomeOf);
   return (
     uris.length > 0 &&
     // every recorded copy, not just the consulted ones, must have been seen to fail
@@ -208,7 +227,7 @@ export default function getNFTPreviewStatusFromCache(
     const uris = consultedUris(candidate);
     if (candidate.hash && uris.length) {
       const { hash } = candidate;
-      const failedPaths = failedIpfsPaths(uris, (uri) => classifyUri(hash, getCacheInfo(uri), now));
+      const failedPaths = failedIpfsPaths(uris, getCacheInfo, (uri) => classifyUri(hash, getCacheInfo(uri), now));
       for (const uri of uris) {
         const cacheInfo = getCacheInfo(uri);
         const outcome = isTwinOfFailure(uri, cacheInfo, failedPaths) ? 'failed' : classifyUri(hash, cacheInfo, now);

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
@@ -121,9 +121,11 @@ function classifyFailure(cacheInfo: CacheInfo | undefined): UriOutcome {
 // (`<CID>[/path]`) of exactly those failures: a persisted HTTP-status or
 // inactivity failure of a gateway link that classifies as failed. Not a hash
 // mismatch (the content exists), not a network or deadline error (no verdict
-// on the content), and not a failed ipfs:// uri (a link's own host would
+// on the content), not a 429 (the cache puts the host on cooldown and still
+// fetches the twin), and not a failed ipfs:// uri (a link's own host would
 // still be tried).
 const HTTP_STATUS_FAILURE = /^HTTP error: \d{3}$/;
+const RATE_LIMITED = 'HTTP error: 429';
 
 function failedIpfsPaths(
   uris: string[],
@@ -136,6 +138,7 @@ function failedIpfsPaths(
     const isGatewayLink = isIpfsBackedUrl(uri) && !isIpfsUrl(uri);
     const isContentFailure =
       cacheInfo?.state === CacheState.ERROR &&
+      cacheInfo.error !== RATE_LIMITED &&
       (HTTP_STATUS_FAILURE.test(cacheInfo.error) || cacheInfo.error.startsWith(INACTIVITY_TIMEOUT_ERROR_PREFIX));
     if (isGatewayLink && isContentFailure && outcomeOf(uri) === 'failed') {
       const ipfsPath = getIpfsPathFromAnyUrl(uri);

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
@@ -11,6 +11,7 @@ import {
   isTransientDownloadError,
   transientRetryDueAt,
 } from './downloadErrors';
+import { getIpfsPathFromAnyUrl } from './ipfs';
 
 export type NFTPreviewSource = {
   dataUris?: string[];
@@ -125,19 +126,34 @@ function classifyFailure(cacheInfo: CacheInfo | undefined, now: number): UriOutc
   return 'undecided';
 }
 
-/**
- * Classifies an NFT's preview from what the cache already persisted about its
- * files, without fetching anything. Mirrors what a preview-mode tile settles
- * on: it walks the same sources `useNFTVerifyHash` verifies — preview video,
- * preview image, data file — and the first uri whose cached bytes match its
- * hash makes the preview available. The preview is unavailable only once
- * every uri of every source has a settled failure (a persisted download error
- * or cached bytes with the wrong checksum). Anything the cache has not seen
- * yet, or failed only transiently, leaves the outcome undecided
- * (`undefined`), as does metadata that is still loading: until it settles the
- * preview sources are unknown, and a thumbnail may still make the preview
- * available even when the data file itself is unreachable.
- */
+// The ipfs paths (`<CID>[/path]`) of the uris among `uris` whose outcome is a
+// failure. An NFT commonly records the same file twice — a gateway link and
+// its ipfs:// twin — and CacheManager refuses the twin of content the gateway
+// just failed to produce without a download and without a sidecar of its own
+// (ColdIpfsPathError), so the twin never gets an outcome here. A uri never
+// fetched that names the same content as one that failed is read as failed
+// too: a tile asking for it would be refused the same way.
+function failedIpfsPaths(uris: string[], outcomeOf: (uri: string) => UriOutcome): Set<string> {
+  const paths = new Set<string>();
+  uris.forEach((uri) => {
+    if (outcomeOf(uri) === 'failed') {
+      const ipfsPath = getIpfsPathFromAnyUrl(uri);
+      if (ipfsPath) {
+        paths.add(ipfsPath);
+      }
+    }
+  });
+  return paths;
+}
+
+function isTwinOfFailure(uri: string, cacheInfo: CacheInfo | undefined, failedPaths: Set<string>): boolean {
+  if (cacheInfo !== undefined && cacheInfo.state !== CacheState.NOT_CACHED) {
+    return false;
+  }
+  const ipfsPath = getIpfsPathFromAnyUrl(uri);
+  return ipfsPath !== undefined && failedPaths.has(ipfsPath);
+}
+
 // A metadata fetch still in flight whose every source the cache has already
 // seen fail — and would serve that failure to a tile asking now. The metadata
 // store fetches every NFT's metadata on the first pass through the gallery,
@@ -155,14 +171,29 @@ function isMetadataFetchDoomed(
   now: number,
 ): boolean {
   const uris = consultedMetadataUris(nft, metadataState);
+  const outcomeOf = (uri: string) => classifyFailure(getCacheInfo(uri), now);
+  const failedPaths = failedIpfsPaths(uris, outcomeOf);
   return (
     uris.length > 0 &&
     // every recorded copy, not just the consulted ones, must have been seen to fail
     uris.length === (nft.metadataUris?.length ?? 0) &&
-    uris.every((uri) => classifyFailure(getCacheInfo(uri), now) === 'failed')
+    uris.every((uri) => outcomeOf(uri) === 'failed' || isTwinOfFailure(uri, getCacheInfo(uri), failedPaths))
   );
 }
 
+/**
+ * Classifies an NFT's preview from what the cache already persisted about its
+ * files, without fetching anything. Mirrors what a preview-mode tile settles
+ * on: it walks the same sources `useNFTVerifyHash` verifies — preview video,
+ * preview image, data file — and the first uri whose cached bytes match its
+ * hash makes the preview available. The preview is unavailable only once
+ * every uri of every source has a settled failure (a persisted download error
+ * or cached bytes with the wrong checksum). Anything the cache has not seen
+ * yet, or failed only transiently, leaves the outcome undecided
+ * (`undefined`), as does metadata that is still loading: until it settles the
+ * preview sources are unknown, and a thumbnail may still make the preview
+ * available even when the data file itself is unreachable.
+ */
 export default function getNFTPreviewStatusFromCache(
   nft: NFTPreviewSource,
   metadataState: MetadataState,
@@ -176,8 +207,11 @@ export default function getNFTPreviewStatusFromCache(
     // nothing — it can neither make the preview available nor fail it
     const uris = consultedUris(candidate);
     if (candidate.hash && uris.length) {
+      const { hash } = candidate;
+      const failedPaths = failedIpfsPaths(uris, (uri) => classifyUri(hash, getCacheInfo(uri), now));
       for (const uri of uris) {
-        const outcome = classifyUri(candidate.hash, getCacheInfo(uri), now);
+        const cacheInfo = getCacheInfo(uri);
+        const outcome = isTwinOfFailure(uri, cacheInfo, failedPaths) ? 'failed' : classifyUri(hash, cacheInfo, now);
 
         if (outcome === 'verified') {
           return NFTPreviewStatus.AVAILABLE;

--- a/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
+++ b/packages/gui/src/util/getNFTPreviewStatusFromCache.ts
@@ -5,13 +5,7 @@ import NFTPreviewStatus from '../@types/NFTPreviewStatus';
 import CacheState from '../constants/CacheState';
 
 import compareChecksums from './compareChecksums';
-import {
-  INACTIVITY_TIMEOUT_ERROR_PREFIX,
-  REPEATED_TRANSIENT_FAILURES,
-  isAbortedDownloadError,
-  isTransientDownloadError,
-  transientRetryDueAt,
-} from './downloadErrors';
+import { INACTIVITY_TIMEOUT_ERROR_PREFIX, isAbortedDownloadError } from './downloadErrors';
 import { getIpfsPathFromAnyUrl, isIpfsBackedUrl, isIpfsUrl } from './ipfs';
 
 export type NFTPreviewSource = {
@@ -82,46 +76,37 @@ export function getNFTPreviewUrls(nft: NFTPreviewSource, metadataState: Metadata
 
 type UriOutcome = 'verified' | 'failed' | 'undecided';
 
-function classifyUri(hash: string, cacheInfo: CacheInfo | undefined, now: number): UriOutcome {
+function classifyUri(hash: string, cacheInfo: CacheInfo | undefined): UriOutcome {
   if (cacheInfo?.state === CacheState.CACHED) {
     // a cached file with the wrong checksum is a settled failure for this uri
     return cacheInfo.checksum && compareChecksums(cacheInfo.checksum, hash) ? 'verified' : 'failed';
   }
 
-  return classifyFailure(cacheInfo, now);
+  return classifyFailure(cacheInfo);
 }
 
 // Whether a persisted outcome without a hash to check against — a metadata
 // uri while its fetch is in flight — is a failure a tile asking for it would
 // be served, by the same rules as classifyUri's. A cached file counts as
 // verified: it is what the fetch will come back with.
-function classifyFailure(cacheInfo: CacheInfo | undefined, now: number): UriOutcome {
+function classifyFailure(cacheInfo: CacheInfo | undefined): UriOutcome {
   if (cacheInfo?.state === CacheState.CACHED) {
     return 'verified';
   }
 
   if (cacheInfo?.state === CacheState.ERROR) {
-    // A failure the cache will try again on the next access — an abort, or a
-    // transient one (timeout, 5xx, rate limit, bot challenge, network error)
-    // whose retry delay has passed — settles nothing: a tile that asked for
-    // the file would fetch it, so calling the NFT unavailable would hide from
-    // a filtered gallery a file that may well arrive. A transient failure
-    // still inside its retry delay is what a tile would be served, so for now
-    // the preview is unavailable — and the sweep looks again when the delay
-    // runs out (getNFTPreviewRetryDueAt). One that has repeated
-    // (REPEATED_TRANSIENT_FAILURES) stays unavailable until a tile gets the
-    // file, and one that has exhausted its retries is settled for good.
-    if (isAbortedDownloadError(cacheInfo.error)) {
-      return 'undecided';
-    }
-    if (isTransientDownloadError(cacheInfo.error)) {
-      if ((cacheInfo.retries ?? 0) >= REPEATED_TRANSIENT_FAILURES) {
-        return 'failed';
-      }
-      const dueAt = transientRetryDueAt(cacheInfo);
-      return dueAt !== undefined && dueAt <= now ? 'undecided' : 'failed';
-    }
-    return 'failed';
+    // A download cancelled from our side is retried on the very next access
+    // and settles nothing. Every other persisted failure — a transient one
+    // (timeout, 5xx, rate limit, bot challenge, network error) as much as a
+    // settled one (404, bad certificate) — is what a tile asking for the file
+    // would be shown right now, so for the filter the preview is unavailable.
+    // The cache keeps its own retry schedule: a tile that asks — in the
+    // unavailable view, or in the unfiltered gallery — is served a retry when
+    // one is due, and its live report replaces this verdict. Reading a due
+    // retry as "undecided" here instead put every file whose hosts are gone
+    // back under "Preview available" as soon as its delay ran out, where it
+    // sat, unasked, until the user scrolled to it and watched it fail again.
+    return isAbortedDownloadError(cacheInfo.error) ? 'undecided' : 'failed';
   }
 
   return 'undecided';
@@ -174,7 +159,7 @@ function isTwinOfFailure(uri: string, cacheInfo: CacheInfo | undefined, failedPa
 }
 
 // A metadata fetch still in flight whose every source the cache has already
-// seen fail — and would serve that failure to a tile asking now. The metadata
+// seen fail. The metadata
 // store fetches every NFT's metadata on the first pass through the gallery,
 // and for a file whose hosts are gone that fetch spends its whole budget
 // (each uri's transfer deadline, in a queue full of the same) before it fails
@@ -187,10 +172,9 @@ function isMetadataFetchDoomed(
   nft: NFTPreviewSource,
   metadataState: MetadataState,
   getCacheInfo: (url: string) => CacheInfo | undefined,
-  now: number,
 ): boolean {
   const uris = consultedMetadataUris(nft, metadataState);
-  const outcomeOf = (uri: string) => classifyFailure(getCacheInfo(uri), now);
+  const outcomeOf = (uri: string) => classifyFailure(getCacheInfo(uri));
   const failedPaths = failedIpfsPaths(uris, getCacheInfo, outcomeOf);
   return (
     uris.length > 0 &&
@@ -208,18 +192,18 @@ function isMetadataFetchDoomed(
  * hash makes the preview available. The preview is unavailable only once
  * every uri of every source has a settled failure (a persisted download error
  * or cached bytes with the wrong checksum). Anything the cache has not seen
- * yet, or failed only transiently, leaves the outcome undecided
- * (`undefined`), as does metadata that is still loading: until it settles the
- * preview sources are unknown, and a thumbnail may still make the preview
- * available even when the data file itself is unreachable.
+ * yet, or a download it aborted, leaves the outcome undecided (`undefined`),
+ * as does metadata that is still loading (unless its fetch is doomed, see
+ * isMetadataFetchDoomed): until it settles the preview sources are unknown,
+ * and a thumbnail may still make the preview available even when the data
+ * file itself is unreachable.
  */
 export default function getNFTPreviewStatusFromCache(
   nft: NFTPreviewSource,
   metadataState: MetadataState,
   getCacheInfo: (url: string) => CacheInfo | undefined,
-  now: number = Date.now(),
 ): NFTPreviewStatus | undefined {
-  let isUndecided = metadataState.isLoading && !isMetadataFetchDoomed(nft, metadataState, getCacheInfo, now);
+  let isUndecided = metadataState.isLoading && !isMetadataFetchDoomed(nft, metadataState, getCacheInfo);
 
   for (const candidate of getCandidates(nft, settledMetadata(metadataState))) {
     // a source without a hash or uris has nothing to verify and contributes
@@ -227,10 +211,10 @@ export default function getNFTPreviewStatusFromCache(
     const uris = consultedUris(candidate);
     if (candidate.hash && uris.length) {
       const { hash } = candidate;
-      const failedPaths = failedIpfsPaths(uris, getCacheInfo, (uri) => classifyUri(hash, getCacheInfo(uri), now));
+      const failedPaths = failedIpfsPaths(uris, getCacheInfo, (uri) => classifyUri(hash, getCacheInfo(uri)));
       for (const uri of uris) {
         const cacheInfo = getCacheInfo(uri);
-        const outcome = isTwinOfFailure(uri, cacheInfo, failedPaths) ? 'failed' : classifyUri(hash, cacheInfo, now);
+        const outcome = isTwinOfFailure(uri, cacheInfo, failedPaths) ? 'failed' : classifyUri(hash, cacheInfo);
 
         if (outcome === 'verified') {
           return NFTPreviewStatus.AVAILABLE;
@@ -250,45 +234,4 @@ export default function getNFTPreviewStatusFromCache(
   }
 
   return isUndecided ? undefined : NFTPreviewStatus.UNAVAILABLE;
-}
-
-/**
- * When an NFT classified unavailable may become undecided again: the earliest
- * time one of its consulted uris' first-time transient failures is retried on
- * access (see transientRetryDueAt), if any lies ahead of `now`. The sweep that
- * classified the NFT looks at it again then, so a file that failed once
- * during a gateway hiccup rejoins the gallery's available previews — and gets
- * its tile to ask for it — without the user having to visit the unavailable
- * ones. A failure that has repeated (REPEATED_TRANSIENT_FAILURES) earns no
- * such wake-up: its verdict holds until a tile gets the file.
- */
-export function getNFTPreviewRetryDueAt(
-  nft: NFTPreviewSource,
-  metadataState: MetadataState,
-  getCacheInfo: (url: string) => CacheInfo | undefined,
-  now: number = Date.now(),
-): number | undefined {
-  let dueAt: number | undefined;
-  const uriGroups = [
-    // a metadata fetch the cache has seen fail: its first-time failures get a wake-up too
-    consultedMetadataUris(nft, metadataState),
-    // consultedUris is empty for a source without a hash
-    ...getCandidates(nft, settledMetadata(metadataState)).map(consultedUris),
-  ];
-  for (const uris of uriGroups) {
-    for (const uri of uris) {
-      const cacheInfo = getCacheInfo(uri);
-      if (
-        cacheInfo?.state === CacheState.ERROR &&
-        isTransientDownloadError(cacheInfo.error) &&
-        (cacheInfo.retries ?? 0) < REPEATED_TRANSIENT_FAILURES
-      ) {
-        const uriDueAt = transientRetryDueAt(cacheInfo);
-        if (uriDueAt !== undefined && uriDueAt > now && (dueAt === undefined || uriDueAt < dueAt)) {
-          dueAt = uriDueAt;
-        }
-      }
-    }
-  }
-  return dueAt;
 }


### PR DESCRIPTION
Follow-up to #3063 / #3067, found while testing the stack. **Stack (merge in this order):** #3060 → #3061 → #3066 → #3062 → #3067 → #3068 → #3069 → #3063 → #3070 → #3071 → this PR. **Stacked on #3071** (its commits are included here; this PR's own work is the nine non-merge commits on top). Targets `release/2.7.4`.

## Problem

The gallery's preview filter classifies NFTs that are not on screen from the outcomes the cache persisted (`getNFTPreviewStatusFromCache`, #3063/#3067). Any failure the cache would eventually retry — a timeout, a 5xx, a 429 — settled nothing, so the NFT stayed *undecided*, and "Preview available" (defined as everything not known to be unavailable) kept showing tiles whose files cannot be fetched. Measured on a wallet with 2,247 NFTs: 215 whose only recorded outcomes were 504 / inactivity timeout / 429 sat under "Preview available" until each tile happened to mount and report live.

## Change

The rule, in one line: **the filter reports what a tile would be shown right now.** Verified bytes → available; any persisted download failure → unavailable until a tile actually gets the file; never fetched, or a download we cancelled ourselves → undecided (shown, so a tile asks). The cache's own retry schedule is untouched: a tile that asks — in the unavailable view, or in the unfiltered gallery — is served a retry when one is due, and its live report replaces the sweep's verdict.

- **A persisted failure is unavailable, whatever its age or count.** The first version gave a transient failure a second chance once the cache's retry delay ran out, with a wake-up timer to re-sweep it. Off screen nothing asks, so a file whose hosts are gone sat "undecided" — which "Preview available" shows — until the user scrolled to it and watched it fail; on the test wallet 138 NFTs, each with a single failure hours old, after every other fix. Only a download cancelled from our side (abort) stays undecided, since the cache retries it on the very next access.
- **A failure recorded under another gateway is still a failure.** The sweep read such a sidecar as "never fetched" (mirroring the cache's re-request on access), so every gateway change put every dead file back under "Preview available" — 226 NFTs twice in one day on the test wallet. The gateway change still forgets the sweep's verdicts and sweeps again, and the metadata store and the tiles still retry on it; the recorded failures themselves now count. The recovery rule (a failure to reach a gateway that has since come back settles nothing) stays.
- **A doomed metadata fetch is not waited for.** While an NFT's metadata is being fetched the classifier stays undecided (a thumbnail could still rescue the preview), and the metadata store fetches every NFT's metadata on the first gallery pass. For a dead NFT that fetch spends its whole budget in a saturated queue before failing exactly as last time. The classifier now consults the metadata uris while the fetch is in flight (`getNFTPreviewUrls` includes them then): when every recorded copy carries a persisted failure, the fetch is doomed and the NFT is classified from its data file alone. Such a verdict is provisional — the NFT is not settled until the metadata store settles it, and if the fetch does bring metadata the store's change notification sweeps it again and a stale verdict is dropped so its tile can fetch the candidates.
- **A never-fetched `ipfs://` twin of failed content counts as failed.** #3071 refuses the `ipfs://` twin of content a gateway link failed to get (HTTP status or inactivity timeout) without a download and without a sidecar, so the sweep saw "never fetched" for it. A never-fetched `ipfs://` uri naming the same ipfs path as such a failed gateway link of the same NFT is read as failed too (data, preview and metadata copies alike). Not for a hash mismatch, a network or deadline error, or a failed `ipfs://` sibling: there the cache would still try.
- **The retry schedule moves** (`TRANSIENT_ERROR_RETRY_DELAY`, `MAX_TRANSIENT_ERROR_RETRY_DELAY`, `MAX_TRANSIENT_RETRIES`, `transientErrorRetryDelay`) from `electron/CacheManager.ts` to `util/downloadErrors.ts`, so main process and renderer share one definition; `CacheManager` re-exports it and its behaviour is unchanged.

## Tests

`getNFTPreviewStatusFromCache.test.ts` (44 cases): aborts stay undecided, every other persisted failure is unavailable whatever its age or count; a doomed metadata fetch classifies from the data file, a copy never fetched or cached keeps the NFT undecided, only fully consulted copy lists count; the `ipfs://` twin rule and each of its exclusions (other content, twin with its own outcome, hash mismatch, network error, deadline error, failed `ipfs://` sibling) and inclusions (404, 504, inactivity timeout). Cache-manager suites unchanged and green; eslint and prettier clean; `tsc` adds no errors in the touched files.

Verified live over the Chrome DevTools Protocol against a wallet of 3,148 NFTs: the provider's verdicts went from 2,777 available / 144 unavailable / 227 undecided to 2,779 / 224 / 145 with the gateway rule alone, and the remaining undecided set was exactly the single-failure second-chance cases this final version removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NFT gallery classification, IPFS gateway behavior, and Electron cache concurrency/deadline policy; regressions are heavily tested but the surface area is broad across main-process downloads and renderer preview state.
> 
> **Overview**
> **Gallery preview filtering** now aligns off-screen classification with what a mounted tile would show. `useNFTPreviewStatuses` batches cache lookups (500 URLs per IPC), treats persisted download errors as unavailable (while still honoring gateway-recovery and host-unreachable retry semantics via `getCacheInfo`), leaves verdicts **provisional** until metadata finishes loading, and **forgets IPFS-based verdicts** when the gateway changes or recovers so stale “available” labels do not linger. `NFTProvider` passes recovery signals through metadata and preview hooks, **invalidates only bounded URI lists** on refresh, and fetches metadata across **multiple URIs** instead of only the first.
> 
> **NFT previews** gain a per-tile error boundary, **media playability probing** before iframe playback (with unplayable URIs excluded from verification), and clearer unavailable states for unsupported codecs. The gallery shows a **single warning** when the configured IPFS gateway is unreachable; settings add a **custom gateway URL** with probe feedback, stricter **cache size limit** validation, and updated IPFS privacy copy. `NFTHashStatus` accepts valid `ipfs://` paths when gateway fetching is enabled.
> 
> **Cache layer** (types and tests in this diff): richer ERROR sidecar fields, `maxDuration` / `getContentWithInfo` on the cache API, and large Jest suites for **admission after 429**, **metadata deadlines**, **migration/invalidation barriers**, **coalesced caller size/duration policy**, and **failure-only quota eviction**. Audit **stack integration docs** and **`@types/node` 20.19.9** are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b855147d3d9100d30f2bf264d14fb635ef3f3a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





