### PR TITLE
checkpoint: into main from release/2.7.4  @ c08035fda037a628ce32ad8e7711a430fde6988d

### DIFF
--- a/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
+++ b/packages/gui/src/components/nfts/provider/hooks/useNFTPreviewStatuses.ts
@@ -313,11 +313,15 @@ export default function useNFTPreviewStatuses(props: UseNFTPreviewStatusesProps)
   // was left so under the old gateway, and an NFT the gallery filter keeps
   // unmounted because it was classified as unavailable would never be looked
   // at again. Forget all of them and the ipfs outcomes behind them, and
-  // sweep again: mounted tiles re-verify on their own and report, and for
-  // the rest an outcome recorded under the old gateway settles nothing, so
-  // the NFT shows up for its tile to re-request the file through the new
-  // gateway — or, with the option now off, is classified from what the
-  // cache holds. An NFT whose metadata is not known is forgotten too — one
+  // sweep again: mounted tiles re-verify on their own and report, and the
+  // rest are classified afresh from what the cache holds. A failure recorded
+  // under the old gateway still counts as one (the look-up says why), so such
+  // an NFT sits under "unavailable" until a tile asks for it — in that view,
+  // or in the unfiltered gallery — and CacheManager re-requests the file
+  // through the new gateway; a verdict that rested on an abort, or on nothing
+  // recorded, is undecided again and the NFT shows up for its tile. With the
+  // option now off, the same sweep classifies from what the cache holds
+  // without a gateway. An NFT whose metadata is not known is forgotten too — one
   // whose metadata failed to load, and one whose metadata is being fetched:
   // the metadata store retries failed fetches on the same change, and its
   // effect runs before this one, so by the time an NFT is looked at here its

--- a/packages/gui/src/electron/CacheManager.admission.test.ts
+++ b/packages/gui/src/electron/CacheManager.admission.test.ts
@@ -145,8 +145,11 @@ describe('CacheManager admission and failure scope', () => {
     await tick();
     fail(new Error('HTTP error: 429'));
     await first;
+    // the clear aborts the request waiting out the cooldown; it settles by
+    // rejecting, and records nothing the clear would have to delete
+    const drained = expect(second).rejects.toThrow('Request aborted');
     await manager.clearCache();
-    await expect(second).resolves.toMatchObject({ state: 'ERROR', error: 'Request aborted' });
+    await drained;
     expect(mockDownloadFile).toHaveBeenCalledTimes(1);
     expect(await fs.readdir(directory)).toEqual([]);
     await expect(manager.getContent('https://other.example/ok.png')).resolves.toEqual(Buffer.from('healthy'));

--- a/packages/gui/src/electron/CacheManager.migration.test.ts
+++ b/packages/gui/src/electron/CacheManager.migration.test.ts
@@ -300,7 +300,12 @@ describe('CacheManager directory migration', () => {
       invalidation = cache.invalidate(url);
       await aborted.promise;
       finish.resolve();
-      await Promise.all([first, invalidation]);
+      // a transfer the invalidation aborted settles by rejecting — no verdict
+      // is recorded for it — while one that already succeeded resolves
+      await Promise.all([
+        completion === 'abort cleanup' ? expect(first).rejects.toThrow('Request aborted') : first,
+        invalidation,
+      ]);
     } finally {
       finish.resolve();
       await Promise.allSettled([first, invalidation]);

--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -2256,3 +2256,82 @@ describe('CacheManager IPFS gateway recovery', () => {
     expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 });
+
+describe('CacheManager clear housekeeping', () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    mockDownloadFile.mockReset();
+    cacheDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'chia-cache-manager-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  // A clear aborts every download in flight or queued and waits for them to
+  // settle before deleting anything. Each aborted download used to record a
+  // "Request aborted" sidecar — which the clear deletes a moment later — and
+  // then run the post-download housekeeping: a full size scan of the cache
+  // directory and possibly an eviction pass. A gallery holding a queue of
+  // hundreds of dead files thus paid for hundreds of full-directory scans
+  // before the first file was deleted, and the occupied-space figure on the
+  // settings page could not move until they were done.
+  it('does not run per-download housekeeping for downloads it aborted', async () => {
+    const FILES = 1500;
+    const QUEUED = 60;
+    // a populated cache: every size scan has to stat all of it
+    await Promise.all(
+      Array.from({ length: FILES }, async (_, index) => {
+        const base = path.join(cacheDirectory, `${index.toString(16).padStart(8, '0')}-chiacache`);
+        await fs.writeFile(base, Buffer.alloc(64));
+        await fs.writeFile(
+          `${base}-info`,
+          JSON.stringify({ url: `https://example.com/${index}.png`, state: 'CACHED', timestamp: Date.now() }),
+        );
+      }),
+    );
+
+    // like the real downloadFile: streams into the temp file, and on abort
+    // removes it and fails
+    mockDownloadFile.mockImplementation(async (_url, localPath, options) => {
+      await fs.writeFile(`${localPath}.tmp`, Buffer.alloc(10));
+      await new Promise<void>((resolve) => {
+        options?.signal?.addEventListener('abort', () => resolve());
+      });
+      await fs.unlink(`${localPath}.tmp`);
+      throw new Error('Request aborted');
+    });
+
+    const cacheManager = new CacheManager({
+      cacheDirectory,
+      maxCacheSize: 1024 * 1024 * 1024,
+    });
+    await cacheManager.init();
+
+    const scans = jest.spyOn(cacheManager, 'getCacheSize');
+    const sidecarWrites = jest.spyOn(cacheManager as any, 'setCacheInfo');
+
+    const pending = Array.from({ length: QUEUED }, (_, index) =>
+      cacheManager.getContent(`https://example.com/queued-${index}.png`).catch((error: Error) => error.message),
+    );
+    await untilDownloadsStarted(10); // the concurrency limit; the rest wait in the queue
+
+    scans.mockClear();
+    sidecarWrites.mockClear();
+    const startedAt = Date.now();
+    await cacheManager.clearCache();
+    const clearTook = Date.now() - startedAt;
+
+    // every caller still learns its download was aborted, and nothing survives the clear
+    expect(await Promise.all(pending)).toEqual(Array(QUEUED).fill('Request aborted'));
+    await expect(fs.readdir(cacheDirectory)).resolves.toEqual([]);
+
+    console.info(
+      `clear of ${FILES} cached files with ${QUEUED} downloads aborted took ${clearTook} ms: ` +
+        `${scans.mock.calls.length} full size scans and ${sidecarWrites.mock.calls.length} sidecars written by the aborted downloads`,
+    );
+    expect(sidecarWrites).not.toHaveBeenCalled();
+    expect(scans).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gui/src/electron/CacheManager.ts
+++ b/packages/gui/src/electron/CacheManager.ts
@@ -938,6 +938,10 @@ export default class CacheManager extends EventEmitter {
 
     const abortController = new AbortController();
     const transferDeadline = new DownloadDeadline(maxDuration, () => abortController.abort());
+    // set when the request was ended from outside — by maintenance (clear,
+    // invalidation, see runMaintenance) or by the requester (abort) — rather
+    // than by its own deadline
+    let abortedByCaller = false;
     let ongoingRequestEntry:
       | {
           promise: Promise<CacheInfo>;
@@ -1124,6 +1128,16 @@ export default class CacheManager extends EventEmitter {
           throw error;
         }
 
+        // A download ended from outside is no verdict on the url. Maintenance
+        // deletes the entry as soon as this request settles, and a requester
+        // that gave up is retried anyway (an abort never settles an entry).
+        // Recording the abort and then running the post-download housekeeping
+        // — a full size scan of the cache directory per aborted download —
+        // would only hold back the clear that is waiting on this very request.
+        if (abortedByCaller) {
+          throw error;
+        }
+
         const currentError = this.redactCachePath(
           transferDeadline.error ?? (error as Error) ?? new Error('Unknown fetchRemoteContent error'),
         );
@@ -1165,7 +1179,10 @@ export default class CacheManager extends EventEmitter {
     const promise = process();
 
     ongoingRequestEntry = {
-      abort: () => abortController.abort(),
+      abort: () => {
+        abortedByCaller = true;
+        abortController.abort();
+      },
       promise,
       gateway: requestGateway,
       deadline: transferDeadline,


### PR DESCRIPTION
Source hash: c08035fda037a628ce32ad8e7711a430fde6988d
Remaining commits: 3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes download failure persistence and clear-cache behavior in the main-process cache layer; incorrect handling could leave stale verdicts or affect clear performance, but scope is bounded to caller-aborted transfers.
> 
> **Overview**
> **Cache clears and invalidations no longer treat externally aborted downloads as cache failures.** `CacheManager` tracks when a transfer was stopped by maintenance (clear, invalidation, migration) or an explicit caller abort via `abortedByCaller`; those paths **reject without writing ERROR sidecars** and **skip post-download housekeeping** (`setCacheInfo`, `trimCache` / full-directory size scans). That avoids hundreds of redundant scans and sidecar writes when a large gallery queue is aborted during clear, so the settings cache size can update promptly.
> 
> Tests now expect **rejected** `Request aborted` (not persisted ERROR) for queued downloads aborted by clear/invalidation, plus a regression test with ~1500 cached files and 60 queued aborts asserting zero `getCacheSize` / `setCacheInfo` calls from aborted work.
> 
> **NFT preview hook:** comment-only clarification that after an IPFS gateway change, real failures under the old gateway still classify as unavailable while abort-only outcomes become undecided again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af262480f71733281c2a6b7f57b233732976fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->