### PR TITLE
[CHIA-4415] Label each NFT card with where its file came from, as an option

### DIFF
--- a/packages/gui/src/@types/CacheInfoBase.ts
+++ b/packages/gui/src/@types/CacheInfoBase.ts
@@ -10,6 +10,13 @@ type CacheInfoBase =
       state: CacheState.CACHED;
       headers: Headers;
       checksum: string;
+      // The gateway base the file came through, when a gateway served it:
+      // the only route for an ipfs:// URI, and the fallback for a gateway
+      // link whose own host failed. Absent when the URL's own host produced
+      // the file, and on sidecars written before this was recorded. Shown
+      // to the user as the file's source (getNFTSource); it plays no part
+      // in the cache's own decisions — a cached file is settled either way.
+      gateway?: string;
     }
   | {
       state: CacheState.ERROR;

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -39,6 +39,7 @@ import useNFTMetadata from '../../hooks/useNFTMetadata';
 import useNFTProvider from '../../hooks/useNFTProvider';
 import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
 import { useNFTVideoLoopGlobal, useNFTVideoLoopForNFT } from '../../hooks/useNFTVideoLoop';
+import useShowNFTSource from '../../hooks/useShowNFTSource';
 import useStateAbort from '../../hooks/useStateAbort';
 import getFileExtension from '../../util/getFileExtension';
 import getNFTId from '../../util/getNFTId';
@@ -46,6 +47,7 @@ import hasSensitiveContent from '../../util/hasSensitiveContent';
 import probeMediaPlayability from '../../util/probeMediaPlayability';
 
 import NFTHashStatus from './NFTHashStatus';
+import NFTSourceStatus from './NFTSourceStatus';
 
 const StyledCardPreview = styled(Box)`
   position: relative;
@@ -232,6 +234,7 @@ function NFTPreviewContent(props: NFTPreviewProps) {
   // never skipped, so an unplayable data file ends up as the notice below.
   const [unplayableUris, setUnplayableUris] = useStateAbort<string[]>([]);
 
+  const [showNFTSource] = useShowNFTSource();
   const { preview, isLoading: isLoadingVerifyHash } = useNFTVerifyHash(nftId, {
     preview: isPreview,
     ignoreSizeLimit,
@@ -731,10 +734,12 @@ function NFTPreviewContent(props: NFTPreviewProps) {
             left: 16,
             right: 16,
             justifyContent: 'center',
+            gap: 1,
             zIndex: 1,
           }}
         >
           <NFTHashStatus nftId={nftId} hideValid />
+          {showNFTSource && <NFTSourceStatus nftId={nftId} preview={isPreview} />}
         </Box>
       )}
     </StyledCardPreview>

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -739,7 +739,7 @@ function NFTPreviewContent(props: NFTPreviewProps) {
           }}
         >
           <NFTHashStatus nftId={nftId} hideValid />
-          {showNFTSource && <NFTSourceStatus nftId={nftId} preview={isPreview} />}
+          {showNFTSource && <NFTSourceStatus uri={preview?.isVerified ? preview.uri : undefined} />}
         </Box>
       )}
     </StyledCardPreview>

--- a/packages/gui/src/components/nfts/NFTPreview.tsx
+++ b/packages/gui/src/components/nfts/NFTPreview.tsx
@@ -733,13 +733,17 @@ function NFTPreviewContent(props: NFTPreviewProps) {
             top: 16,
             left: 16,
             right: 16,
-            justifyContent: 'center',
+            alignItems: 'flex-start',
             gap: 1,
             zIndex: 1,
           }}
         >
-          <NFTHashStatus nftId={nftId} hideValid />
+          {/* The source chip keeps the top-left corner; the hash status stays
+              centered in whatever width is left, so the two never overlap. */}
           {showNFTSource && <NFTSourceStatus uri={preview?.isVerified ? preview.uri : undefined} />}
+          <Box sx={{ display: 'flex', flex: 1, justifyContent: 'center' }}>
+            <NFTHashStatus nftId={nftId} hideValid />
+          </Box>
         </Box>
       )}
     </StyledCardPreview>

--- a/packages/gui/src/components/nfts/NFTSourceStatus.tsx
+++ b/packages/gui/src/components/nfts/NFTSourceStatus.tsx
@@ -1,0 +1,100 @@
+import { Tooltip } from '@chia-network/core';
+import { Trans } from '@lingui/macro';
+import DeviceHubIcon from '@mui/icons-material/DeviceHub';
+import LanguageIcon from '@mui/icons-material/Language';
+import { Chip, Typography } from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import type CacheInfo from '../../@types/CacheInfo';
+import useCache from '../../hooks/useCache';
+import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
+import getNFTSource from '../../util/getNFTSource';
+
+export type NFTSourceStatusProps = {
+  nftId: string;
+  preview?: boolean;
+};
+
+// A chip saying where the file a tile shows came from (see getNFTSource).
+// Rendered only once the file has verified: until then there is no file to
+// describe, and the hash-status chip beside it is reporting instead. The
+// gateway that produced an IPFS file is read from its cache sidecar, one
+// lookup per tile, made only while the user has the label switched on
+// (useShowNFTSource) — the tile mounts this component only then.
+export default function NFTSourceStatus(props: NFTSourceStatusProps) {
+  const { nftId, preview = false } = props;
+  const { preview: nftPreview } = useNFTVerifyHash(nftId, { preview });
+  const { getCacheInfos } = useCache();
+
+  const uri = nftPreview?.isVerified ? nftPreview.uri : undefined;
+  const [cacheInfo, setCacheInfo] = useState<{ uri: string; info: CacheInfo | undefined } | undefined>();
+
+  useEffect(() => {
+    if (!uri) {
+      return undefined;
+    }
+
+    let isCurrent = true;
+    getCacheInfos([uri]).then(
+      ([info]) => {
+        if (isCurrent) {
+          setCacheInfo({ uri, info });
+        }
+      },
+      () => {
+        // The source is still known from the URI alone; only which gateway
+        // served an IPFS file is not.
+        if (isCurrent) {
+          setCacheInfo({ uri, info: undefined });
+        }
+      },
+    );
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [uri, getCacheInfos]);
+
+  // The sidecar looked up for the previous URI describes another file.
+  const source = useMemo(
+    () => (uri ? getNFTSource(uri, cacheInfo?.uri === uri ? cacheInfo.info : undefined) : undefined),
+    [uri, cacheInfo],
+  );
+
+  if (!uri || !source || (source.kind === 'ipfs' && cacheInfo?.uri !== uri)) {
+    // For IPFS content, wait for the sidecar: a gateway link would otherwise
+    // flip from "direct" to "gateway" a moment after it appears.
+    return null;
+  }
+
+  const label =
+    source.kind === 'web' ? <Trans>Web</Trans> : source.viaGateway ? <Trans>IPFS gateway</Trans> : <Trans>IPFS</Trans>;
+
+  let tooltip: React.ReactNode;
+  if (source.kind === 'web') {
+    tooltip = <Trans>Fetched from {source.host}. This file is not published on IPFS.</Trans>;
+  } else if (!source.viaGateway) {
+    tooltip = <Trans>IPFS content fetched directly from {source.host}, the host in the file's address.</Trans>;
+  } else if (source.host) {
+    tooltip = <Trans>IPFS content fetched through the IPFS gateway {source.host}.</Trans>;
+  } else {
+    tooltip = <Trans>IPFS content fetched through an IPFS gateway.</Trans>;
+  }
+
+  return (
+    <Tooltip title={<Typography variant="caption">{tooltip}</Typography>}>
+      <Chip
+        icon={source.kind === 'web' ? <LanguageIcon /> : <DeviceHubIcon />}
+        label={label}
+        size="small"
+        sx={{
+          backgroundColor: 'primary.main',
+          color: 'primary.contrastText',
+          '& .MuiChip-icon': {
+            color: 'primary.contrastText',
+          },
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/gui/src/components/nfts/NFTSourceStatus.tsx
+++ b/packages/gui/src/components/nfts/NFTSourceStatus.tsx
@@ -1,32 +1,32 @@
-import { Tooltip } from '@chia-network/core';
+import { Tooltip, getSemanticColors } from '@chia-network/core';
 import { Trans } from '@lingui/macro';
 import DeviceHubIcon from '@mui/icons-material/DeviceHub';
 import LanguageIcon from '@mui/icons-material/Language';
-import { Chip, Typography } from '@mui/material';
+import { Chip, Typography, useTheme } from '@mui/material';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import type CacheInfo from '../../@types/CacheInfo';
 import useCache from '../../hooks/useCache';
-import useNFTVerifyHash from '../../hooks/useNFTVerifyHash';
 import getNFTSource from '../../util/getNFTSource';
 
 export type NFTSourceStatusProps = {
-  nftId: string;
-  preview?: boolean;
+  // The URI of the verified file the tile is showing — the tile's own
+  // verification result, exclusions and all, so the chip describes the file
+  // on screen and not another candidate of the same NFT. Undefined while
+  // nothing has verified: there is no file to describe then, and the
+  // hash-status chip beside this one is reporting instead.
+  uri?: string;
 };
 
 // A chip saying where the file a tile shows came from (see getNFTSource).
-// Rendered only once the file has verified: until then there is no file to
-// describe, and the hash-status chip beside it is reporting instead. The
-// gateway that produced an IPFS file is read from its cache sidecar, one
+// The gateway that produced an IPFS file is read from its cache sidecar, one
 // lookup per tile, made only while the user has the label switched on
 // (useShowNFTSource) — the tile mounts this component only then.
 export default function NFTSourceStatus(props: NFTSourceStatusProps) {
-  const { nftId, preview = false } = props;
-  const { preview: nftPreview } = useNFTVerifyHash(nftId, { preview });
+  const { uri } = props;
   const { getCacheInfos } = useCache();
+  const theme = useTheme();
 
-  const uri = nftPreview?.isVerified ? nftPreview.uri : undefined;
   const [cacheInfo, setCacheInfo] = useState<{ uri: string; info: CacheInfo | undefined } | undefined>();
 
   useEffect(() => {
@@ -81,6 +81,12 @@ export default function NFTSourceStatus(props: NFTSourceStatusProps) {
     tooltip = <Trans>IPFS content fetched through an IPFS gateway.</Trans>;
   }
 
+  // The chip sits over the media, where a theme's primary.main can be too
+  // dark to read; highlight is the accent that stays readable on overlays
+  // (the loop control in NFTPreview uses it for the same reason).
+  const accent = getSemanticColors(theme.palette).highlight;
+  const onAccent = theme.palette.getContrastText(accent);
+
   return (
     <Tooltip title={<Typography variant="caption">{tooltip}</Typography>}>
       <Chip
@@ -88,10 +94,10 @@ export default function NFTSourceStatus(props: NFTSourceStatusProps) {
         label={label}
         size="small"
         sx={{
-          backgroundColor: 'primary.main',
-          color: 'primary.contrastText',
+          backgroundColor: accent,
+          color: onAccent,
           '& .MuiChip-icon': {
-            color: 'primary.contrastText',
+            color: onAccent,
           },
         }}
       />

--- a/packages/gui/src/components/settings/SettingsNFT.tsx
+++ b/packages/gui/src/components/settings/SettingsNFT.tsx
@@ -20,6 +20,7 @@ import useHideObjectionableContent from '../../hooks/useHideObjectionableContent
 import useIpfsGateway from '../../hooks/useIpfsGateway';
 import useNFTImageFittingMode from '../../hooks/useNFTImageFittingMode';
 import { useNFTVideoLoopGlobal } from '../../hooks/useNFTVideoLoop';
+import useShowNFTSource from '../../hooks/useShowNFTSource';
 
 import IpfsGatewayUrl from './IpfsGatewayUrl';
 import LimitCacheSize from './LimitCacheSize';
@@ -45,6 +46,7 @@ export default function SettingsGeneral() {
   const [nftVideoLoop, setNFTVideoLoop] = useNFTVideoLoopGlobal();
   const [ipfsGateway, setIpfsGateway] = useIpfsGateway();
   const [allowUnverifiedPreviews, setAllowUnverifiedPreviews] = useAllowUnverifiedNFTPreviews();
+  const [showNFTSource, setShowNFTSource] = useShowNFTSource();
   // const [, setCacheFolder] = usePrefs('cacheFolder', '');
   const openDialog = useOpenDialog();
 
@@ -62,6 +64,10 @@ export default function SettingsGeneral() {
 
   function handleChangeAllowUnverifiedPreviews(event: React.ChangeEvent<HTMLInputElement>) {
     setAllowUnverifiedPreviews(event.target.checked);
+  }
+
+  function handleChangeShowNFTSource(event: React.ChangeEvent<HTMLInputElement>) {
+    setShowNFTSource(event.target.checked);
   }
 
   async function clearNFTCache() {
@@ -195,6 +201,26 @@ export default function SettingsGeneral() {
               ipfs.io gateway, which is being wound down and rate limits applications; https://ipfs.mintgarden.io,
               https://gateway.pinata.cloud and https://ipfs.filebase.io currently work, as does a local IPFS node such
               as http://127.0.0.1:8080. Files are re-checked through the new gateway right away.
+            </Trans>
+          </SettingsText>
+        </Grid>
+      </Grid>
+
+      <Grid container>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsTitle>
+            <Trans>Show where NFT files come from</Trans>
+          </SettingsTitle>
+        </Grid>
+        <Grid item container xs justifyContent="flex-end" marginTop="-6px">
+          <FormControlLabel control={<Switch checked={showNFTSource} onChange={handleChangeShowNFTSource} />} />
+        </Grid>
+        <Grid item style={{ width: '400px' }}>
+          <SettingsText>
+            <Trans>
+              Each NFT card gets a label saying whether the file it shows is IPFS content, and whether that content came
+              through the IPFS gateway above or directly from the host in the file's address. A file downloaded before
+              this option existed may be labeled as direct even when a gateway served it.
             </Trans>
           </SettingsText>
         </Grid>

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -511,6 +511,54 @@ describe('CacheManager eviction', () => {
     }
   });
 
+  it('records the gateway that served an ipfs:// file', async () => {
+    const payload = Buffer.from('cached payload');
+    const url = 'ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png';
+    mockDownloadFile.mockImplementationOnce(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return { 'content-type': 'image/png' };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent(url)).resolves.toEqual(payload);
+
+    const [info] = await cacheManager.getCacheInfos([url]);
+    expect(info).toMatchObject({ state: 'CACHED', gateway: 'https://ipfs.io/ipfs/' });
+  });
+
+  it('records the gateway that served a gateway link through the fallback, and none for one its own host served', async () => {
+    const payload = Buffer.from('cached payload');
+    const fallbackUrl = 'https://nftstorage.link/ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png';
+    const directUrl = 'https://nftstorage.link/ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/other.png';
+    const serve = async (_url: string, localPath: string) => {
+      await fs.writeFile(localPath, payload);
+      return { 'content-type': 'image/png' };
+    };
+    mockDownloadFile
+      .mockRejectedValueOnce(new Error('HTTP error: 403'))
+      .mockImplementationOnce(serve)
+      .mockImplementationOnce(serve);
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent(fallbackUrl)).resolves.toEqual(payload);
+    await expect(cacheManager.getContent(directUrl)).resolves.toEqual(payload);
+
+    const [viaFallback, viaOwnHost] = await cacheManager.getCacheInfos([fallbackUrl, directUrl]);
+    expect(viaFallback).toMatchObject({ state: 'CACHED', gateway: 'https://ipfs.io/ipfs/' });
+    expect(viaOwnHost).toMatchObject({ state: 'CACHED' });
+    expect(viaOwnHost).not.toHaveProperty('gateway');
+  });
+
   it('downloads through the gateway captured when the request entered, even if the preference changed before the transfer started', async () => {
     const url = 'ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png';
     mockDownloadFile.mockRejectedValue(new Error('HTTP error: 403'));

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -587,6 +587,28 @@ describe('CacheManager eviction', () => {
     }
   });
 
+  it('records no gateway for a link whose own host is the configured gateway', async () => {
+    const payload = Buffer.from('cached payload');
+    const url = 'https://ipfs.io/ipfs/QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png';
+    mockDownloadFile.mockImplementationOnce(async (_url, localPath) => {
+      await fs.writeFile(localPath, payload);
+      return { 'content-type': 'image/png' };
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024,
+    });
+    await cacheManager.init();
+
+    await expect(cacheManager.getContent(url)).resolves.toEqual(payload);
+    expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+
+    const [info] = await cacheManager.getCacheInfos([url]);
+    expect(info).toMatchObject({ state: 'CACHED' });
+    expect(info).not.toHaveProperty('gateway');
+  });
+
   it('does not keep re-requesting an ipfs failure whose sidecar predates gateway tracking', async () => {
     const url = 'ipfs://QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB/img.png';
     // an ERROR sidecar written by a version that did not record the gateway

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -1063,8 +1063,14 @@ export default class CacheManager extends EventEmitter {
             headers,
             checksum,
             // Which gateway produced the file, when one did (see
-            // CacheInfoBase). The renderer shows it as the file's source.
-            ...(gatewayLegUsed && requestGateway !== undefined ? { gateway: requestGateway } : {}),
+            // CacheInfoBase): the only route for an ipfs:// URI, or the
+            // fallback a gateway link got once its own host failed. A link
+            // whose own host is the gateway is charged to the gateway above
+            // (outage accounting) but was served by the host in its address,
+            // so the renderer shows it as fetched directly (getNFTSource).
+            ...(gatewayLegUsed && requestGateway !== undefined && (isIpfsUrl(url) || !isSelfGatewayLink)
+              ? { gateway: requestGateway }
+              : {}),
           });
 
           log('Cache info saved', url);

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -1062,6 +1062,9 @@ export default class CacheManager extends EventEmitter {
             state: CacheState.CACHED,
             headers,
             checksum,
+            // Which gateway produced the file, when one did (see
+            // CacheInfoBase). The renderer shows it as the file's source.
+            ...(gatewayLegUsed && requestGateway !== undefined ? { gateway: requestGateway } : {}),
           });
 
           log('Cache info saved', url);

--- a/packages/gui/src/hooks/useShowNFTSource.ts
+++ b/packages/gui/src/hooks/useShowNFTSource.ts
@@ -1,0 +1,10 @@
+import { usePrefs } from '@chia-network/api-react';
+
+// When enabled, every NFT card carries a label saying where the file it
+// shows came from: IPFS content or not, and — for IPFS content — whether the
+// configured gateway produced it or the host in the file's own address did
+// (NFTSourceStatus). Off by default: it is a diagnostic for users who run or
+// choose their own gateway, and one more chip over every tile otherwise.
+export default function useShowNFTSource() {
+  return usePrefs<boolean>('nftShowSource', false);
+}

--- a/packages/gui/src/util/getNFTSource.test.ts
+++ b/packages/gui/src/util/getNFTSource.test.ts
@@ -1,0 +1,89 @@
+import CacheState from '../constants/CacheState';
+
+import getNFTSource from './getNFTSource';
+
+const CID = 'QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB';
+
+function cached(url: string, gateway?: string) {
+  return {
+    url,
+    timestamp: 1,
+    state: CacheState.CACHED as const,
+    headers: {},
+    checksum: 'abc',
+    ...(gateway === undefined ? {} : { gateway }),
+  };
+}
+
+describe('getNFTSource', () => {
+  it('reports a plain web URL as served by its own host', () => {
+    expect(getNFTSource('https://raw.githubusercontent.com/org/repo/main/nft.png')).toEqual({
+      kind: 'web',
+      host: 'raw.githubusercontent.com',
+    });
+  });
+
+  it('reports a gateway link as IPFS content served by the host in the link', () => {
+    const url = `https://ipfs.mintgarden.io/ipfs/${CID}/img.png`;
+    expect(getNFTSource(url, cached(url))).toEqual({
+      kind: 'ipfs',
+      host: 'ipfs.mintgarden.io',
+      ipfsPath: `${CID}/img.png`,
+      viaGateway: false,
+    });
+  });
+
+  it('names the subdomain gateway operator, not the CID label', () => {
+    const url = 'https://bafybeiceg2gltyhlkukwetn26k7t2zdvthg4u4c6uj23rpni2adzgvo5si.ipfs.dweb.link/img.png';
+    expect(getNFTSource(url)).toMatchObject({ kind: 'ipfs', host: 'dweb.link', viaGateway: false });
+  });
+
+  it('reports a gateway link the fallback served as coming through that gateway', () => {
+    const url = `https://nftstorage.link/ipfs/${CID}/img.png`;
+    expect(getNFTSource(url, cached(url, 'http://127.0.0.1:8080/ipfs/'))).toEqual({
+      kind: 'ipfs',
+      host: '127.0.0.1',
+      ipfsPath: `${CID}/img.png`,
+      viaGateway: true,
+    });
+  });
+
+  it('reports an ipfs:// file as coming through its recorded gateway', () => {
+    const url = `ipfs://${CID}/img.png`;
+    expect(getNFTSource(url, cached(url, 'https://ipfs.mintgarden.io/ipfs/'))).toEqual({
+      kind: 'ipfs',
+      host: 'ipfs.mintgarden.io',
+      ipfsPath: `${CID}/img.png`,
+      viaGateway: true,
+    });
+  });
+
+  it('knows an ipfs:// file came through a gateway even when the sidecar does not say which', () => {
+    const url = `ipfs://${CID}/img.png`;
+    expect(getNFTSource(url, cached(url))).toEqual({
+      kind: 'ipfs',
+      host: undefined,
+      ipfsPath: `${CID}/img.png`,
+      viaGateway: true,
+    });
+    expect(getNFTSource(url)).toMatchObject({ viaGateway: true, host: undefined });
+  });
+
+  it('ignores a gateway recorded on a failure', () => {
+    const url = `https://nftstorage.link/ipfs/${CID}/img.png`;
+    expect(
+      getNFTSource(url, {
+        url,
+        timestamp: 1,
+        state: CacheState.ERROR,
+        error: 'HTTP error: 504',
+        gateway: 'https://ipfs.io/ipfs/',
+      }),
+    ).toMatchObject({ viaGateway: false, host: 'nftstorage.link' });
+  });
+
+  it('returns undefined for something that is not a URL', () => {
+    expect(getNFTSource('not a url')).toBeUndefined();
+    expect(getNFTSource('')).toBeUndefined();
+  });
+});

--- a/packages/gui/src/util/getNFTSource.ts
+++ b/packages/gui/src/util/getNFTSource.ts
@@ -1,0 +1,44 @@
+import type CacheInfo from '../@types/CacheInfo';
+import CacheState from '../constants/CacheState';
+
+import { getGatewayHost, getIpfsPathFromAnyUrl, isIpfsUrl } from './ipfs';
+
+// Where the file behind an NFT URI came from, for display (NFTSourceStatus).
+//
+// - `web`: the URI does not name IPFS content; its own host served it.
+// - `ipfs` with `viaGateway: false`: a gateway link (https://…/ipfs/<CID>)
+//   served by the host in the link.
+// - `ipfs` with `viaGateway: true`: IPFS content the configured gateway
+//   produced — an ipfs:// URI (its only route), or a gateway link whose own
+//   host failed and got the fallback. `host` is the gateway's, taken from the
+//   cache sidecar; undefined for an ipfs:// file cached before sidecars
+//   recorded the gateway (which gateway it was is not known, that one was
+//   used is).
+export type NFTSource =
+  | { kind: 'web'; host: string }
+  | { kind: 'ipfs'; host: string | undefined; ipfsPath: string; viaGateway: boolean };
+
+export default function getNFTSource(uri: string, cacheInfo?: CacheInfo): NFTSource | undefined {
+  const ipfsPath = getIpfsPathFromAnyUrl(uri);
+  if (ipfsPath === undefined) {
+    let host: string;
+    try {
+      host = new URL(uri).hostname;
+    } catch {
+      return undefined;
+    }
+
+    return host ? { kind: 'web', host } : undefined;
+  }
+
+  const gateway = cacheInfo?.state === CacheState.CACHED ? cacheInfo.gateway : undefined;
+  if (gateway !== undefined) {
+    return { kind: 'ipfs', host: getGatewayHost(gateway), ipfsPath, viaGateway: true };
+  }
+
+  if (isIpfsUrl(uri)) {
+    return { kind: 'ipfs', host: undefined, ipfsPath, viaGateway: true };
+  }
+
+  return { kind: 'ipfs', host: getGatewayHost(uri), ipfsPath, viaGateway: false };
+}


### PR DESCRIPTION
**Base and merge order.** Four linear commits on the `release/2.7.4` tip (1059cdf15, the 2.7.4 submodule pointer). They build on NFT-cache work already merged into `release/2.7.4` — #3063, #3070, #3071, #3072 and #3075 (the `gateway` / `gatewayLegUsed` sidecar accounting, `isSelfGatewayLink`, `abortedByCaller`, the per-tile error boundary) — so those have to be on the target branch first. They are not on `main` yet: the checkpoint merges from `release/2.7.4` are still catching up (#3090 stopped at the #3067 merge, #3093 reaches #3068). This PR therefore stays on `release/2.7.4` until a checkpoint carries 1059cdf15 into `main`, then retargets to `main` unchanged; a trial merge of today's `main` into this branch is already clean. Nothing in the already-merged PRs needs rebasing — they travel with the checkpoints.

### What the user sees

A new switch in Settings › NFT, **Show where NFT files come from**, off by default. With it on, every NFT card gets a chip beside the hash status once its file has verified:

| Chip | Meaning | Tooltip |
|---|---|---|
| **Web** | the file is not IPFS content | "Fetched from `<host>`. This file is not published on IPFS." |
| **IPFS** | a gateway link (`https://…/ipfs/<CID>`) served by the host in the link | "IPFS content fetched directly from `<host>`, the host in the file's address." |
| **IPFS gateway** | IPFS content the configured gateway produced: an `ipfs://` address, or a gateway link whose own host failed | "IPFS content fetched through the IPFS gateway `<host>`." |

### Why

A user who runs or chooses their own IPFS gateway (#3061, #3070) has no way to see, in the gallery, which files that gateway is actually producing. An `ipfs://` address always goes through it, a gateway link only when its own host fails (#3066), and everything else never. The cache knew which leg served a file at the moment it wrote the sidecar, and then forgot. On the wallet this was built against, 4,145 of the ~5,400 cached files came straight from ipfs.mintgarden.io and 166 through a local Kubo node, and the only way to tell them apart was to read response headers out of the sidecars by hand.

### How

- **CacheManager** records the gateway base on the CACHED sidecar when the gateway leg produced the file (`gateway`, the field ERROR sidecars already carry for their own reason). A cached file is settled whatever the field says (`isSettledOutcome` returns before looking), so nothing in the cache's decisions changes; the renderer's sweep reads `gateway` only on ERROR entries.
- **getNFTSource** (pure, tested) classifies from the URI and the sidecar. An `ipfs://` file cached before the field existed is still known to have come through a gateway (its only route), just not which one; a gateway link cached that way shows as direct until it is fetched again — the settings text says so.
- **NFTSourceStatus** renders the chip. It is mounted by `NFTPreview` only while the option is on, looks the sidecar up once per card (`getCacheInfos([uri])`), and for IPFS content waits for that answer so a chip never flips from "IPFS" to "IPFS gateway" a moment after appearing. It renders nothing until the file has verified — until then there is no file to describe, and the hash-status chip is reporting instead.
- **useShowNFTSource** is the preference (`nftShowSource`, renderer-only; the main process never needs it).

### Tests

- `CacheManager.test.ts` +2: an `ipfs://` file records its gateway; a gateway link the fallback served records it, one its own host served does not.
- `getNFTSource.test.ts` (new, 8 cases): web host, gateway link, subdomain gateway operator, fallback-served link, `ipfs://` with and without a recorded gateway, a gateway recorded on a failure is ignored, non-URLs.

128 tests green across the two suites; eslint and prettier clean; `tsc` adds one error of the same pre-existing kind as every other `FormControlLabel` on the settings page (missing `label`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only metadata and an off-by-default UI toggle; cache fetch/retry logic is unchanged aside from recording gateway on successful CACHED sidecars.
> 
> **Overview**
> Adds an **optional** NFT setting to show where each card’s verified preview file was fetched from, as a chip beside the existing hash status.
> 
> **Cache / metadata:** Successful downloads now persist an optional `gateway` on **CACHED** cache sidecars (same idea as ERROR entries) when the configured IPFS gateway leg actually served the bytes—`ipfs://` URIs, or gateway links after their own host failed. Direct gateway-link hits and links whose host is the configured gateway omit the field so the UI can treat them as “direct.”
> 
> **UI:** New `getNFTSource` classifies a URI (+ sidecar) as Web, IPFS (host in link), or IPFS gateway; `NFTSourceStatus` renders the chip with tooltips after a per-tile `getCacheInfos` lookup (waits on sidecar for IPFS to avoid label flicker). `NFTPreview` lays out source top-left and centers hash status when the pref is on (`useShowNFTSource`, default off).
> 
> **Tests:** `CacheManager` cases for gateway recording on success; new `getNFTSource.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adec492f02ebc21629f0f84a478a37d3e893aed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

