### PR TITLE
checkpoint: into main from release/2.7.4  @ c8b461097319b31e1b3fe093499d9139d783123d

### DIFF
--- a/packages/gui/src/electron/CacheManager.test.ts
+++ b/packages/gui/src/electron/CacheManager.test.ts
@@ -2278,7 +2278,8 @@ describe('CacheManager clear housekeeping', () => {
   // before the first file was deleted, and the occupied-space figure on the
   // settings page could not move until they were done.
   it('does not run per-download housekeeping for downloads it aborted', async () => {
-    const FILES = 1500;
+    // enough for a scan to cost something; 1500 times out on CI
+    const FILES = 300;
     const QUEUED = 60;
     // a populated cache: every size scan has to stat all of it
     await Promise.all(
@@ -2296,8 +2297,14 @@ describe('CacheManager clear housekeeping', () => {
     // removes it and fails
     mockDownloadFile.mockImplementation(async (_url, localPath, options) => {
       await fs.writeFile(`${localPath}.tmp`, Buffer.alloc(10));
+      // like the real downloadFile, an already-aborted signal ends it at once
+      const { signal } = options ?? {};
       await new Promise<void>((resolve) => {
-        options?.signal?.addEventListener('abort', () => resolve());
+        if (signal?.aborted) {
+          resolve();
+          return;
+        }
+        signal?.addEventListener('abort', () => resolve(), { once: true });
       });
       await fs.unlink(`${localPath}.tmp`);
       throw new Error('Request aborted');
@@ -2333,5 +2340,5 @@ describe('CacheManager clear housekeeping', () => {
     );
     expect(sidecarWrites).not.toHaveBeenCalled();
     expect(scans).not.toHaveBeenCalled();
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Source hash: c8b461097319b31e1b3fe093499d9139d783123d
Remaining commits: 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to timeouts, fixture size, and mock abort behavior; no production code is modified.
> 
> **Overview**
> Stabilizes the **`CacheManager` clear-housekeeping** test that asserts aborted downloads do not trigger per-download size scans or sidecar writes.
> 
> The fixture cache is reduced from **1500 to 300** files so directory scans still matter but the test stops timing out on CI, and the case gets a **30s Jest timeout**. The mocked `downloadFile` now mirrors production by **resolving immediately when `signal` is already aborted** and registering the abort listener with `{ once: true }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b8ab68b28431a42036616ad8481177b394fc89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->