### PR TITLE
[CHIA-4417] Fix block viewer

### DIFF
--- a/packages/gui/src/components/app/AppRouter.tsx
+++ b/packages/gui/src/components/app/AppRouter.tsx
@@ -65,6 +65,7 @@ export default function AppRouter() {
               <Route path="dashboard/pool/*" element={<Pool />} />
               <Route path="dashboard/addressbook/*" element={<AddressBook />} />
               <Route path="dashboard/chiatools/*" element={<ChiaToolsPage />} />
+              <Route path="dashboard/*" element={<Navigate to="/dashboard" />} />
             </Route>
           )}
         </Route>

--- a/packages/gui/src/components/block/BlockTitle.tsx
+++ b/packages/gui/src/components/block/BlockTitle.tsx
@@ -18,7 +18,7 @@ export default function BlockTitle(props: Props) {
   const navigate = useNavigate();
 
   function handleGoBack() {
-    navigate('/dashboard');
+    navigate('/dashboard/fullnode');
   }
 
   return (

--- a/packages/gui/src/components/fullNode/FullNode.jsx
+++ b/packages/gui/src/components/fullNode/FullNode.jsx
@@ -97,7 +97,7 @@ function BlocksCard() {
     const { isFinished, headerHash } = row;
 
     if (isFinished && headerHash) {
-      navigate(`block/${headerHash}`);
+      navigate(`/dashboard/block/${headerHash}`);
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small routing and navigation path changes in the GUI with no auth, data, or security impact.
> 
> **Overview**
> **Fixes block detail navigation** from the full node blocks table by using an absolute path (`/dashboard/block/:hash`) instead of a relative `block/:hash`, matching block search and the block viewer’s own prev/next links.
> 
> **Adjusts dashboard routing UX:** the block page back control now returns to **`/dashboard/fullnode`** (where blocks are listed) rather than the dashboard overview, and a **`dashboard/*` catch-all** in farmer/full-node mode redirects unknown dashboard URLs to `/dashboard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4c3eced8c0a0394995123ba867523dae0abe47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->