### PR TITLE
[CHIA-4407] Skip per-download housekeeping for downloads a clear or invalidation aborted

### DIFF
--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -313,11 +313,15 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   // was left so under the old gateway, and an NFT the gallery filter keeps
   // unmounted because it was classified as unavailable would never be looked
   // at again. Forget all of them and the ipfs outcomes behind them, and
-  // sweep again: mounted tiles re-verify on their own and report, and for
-  // the rest an outcome recorded under the old gateway settles nothing, so
-  // the NFT shows up for its tile to re-request the file through the new
-  // gateway — or, with the option now off, is classified from what the
-  // cache holds. An NFT whose metadata is not known is forgotten too — one
+  // sweep again: mounted tiles re-verify on their own and report, and the
+  // rest are classified afresh from what the cache holds. A failure recorded
+  // under the old gateway still counts as one (the look-up says why), so such
+  // an NFT sits under "unavailable" until a tile asks for it — in that view,
+  // or in the unfiltered gallery — and CacheManager re-requests the file
+  // through the new gateway; a verdict that rested on an abort, or on nothing
+  // recorded, is undecided again and the NFT shows up for its tile. With the
+  // option now off, the same sweep classifies from what the cache holds
+  // without a gateway. An NFT whose metadata is not known is forgotten too — one
   // whose metadata failed to load, and one whose metadata is being fetched:
   // the metadata store retries failed fetches on the same change, and its
   // effect runs before this one, so by the time an NFT is looked at here its

--- a/packages/gui/src/electron/CacheManager.admission.test.ts
+++ b/packages/gui/src/electron/CacheManager.admission.test.ts
@@ -145,8 +145,11 @@ describe('CacheManager admission and failure scope', () => {
     await tick();
     fail(new Error('HTTP error: 429'));
     await first;
+    // the clear aborts the request waiting out the cooldown; it settles by
+    // rejecting, and records nothing the clear would have to delete
+    const drained = expect(second).rejects.toThrow('Request aborted');
     await manager.clearCache();
-    await expect(second).resolves.toMatchObject({ state: 'ERROR', error: 'Request aborted' });
+    await drained;
     expect(mockDownloadFile).toHaveBeenCalledTimes(1);
     expect(await fs.readdir(directory)).toEqual([]);
     await expect(manager.getContent('https://other.example/ok.png')).resolves.toEqual(Buffer.from('healthy'));

--- a/packages/gui/src/electron/CacheManager.migration.test.ts
+++ b/packages/gui/src/electron/CacheManager.migration.test.ts
@@ -300,7 +300,12 @@ describe('CacheManager directory migration', () => {
       invalidation = cache.invalidate(url);
       await aborted.promise;
       finish.resolve();
-      await Promise.all([first, invalidation]);
+      // a transfer the invalidation aborted settles by rejecting — no verdict
+      // is recorded for it — while one that already succeeded resolves
+      await Promise.all([
+        completion === 'abort cleanup' ? expect(first).rejects.toThrow('Request aborted') : first,
+        invalidation,
+      ]);
     } finally {
       finish.resolve();
       await Promise.allSettled([first, invalidation]);

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -2256,3 +2256,82 @@ describe('CacheManager IPFS gateway recovery', () => {
     expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 });
+
+describe('CacheManager clear housekeeping', () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    mockDownloadFile.mockReset();
+    cacheDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'chia-cache-manager-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  // A clear aborts every download in flight or queued and waits for them to
+  // settle before deleting anything. Each aborted download used to record a
+  // "Request aborted" sidecar — which the clear deletes a moment later — and
+  // then run the post-download housekeeping: a full size scan of the cache
+  // directory and possibly an eviction pass. A gallery holding a queue of
+  // hundreds of dead files thus paid for hundreds of full-directory scans
+  // before the first file was deleted, and the occupied-space figure on the
+  // settings page could not move until they were done.
+  it('does not run per-download housekeeping for downloads it aborted', async () => {
+    const FILES = 1500;
+    const QUEUED = 60;
+    // a populated cache: every size scan has to stat all of it
+    await Promise.all(
+      Array.from({ length: FILES }, async (_, index) => {
+        const base = path.join(cacheDirectory, `${index.toString(16).padStart(8, '0')}-chiacache`);
+        await fs.writeFile(base, Buffer.alloc(64));
+        await fs.writeFile(
+          `${base}-info`,
+          JSON.stringify({ url: `https://example.com/${index}.png`, state: 'CACHED', timestamp: Date.now() }),
+        );
+      }),
+    );
+
+    // like the real downloadFile: streams into the temp file, and on abort
+    // removes it and fails
+    mockDownloadFile.mockImplementation(async (_url, localPath, options) => {
+      await fs.writeFile(`${localPath}.tmp`, Buffer.alloc(10));
+      await new Promise<void>((resolve) => {
+        options?.signal?.addEventListener('abort', () => resolve());
+      });
+      await fs.unlink(`${localPath}.tmp`);
+      throw new Error('Request aborted');
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024 * 1024 * 1024,
+    });
+    await cacheManager.init();
+
+    const scans = jest.spyOn(cacheManager, 'getCacheSize');
+    const sidecarWrites = jest.spyOn(cacheManager as any, 'setCacheInfo');
+
+    const pending = Array.from({ length: QUEUED }, (_, index) =>
+      cacheManager.getContent(`https://example.com/queued-${index}.png`).catch((error: Error) => error.message),
+    );
+    await untilDownloadsStarted(10); // the concurrency limit; the rest wait in the queue
+
+    scans.mockClear();
+    sidecarWrites.mockClear();
+    const startedAt = Date.now();
+    await cacheManager.clearCache();
+    const clearTook = Date.now() - startedAt;
+
+    // every caller still learns its download was aborted, and nothing survives the clear
+    expect(await Promise.all(pending)).toEqual(Array(QUEUED).fill('Request aborted'));
+    await expect(fs.readdir(cacheDirectory)).resolves.toEqual([]);
+
+    console.info(
+      `clear of ${FILES} cached files with ${QUEUED} downloads aborted took ${clearTook} ms: ` +
+        `${scans.mock.calls.length} full size scans and ${sidecarWrites.mock.calls.length} sidecars written by the aborted downloads`,
+    );
+    expect(sidecarWrites).not.toHaveBeenCalled();
+    expect(scans).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -938,6 +938,10 @@ export default class CacheManager extends EventEmitter {
 
     const abortController = new AbortController();
     const transferDeadline = new DownloadDeadline(maxDuration, () => abortController.abort());
+    // set when the request was ended from outside — by maintenance (clear,
+    // invalidation, see runMaintenance) or by the requester (abort) — rather
+    // than by its own deadline
+    let abortedByCaller = false;
     let ongoingRequestEntry:
       | {
           promise: Promise<CacheInfo>;
@@ -1124,6 +1128,16 @@ export default class CacheManager extends EventEmitter {
           throw error;
         }
 
+        // A download ended from outside is no verdict on the url. Maintenance
+        // deletes the entry as soon as this request settles, and a requester
+        // that gave up is retried anyway (an abort never settles an entry).
+        // Recording the abort and then running the post-download housekeeping
+        // — a full size scan of the cache directory per aborted download —
+        // would only hold back the clear that is waiting on this very request.
+        if (abortedByCaller) {
+          throw error;
+        }
+
         const currentError = this.redactCachePath(
           transferDeadline.error ?? (error as Error) ?? new Error('Unknown fetchRemoteContent error'),
         );
@@ -1165,7 +1179,10 @@ export default class CacheManager extends EventEmitter {
     const promise = process();
 
     ongoingRequestEntry = {
-      abort: () => abortController.abort(),
+      abort: () => {
+        abortedByCaller = true;
+        abortController.abort();
+      },
       promise,
       gateway: requestGateway,
       deadline: transferDeadline,


### PR DESCRIPTION
Follow-up to #3068, found while testing the stack. **Stack (merge in this order):** #3060 → #3061 → #3066 → #3062 → #3067 → #3068 → #3069 → #3063 → #3070 → #3071 → #3072 → this PR. **Stacked on #3072** (its commits are included here; this PR's own work is the one non-merge commit on top). Targets `release/2.7.4`.

## Problem

Clearing the NFT cache from Settings aborts every download in flight or queued and waits for them to settle before deleting anything (so no temp file or late sidecar survives the clear — #3068). Each aborted download then did what a failed download does: it recorded a `Request aborted` sidecar and ran the post-download housekeeping — a full size scan of the cache directory, and an eviction pass if the cache is over its limit. The clear deleted that sidecar a moment later, so the record was worthless, and the scans ran while the clear was still waiting.

A gallery holding a queue of hundreds of dead files (every nftstorage-era NFT retries after a gateway change) paid for hundreds of full-directory scans before the first file was deleted. Observed on a wallet with 3,149 NFTs and a cache of ~11,700 files: after "Clear NFT cache" the *Occupied space* figure on the settings page did not move until the GUI was restarted.

## Change

A download ended from outside — by a clear or invalidation (`runMaintenance`), or by the requester (`abort`) — is no verdict on the url. It now settles by rejecting with the abort error, records nothing, and runs no housekeeping. Maintenance deletes the entry as soon as the request settles anyway, and an abort never settled an entry before either (the cache retried it on the next access), so nothing observable changes for callers: every public method already turned the persisted abort record into the same thrown error.

Deadline aborts are untouched: a download that ran out of its own time still records its failure and runs housekeeping, as before.

## Measured

New test `CacheManager clear housekeeping › does not run per-download housekeeping for downloads it aborted`: a cache of 1,500 files, 60 downloads queued (10 in flight, 50 waiting), then `clearCache()`.

| | before | after |
|---|---|---|
| full size scans run by the aborted downloads | 60 | 0 |
| sidecars written by the aborted downloads | 60 | 0 |
| clear duration (tmpfs) | 1,352 ms | 17 ms |

## Tests

- New case above (fails before the change with 60 scans / 60 sidecars).
- Two existing cases asserted the old shape — an aborted request resolving to an `ERROR` record — and now assert the rejection: `CacheManager.migration.test.ts` "drains abort cleanup before invalidation removes the entry", `CacheManager.admission.test.ts` "drains a request sent back to cooldown when the cache is cleared".
- `packages/gui` electron + util suites: 934 passed. eslint and prettier clean; `tsc` unchanged from the branch baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling in the Electron cache download path used by NFT previews and cache maintenance; behavior is narrowed and heavily tested but affects core fetch/clear semantics.
> 
> **Overview**
> Fixes **NFT cache clear** stalling when many downloads are in flight: each aborted fetch no longer writes a throwaway `Request aborted` sidecar or runs **post-download housekeeping** (full cache directory size scans and possible eviction). **`CacheManager`** now tracks **`abortedByCaller`** when maintenance (`clearCache` / invalidation via `runMaintenance`) or the requester aborts the transfer; those paths **reject without persisting** and skip `setCacheInfo` / `trimCache`. Deadline-driven timeouts still record failures as before.
> 
> Tests now expect **rejected promises** instead of resolved `ERROR` cache records for caller-aborted downloads, plus a new regression case with ~1,500 cached files and 60 queued downloads asserting **zero** size scans and sidecar writes during clear. A comment in **`useNFTPreviewStatuses`** is updated to match: gateway changes still treat old real failures as unavailable, while outcomes that depended on a persisted abort become undecided again because aborts are no longer stored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7877beb727cb5c4e36618598db7c3c3fc7dc313f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->