### PR TITLE
Attempt to address flaky CI timeouts in CacheManager housekeeping test

### DIFF
--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -2278,7 +2278,8 @@ describe('CacheManager clear housekeeping', () => {
   // before the first file was deleted, and the occupied-space figure on the
   // settings page could not move until they were done.
   it('does not run per-download housekeeping for downloads it aborted', async () => {
-    const FILES = 1500;
+    // enough for a scan to cost something; 1500 times out on CI
+    const FILES = 300;
     const QUEUED = 60;
     // a populated cache: every size scan has to stat all of it
     await Promise.all(
@@ -2333,5 +2334,5 @@ describe('CacheManager clear housekeeping', () => {
     );
     expect(sidecarWrites).not.toHaveBeenCalled();
     expect(scans).not.toHaveBeenCalled();
-  });
+  }, 30_000);
 });

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -2297,8 +2297,14 @@ describe('CacheManager clear housekeeping', () => {
     // removes it and fails
     mockDownloadFile.mockImplementation(async (_url, localPath, options) => {
       await fs.writeFile(`${localPath}.tmp`, Buffer.alloc(10));
+      // like the real downloadFile, an already-aborted signal ends it at once
+      const { signal } = options ?? {};
       await new Promise<void>((resolve) => {
-        options?.signal?.addEventListener('abort', () => resolve());
+        if (signal?.aborted) {
+          resolve();
+          return;
+        }
+        signal?.addEventListener('abort', () => resolve(), { once: true });
       });
       await fs.unlink(`${localPath}.tmp`);
       throw new Error('Request aborted');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes; no production CacheManager behavior is modified.
> 
> **Overview**
> **Stabilizes** the `CacheManager` test that asserts aborted downloads during `clearCache` do not trigger per-download housekeeping (full size scans / sidecar writes).
> 
> The populated-cache fixture is **reduced from 1500 to 300** cached files so setup and scans finish within CI limits, with a comment noting 1500 was timing out. The mocked `downloadFile` now **handles an already-aborted `AbortSignal`** (resolve immediately, `{ once: true }` on the listener) so abort behavior matches production and queued clears settle faster. The test is given an explicit **30s Jest timeout**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f0eac91c23149f5cca8c55bf62f47ecdb4dd86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->