### PR TITLE
checkpoint: into main from release/2.7.4  @ a70c8752c413e6855ce262c82b64aa04ff153f43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "fast-uri": "^3.1.7",
         "lerna": "9.0.7",
         "rollup": "4.62.4"
       },
@@ -5677,6 +5678,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5684,10 +5688,7 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
@@ -7635,13 +7636,13 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
@@ -7651,13 +7652,13 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
@@ -7667,13 +7668,13 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
@@ -7683,13 +7684,13 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
@@ -7699,13 +7700,13 @@
       "cpu": [
         "loong64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
@@ -7715,13 +7716,13 @@
       "cpu": [
         "loong64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
@@ -7731,13 +7732,13 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
@@ -7747,13 +7748,13 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
@@ -7763,13 +7764,13 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
@@ -7779,13 +7780,13 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
@@ -7795,13 +7796,13 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
@@ -7811,13 +7812,13 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
@@ -7827,13 +7828,13 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
@@ -15535,10 +15536,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "dev": true,
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "*": "prettier --check --ignore-unknown --ignore-path .gitignore"
   },
   "dependencies": {
+    "fast-uri": "^3.1.7",
     "lerna": "9.0.7",
     "rollup": "4.62.4"
   },


### PR DESCRIPTION
Source hash: a70c8752c413e6855ce262c82b64aa04ff153f43
Remaining commits: 4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no source modifications; main risk is install/audit behavior if `fast-uri` version resolution differs across environments.
> 
> **Overview**
> Adds **`fast-uri` `^3.1.7`** as a direct root dependency in `package.json` and refreshes `package-lock.json` accordingly.
> 
> The lockfile also bumps the resolved **`fast-uri`** package from **3.1.5** to **3.1.7** and treats it as a normal (non-`dev`) dependency at the workspace root. Remaining lockfile edits are metadata reordering (e.g. `libc` field placement on optional Linux native packages) with no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79adb73129825eee529d09f6bac0b20073c5c5ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->