### PR TITLE
Bump smol-toml to 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26355,9 +26355,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "yaml": "2.8.3",
     "js-cookie": "3.0.8",
     "ws": "8.21.0",
-    "pacote": "21.5.1"
+    "pacote": "21.5.1",
+    "smol-toml": "1.7.1"
   },
   "version": "2.6.1-rc2.dev60"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile and npm override only; no runtime or application code changes.
> 
> **Overview**
> Pins **smol-toml** to **1.7.1** (from **1.6.1**) via a new root `package.json` **overrides** entry, with **package-lock.json** updated to match.
> 
> This is a dependency-only change: no application source files are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e10bd3e791dffe5a8b8788eee023ed57faf408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->